### PR TITLE
fix(llm): label input_tokens semantics by protocol on usage rows

### DIFF
--- a/src/quickquip/llm/pricing.py
+++ b/src/quickquip/llm/pricing.py
@@ -37,10 +37,6 @@ class CanonicalUsage:
             return None
         return (self.prompt or 0) + (self.completion or 0)
 
-    @property
-    def input_token_semantics(self) -> str:
-        return "inclusive"
-
 
 def normalize_usage(
     protocol: str,

--- a/src/quickquip/llm/usage.py
+++ b/src/quickquip/llm/usage.py
@@ -193,7 +193,12 @@ async def _record_usage(
             priced = 1 if priced_flag else 0
             fresh_input_tokens = usage.fresh_input
             total_tokens = usage.total_tokens
-            input_token_semantics = usage.input_token_semantics
+            # input_tokens 列存的是原始上报值：claude 协议按 exclusive 口径上报
+            # （不含 cache_read/cache_creation），其余协议 inclusive。标签描述
+            # 列值口径，与 canonical（恒 inclusive）是两回事（issue #202）
+            input_token_semantics = (
+                "exclusive" if client.config.protocol == "claude" else "inclusive"
+            )
             if rates is not None:
                 pricing_model = f"{client.config.id}/{model}" if f"{client.config.id}/{model}" in configured else model
                 pricing_source = rates.source

--- a/src/quickquip/llm/usage.py
+++ b/src/quickquip/llm/usage.py
@@ -195,7 +195,9 @@ async def _record_usage(
             total_tokens = usage.total_tokens
             # input_tokens 列存的是原始上报值：claude 协议按 exclusive 口径上报
             # （不含 cache_read/cache_creation），其余协议 inclusive。标签描述
-            # 列值口径，与 canonical（恒 inclusive）是两回事（issue #202）
+            # 列值口径，与 canonical（恒 inclusive）是两回事（issue #202）。
+            # 「claude ⇒ exclusive」口径另见 pricing.normalize_usage 的归一化侧
+            # 与 usage_store 的 SQL CASE——新增协议时需同步
             input_token_semantics = (
                 "exclusive" if client.config.protocol == "claude" else "inclusive"
             )

--- a/src/quickquip/llm/usage_store.py
+++ b/src/quickquip/llm/usage_store.py
@@ -208,6 +208,16 @@ class LLMUsageStore:
                     CREATE INDEX IF NOT EXISTS idx_usage_persona  ON llm_usage_events(persona_id, ts DESC);
                     """
                 )
+                # 历史 claude 行标签 backfill（issue #202）：input_tokens 列自始存
+                # exclusive 原始值，落库标签却恒写 inclusive。UPDATE 天然幂等，
+                # 首次执行修完全库后，后续重跑 0 行受影响
+                conn.execute(
+                    """
+                    UPDATE llm_usage_events
+                    SET input_token_semantics = 'exclusive'
+                    WHERE protocol = 'claude' AND input_token_semantics = 'inclusive'
+                    """
+                )
             self._schema_ready = True
 
     def record(self, row: dict) -> None:

--- a/tests/unit/llm/test_pricing.py
+++ b/tests/unit/llm/test_pricing.py
@@ -105,7 +105,6 @@ def test_cost_components_expose_canonical_buckets():
     assert priced is True
     assert usage.fresh_input == 100
     assert usage.total_tokens == 430
-    assert usage.input_token_semantics == "inclusive"
     assert components["input_cost_usd"] == 100 * 2 / 1e6
     assert components["cache_read_cost_usd"] == 200 * 0.2 / 1e6
 

--- a/tests/unit/llm/test_usage_metering.py
+++ b/tests/unit/llm/test_usage_metering.py
@@ -333,3 +333,40 @@ async def test_record_usage_uses_provider_level_pricing(monkeypatch, tmp_path):
     expected = 100 * 2 / 1e6 + 50 * 10 / 1e6
     assert abs(row["cost_usd"] - expected) < 1e-9
     assert row["priced"] == 1
+
+
+async def test_record_usage_input_semantics_matches_protocol(monkeypatch, tmp_path):
+    """issue #202：input_tokens 列存原始上报值，标签须描述列值口径——
+    claude 协议 exclusive（不含 cache_read/creation），其余 inclusive。"""
+    from quickquip.llm.usage import _record_usage
+    from quickquip.llm.usage_store import LLMUsageStore
+    from plugins.llm_config import ProviderConfig
+    from plugins.llm_provider import LLMResponse
+
+    fake_store = LLMUsageStore(tmp_path / "u.db")
+    monkeypatch.setattr("quickquip.llm.usage_store.usage_store", fake_store)
+
+    async def _record(protocol: str) -> str | None:
+        class FakeClient:
+            config = ProviderConfig(
+                id="p", protocol=protocol, base_url="https://x/v1",
+                api_key_env="K", default_model="m", models=["m"],
+            )
+
+        class FakeReq:
+            model = "m"
+
+        response = LLMResponse(
+            text="ok", model="m", input_tokens=100, output_tokens=50,
+            cache_read_tokens=200,
+        )
+        await _record_usage(FakeClient(), FakeReq(), response, 0.0, True, "ok")
+        with fake_store.connect() as conn:
+            return conn.execute(
+                "SELECT input_token_semantics FROM llm_usage_events"
+                " WHERE protocol = ?", (protocol,)
+            ).fetchone()[0]
+
+    assert await _record("claude") == "exclusive"
+    assert await _record("openai") == "inclusive"
+    assert await _record("gemini") == "inclusive"

--- a/tests/unit/llm/test_usage_store.py
+++ b/tests/unit/llm/test_usage_store.py
@@ -287,3 +287,34 @@ def test_half_migrated_schema_is_completed(tmp_path):
         ).fetchone()
     assert {"group_id", "total_tokens", "pricing_confidence"} <= columns
     assert kept["feature"] == "chat"
+
+
+def test_claude_input_semantics_backfill_migration(tmp_path):
+    """issue #202：_ensure_schema 把历史 claude 行的 inclusive 标签 backfill 为
+    exclusive（input_tokens 列自始存 exclusive 原始值）；非 claude 行不动；
+    重跑幂等。"""
+    import sqlite3
+
+    path = tmp_path / "u.db"
+    store = LLMUsageStore(path)
+    for i, protocol in enumerate(("claude", "claude", "openai")):
+        store.record({
+            "provider_id": f"p{i}", "protocol": protocol, "model": "m",
+            "stream": 1, "input_tokens": 10, "cache_read_tokens": 200,
+            "input_token_semantics": "inclusive", "state": "ok",
+        })
+    with sqlite3.connect(path) as conn:
+        conn.execute(
+            "UPDATE llm_usage_events SET input_token_semantics = 'inclusive'"
+        )  # 模拟 backfill 前的历史库（新代码已派生 exclusive，手工还原成旧形态）
+
+    reopened = LLMUsageStore(path)  # 触发 _ensure_schema backfill
+    reopened._ensure_schema()
+    with reopened.connect() as conn:
+        rows = conn.execute(
+            "SELECT protocol, input_token_semantics FROM llm_usage_events"
+            " ORDER BY protocol, provider_id"
+        ).fetchall()
+    assert [tuple(r) for r in rows] == [
+        ("claude", "exclusive"), ("claude", "exclusive"), ("openai", "inclusive"),
+    ]

--- a/tests/unit/llm/test_usage_store.py
+++ b/tests/unit/llm/test_usage_store.py
@@ -318,3 +318,48 @@ def test_claude_input_semantics_backfill_migration(tmp_path):
     assert [tuple(r) for r in rows] == [
         ("claude", "exclusive"), ("claude", "exclusive"), ("openai", "inclusive"),
     ]
+    reopened._ensure_schema()  # 二跑幂等：0 行受影响，标签不再变化
+    with reopened.connect() as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM llm_usage_events"
+            " WHERE protocol = 'claude' AND input_token_semantics != 'exclusive'"
+        ).fetchone()[0] == 0
+
+
+def test_claude_backfill_keeps_summary_values_stable(tmp_path):
+    """issue #202 回归锚定：backfill 只翻标签列，summary 聚合数值前后一致
+    （ok 行的存储列 COALESCE 优先，CASE 分支翻转不改变任何行形态的取值）。"""
+    import sqlite3
+
+    from quickquip.llm.usage_store import window_start
+
+    path = tmp_path / "u.db"
+    store = LLMUsageStore(path)
+    # claude 行：input=100（exclusive 原始值）、read=200、creation=80、
+    # 存储列 fresh=100 / total=430（normalize 后写入，聚合只看这里）
+    store.record({
+        "provider_id": "p", "protocol": "claude", "model": "m", "feature": "chat",
+        "stream": 1, "input_tokens": 100, "cache_read_tokens": 200,
+        "cache_creation_tokens": 80, "output_tokens": 50,
+        "fresh_input_tokens": 100, "total_tokens": 430,
+        "input_token_semantics": "exclusive", "cost_usd": 0.01, "priced": 1,
+        "state": "ok",
+    })
+    with sqlite3.connect(path) as conn:
+        conn.execute("UPDATE llm_usage_events SET input_token_semantics = 'inclusive'")
+
+    cutoff = window_start(7).isoformat()
+    # 同一实例 _schema_ready 已置位 → 取的是 backfill 前口径
+    before = store.summary(cutoff)
+    # 新实例首开触发 backfill → 标签翻 exclusive
+    reopened = LLMUsageStore(path)
+    after = reopened.summary(cutoff)
+
+    # 存储列 total_tokens=430（canonical，含 output）COALESCE 短路优先
+    assert after["total_tokens"] == before["total_tokens"] == 430
+    assert after["total_fresh_input_tokens"] == before["total_fresh_input_tokens"] == 100
+    assert after["total_calls"] == before["total_calls"] == 1
+    assert after["cache_hit_rate"] == before["cache_hit_rate"] == round(200 / 380, 4)
+    with reopened.connect() as conn:
+        sem = conn.execute("SELECT input_token_semantics FROM llm_usage_events").fetchone()[0]
+    assert sem == "exclusive"


### PR DESCRIPTION
Fixes #202（方案 A：标签诚实化 + backfill）。

## 问题

`input_tokens` 列存的是**原始上报值**（claude 协议下 fresh-only/exclusive），`input_token_semantics` 却恒写 canonical 的 `"inclusive"`（`CanonicalUsage` 常量）——列值与标签不自洽：朴素 `cache_read/input_tokens` 对 claude 行可破 100%（生产实测 ~306 行），SQL 的 `'exclusive'` 分支永远走不到。

## 改动（3 处）

- **usage.py**：落库标签改按 `client.config.protocol` 派生（claude → `exclusive`，其余 → `inclusive`）；`input_tokens` 列保持原始上报值（保真度不丢）
- **pricing.py**：`CanonicalUsage.input_token_semantics` 恒值 property 唯一消费者已改，删除
- **usage_store.py**：`_ensure_schema` 加幂等 backfill `UPDATE … SET input_token_semantics='exclusive' WHERE protocol='claude' AND input_token_semantics='inclusive'`（历史 claude 行自始均为 exclusive，安全；重跑 0 行受影响）

## 不变的（回归口径）

- 聚合路径本就正确：`_total_expr`/`_fresh_expr` 的 `COALESCE(total_tokens/fresh_input_tokens, …)` 存储列优先，看板数值修复前后一致
- backfill 后 claude 行走 SQL 第一分支（`'exclusive'`），与既有 legacy 兜底（`NULL + claude`）同值；该兜底自然退役但保留

## 验收对照（issue #202）

- [x] claude 协议新行标签与列口径一致（`test_record_usage_input_semantics_matches_protocol`：claude→exclusive / openai→inclusive / gemini→inclusive）
- [x] 历史行 backfill（`test_claude_input_semantics_backfill_migration`：claude 行翻转、openai 行不动、重跑幂等）
- [x] 聚合回归不变（既有 cache_hit_rate / 成本四桶 / summary 全量测试绿）

## 验证

1638 测试全绿（+2）、ruff 干净（本 PR 不动前端；pre-push type-check 绿）。

## 回滚

revert 单 commit；backfill 已执行的行如需还原可反向 UPDATE（但无场景需要——标签描述的口径本就是事实）。