### PR TITLE
release: v1.14.2 — 管理后台日期时间选择器与调度任务可读名

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 （暂无）
 
+## [1.14.2] - 2026-09-05
+
+### 🐛 修复 (Fixed)
+
+- 调度器监控页的「任务名称」列此前显示的是内部函数名（如 `_auto_save_with_result` 这类下划线开头的闭包限定名）：全部后台定时任务注册时现在显式传入与任务 ID 一致的可读名称，监控页、状态文件与日志全链路同名，排查调度问题时不再需要「脑内翻译」。
+- Web 管理后台的全部原生日期/时间输入框（定时消息的「仅一次」触发日期时间、每日触发时间与审计页的起止筛选）替换为统一的日历/时间选择器组件：中文环境下原生日期控件的空值占位符是浏览器固化的「yyyy/mm/日」中英混合格式且无法用 placeholder 定制（1.14.1 拆分日期+时间只消掉了日期时间混排的半截），新组件自带中文占位符、弹层日历、键盘输入与暗色主题适配，输入值格式与既有校验语义完全不变。
+
 ## [1.14.1] - 2026-09-05
 
 ### 🐛 修复 (Fixed)
@@ -826,7 +833,8 @@
 - 初始化项目骨架：NoneBot2 + OneBot V11，规则驱动回复
 - 时区猜测、复读检测、好姐姐接龙、文字 meme 回复
 
-[Unreleased]: https://github.com/3aKHP/QuickQuip/compare/v1.14.1...HEAD
+[Unreleased]: https://github.com/3aKHP/QuickQuip/compare/v1.14.2...HEAD
+[1.14.2]: https://github.com/3aKHP/QuickQuip/compare/v1.14.1...v1.14.2
 [1.14.1]: https://github.com/3aKHP/QuickQuip/compare/v1.14.0...v1.14.1
 [1.14.0]: https://github.com/3aKHP/QuickQuip/compare/v1.13.2...v1.14.0
 [1.13.2]: https://github.com/3aKHP/QuickQuip/compare/v1.13.1...v1.13.2

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,11 +8,13 @@
     "type-check": "vue-tsc --noEmit"
   },
   "dependencies": {
+    "@vuepic/vue-datepicker": "^14.0.0",
+    "date-fns": "^4.4.0",
     "dompurify": "^3.4.2",
     "echarts": "^6.1.0",
     "lucide-vue-next": "^1.0.0",
     "marked": "^18.0.3",
-    "vue": "^3.4.0",
+    "vue": "^3.5.0",
     "vue-router": "^4.6.4"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@vuepic/vue-datepicker':
+        specifier: ^14.0.0
+        version: 14.0.0(vue@3.5.39(typescript@6.0.3))
+      date-fns:
+        specifier: ^4.4.0
+        version: 4.4.0
       dompurify:
         specifier: ^3.4.2
         version: 3.4.12
@@ -21,7 +27,7 @@ importers:
         specifier: ^18.0.3
         version: 18.0.6
       vue:
-        specifier: ^3.4.0
+        specifier: ^3.5.0
         version: 3.5.39(typescript@6.0.3)
       vue-router:
         specifier: ^4.6.4
@@ -61,6 +67,9 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@date-fns/tz@1.5.0':
+    resolution: {integrity: sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -199,6 +208,18 @@ packages:
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
+
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@floating-ui/vue@1.1.11':
+    resolution: {integrity: sha512-HzHKCNVxnGS35r9fCHBc3+uCnjw9IWIlCPL683cGgM9Kgj2BiAl8x1mS7vtvP6F9S/e/q4O6MApwSHj8hNLGfw==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -347,6 +368,9 @@ packages:
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
   '@vitejs/plugin-vue@5.2.4':
     resolution: {integrity: sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -409,11 +433,33 @@ packages:
       vue:
         optional: true
 
+  '@vuepic/vue-datepicker@14.0.0':
+    resolution: {integrity: sha512-zDl1U2MRk+udu0gYA3pdY2f0O+ckqUPiKgWmp7qQV3D7CRgDKYvUXFpnt+rgMQ+uLydtlRqzy4eS6nvtVjNS4A==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      vue: '>=3.5.0'
+
+  '@vueuse/core@14.4.0':
+    resolution: {integrity: sha512-X4WHz1HlCzCBoYXesUkifzzWBAcZgXG8Fi5iNPQg/epdzOB3gu8Fawj3hvuwYR1nGcXGnvxwYYcUC/71++svtQ==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/metadata@14.4.0':
+    resolution: {integrity: sha512-swx/255R6JyHZFJhx845iz5CRWDZdCfvkZOpACWc5+c5WHcG24mv8gUT1WIdFQaHt6dq79rvILd9QnCWiyVm9g==}
+
+  '@vueuse/shared@14.4.0':
+    resolution: {integrity: sha512-JRgY90Sz8DDtPMsaDflvPMp9xYk69JZAmbuDvAquUVXKr2gEjqtzGNTTthLfckH0BzBqvnu31gb4a8TGLRe79g==}
+    peerDependencies:
+      vue: ^3.5.0
+
   alien-signals@3.2.1:
     resolution: {integrity: sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   dompurify@3.4.12:
     resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
@@ -525,6 +571,17 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  vue-demi@0.14.10:
+    resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
+    engines: {node: '>=12'}
+    hasBin: true
+    peerDependencies:
+      '@vue/composition-api': ^1.0.0-rc.1
+      vue: ^3.0.0-0 || ^2.6.0
+    peerDependenciesMeta:
+      '@vue/composition-api':
+        optional: true
+
   vue-router@4.6.4:
     resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
     peerDependencies:
@@ -561,6 +618,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@date-fns/tz@1.5.0': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -630,6 +689,26 @@ snapshots:
 
   '@esbuild/win32-x64@0.21.5':
     optional: true
+
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/utils@0.2.12': {}
+
+  '@floating-ui/vue@1.1.11(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      '@floating-ui/dom': 1.8.0
+      '@floating-ui/utils': 0.2.12
+      vue-demi: 0.14.10(vue@3.5.39(typescript@6.0.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -712,6 +791,8 @@ snapshots:
 
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/web-bluetooth@0.0.21': {}
 
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21)(vue@3.5.39(typescript@6.0.3))':
     dependencies:
@@ -801,9 +882,34 @@ snapshots:
       typescript: 6.0.3
       vue: 3.5.39(typescript@6.0.3)
 
+  '@vuepic/vue-datepicker@14.0.0(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      '@date-fns/tz': 1.5.0
+      '@floating-ui/vue': 1.1.11(vue@3.5.39(typescript@6.0.3))
+      '@vueuse/core': 14.4.0(vue@3.5.39(typescript@6.0.3))
+      date-fns: 4.4.0
+      vue: 3.5.39(typescript@6.0.3)
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+
+  '@vueuse/core@14.4.0(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.4.0
+      '@vueuse/shared': 14.4.0(vue@3.5.39(typescript@6.0.3))
+      vue: 3.5.39(typescript@6.0.3)
+
+  '@vueuse/metadata@14.4.0': {}
+
+  '@vueuse/shared@14.4.0(vue@3.5.39(typescript@6.0.3))':
+    dependencies:
+      vue: 3.5.39(typescript@6.0.3)
+
   alien-signals@3.2.1: {}
 
   csstype@3.2.3: {}
+
+  date-fns@4.4.0: {}
 
   dompurify@3.4.12:
     optionalDependencies:
@@ -919,6 +1025,10 @@ snapshots:
       fsevents: 2.3.3
 
   vscode-uri@3.1.0: {}
+
+  vue-demi@0.14.10(vue@3.5.39(typescript@6.0.3)):
+    dependencies:
+      vue: 3.5.39(typescript@6.0.3)
 
   vue-router@4.6.4(vue@3.5.39(typescript@6.0.3)):
     dependencies:

--- a/frontend/src/components/ui/UiDatePicker.vue
+++ b/frontend/src/components/ui/UiDatePicker.vue
@@ -95,8 +95,9 @@ function onUpdate(value: unknown) {
 }
 
 /* base.css 的全局 input[type=text] 会作用于选择器输入框（36px 高/边框，视觉一致），
-   只需为尾部日历图标留出避让空间 */
+   但它的 padding（7px 11px）也压掉了库的图标避让（--dp-input-icon-padding）：
+   日历/时钟图标 absolute 定位在输入框左缘，clear 图标在右缘，两侧都要补避让 */
 .ui-date-picker :deep(input.dp--input) {
-  padding-right: 34px;
+  padding-inline: 40px;
 }
 </style>

--- a/frontend/src/components/ui/UiDatePicker.vue
+++ b/frontend/src/components/ui/UiDatePicker.vue
@@ -41,7 +41,7 @@ const props = withDefaults(defineProps<{
   modelValue: string
   mode?: 'date' | 'time'
   placeholder?: string
-  /** 输入框的可读名称（库经 aria-labels.input 透传，attr 不回落） */
+  /** 输入框的可读名称（库只认 aria-labels.input 配置，不透传原生 aria-label attr） */
   ariaLabel?: string
 }>(), {
   mode: 'date',

--- a/frontend/src/components/ui/UiDatePicker.vue
+++ b/frontend/src/components/ui/UiDatePicker.vue
@@ -1,0 +1,102 @@
+<template>
+  <VueDatePicker
+    class="ui-date-picker"
+    :model-value="inner"
+    :model-type="modelType"
+    :time-picker="mode === 'time'"
+    :time-config="timeConfig"
+    :formats="{ input: modelType }"
+    :locale="zhCN"
+    :dark="theme === 'dark'"
+    :config="{ monthChangeOnScroll: false }"
+    :aria-labels="ariaLabel ? { input: ariaLabel } : undefined"
+    :placeholder="placeholder"
+    auto-apply
+    text-input
+    clearable
+    teleport
+    @update:model-value="onUpdate"
+  />
+</template>
+
+<script setup lang="ts">
+/**
+ * 日期/时间选择器（@vuepic/vue-datepicker 封装）。
+ * - 字符串契约：date 模式 '' | "yyyy-MM-dd"，time 模式 '' | "HH:mm"——与被替换的
+ *   原生 input[type=date/time] v-model 完全一致，调用方的 watch/组装/校验零改动；
+ * - 库清空时 emit null，统一归一为 ''；防御性兼容字符串 / Date / {hours,minutes}
+ *   三种形态，model-type 若有行为出入时降级正确而非坏值；
+ * - 弹层 teleport 到 body（避免被 UiCard 的 overflow:hidden 裁剪），暗色走 :dark
+ *   prop + styles/datepicker.css 的 --dp-* → --qq-* 变量重映射；
+ * - text-input 模式保留键盘输入（E2E fill 亦依赖），auto-apply 免掉英文操作行。
+ */
+import { computed } from 'vue'
+import { VueDatePicker } from '@vuepic/vue-datepicker'
+import { zhCN } from 'date-fns/locale'
+import { format } from 'date-fns'
+import { useTheme } from '../../composables/useTheme'
+
+const props = withDefaults(defineProps<{
+  /** '' 或模式对应格式的字符串 */
+  modelValue: string
+  mode?: 'date' | 'time'
+  placeholder?: string
+  /** 输入框的可读名称（库经 aria-labels.input 透传，attr 不回落） */
+  ariaLabel?: string
+}>(), {
+  mode: 'date',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string]
+}>()
+
+const { theme } = useTheme()
+
+const modelType = computed(() => (props.mode === 'time' ? 'HH:mm' : 'yyyy-MM-dd'))
+
+const timeConfig = computed(() => (
+  props.mode === 'time'
+    ? { is24: true }
+    // enableTimePicker 默认 true，date 模式必须显式关闭，否则会长出时间区
+    : { enableTimePicker: false }
+))
+
+const inner = computed(() => props.modelValue || null)
+
+function onUpdate(value: unknown) {
+  if (value == null || value === '') {
+    emit('update:modelValue', '')
+    return
+  }
+  if (typeof value === 'string') {
+    emit('update:modelValue', value)
+    return
+  }
+  if (value instanceof Date) {
+    emit('update:modelValue', format(value, modelType.value))
+    return
+  }
+  if (typeof value === 'object' && 'hours' in (value as Record<string, unknown>)) {
+    const t = value as { hours?: number; minutes?: number }
+    const h = String(t.hours ?? 0).padStart(2, '0')
+    const m = String(t.minutes ?? 0).padStart(2, '0')
+    emit('update:modelValue', `${h}:${m}`)
+    return
+  }
+  emit('update:modelValue', '')
+}
+</script>
+
+<style scoped>
+.ui-date-picker {
+  width: 100%;
+  min-width: 0;
+}
+
+/* base.css 的全局 input[type=text] 会作用于选择器输入框（36px 高/边框，视觉一致），
+   只需为尾部日历图标留出避让空间 */
+.ui-date-picker :deep(input.dp--input) {
+  padding-right: 34px;
+}
+</style>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -3,6 +3,7 @@ import App from './App.vue'
 import { router } from './router/index'
 import './styles/variables.css'
 import './styles/base.css'
+import './styles/datepicker.css'
 import './styles/transitions.css'
 import './styles/responsive.css'
 

--- a/frontend/src/styles/datepicker.css
+++ b/frontend/src/styles/datepicker.css
@@ -2,6 +2,23 @@
 @import '@vuepic/vue-datepicker/dist/main.css';
 
 /*
+ * 紧凑尺寸：库默认面向移动端密度（--dp-font-size 1rem、--dp-time-font-size 2rem、
+ * cell 35px），与本项目 36px 输入框 / 13px 文字的密度不协调。:root 覆盖与库同级同特异性，
+ * 依赖本文件在 @import 之后声明（后者胜）。
+ */
+:root {
+  --dp-font-size: 0.8125rem;        /* 13px，对齐 --qq-text-sm 档 */
+  --dp-time-font-size: 1rem;        /* time-picker 大数字从 32px 收到 16px */
+  --dp-preview-font-size: 0.75rem;
+  --dp-cell-size: 30px;
+  --dp-button-height: 30px;
+  --dp-month-year-row-height: 30px;
+  --dp-button-icon-height: 16px;
+  --dp-time-inc-dec-button-size: 26px;
+  --dp-menu-min-width: 230px;
+}
+
+/*
  * 主题重映射：--dp-* → --qq-*。
  * - 类名/变量在库 v13+ 为 dp-- 前缀（官方 theming 文档页仍展示旧 dp__，以 dist 源码为准）；
  * - html 前缀把特异性提到 0,1,1，压过库的 .dp--theme-*（0,1,0），与构建产物加载顺序无关；

--- a/frontend/src/styles/datepicker.css
+++ b/frontend/src/styles/datepicker.css
@@ -1,0 +1,42 @@
+/* @vuepic/vue-datepicker 基础样式（必须先于重映射加载） */
+@import '@vuepic/vue-datepicker/dist/main.css';
+
+/*
+ * 主题重映射：--dp-* → --qq-*。
+ * - 类名/变量在库 v13+ 为 dp-- 前缀（官方 theming 文档页仍展示旧 dp__，以 dist 源码为准）；
+ * - html 前缀把特异性提到 0,1,1，压过库的 .dp--theme-*（0,1,0），与构建产物加载顺序无关；
+ *   teleport 到 body 的菜单节点同样位于 html 下，可被命中；
+ * - --qq-* 在使用点解析，跟随 html[data-theme] 自动翻转；
+ * - 输入框本身由 base.css 的全局 input[type=text] 规则接管（高度/边框/focus），此处只管弹层。
+ */
+html .dp--theme-dark {
+  --dp-background-color: var(--qq-surface-elevated);
+  --dp-text-color: var(--qq-text);
+  --dp-hover-color: var(--qq-surface-hover);
+  --dp-hover-text-color: var(--qq-text);
+  --dp-hover-icon-color: var(--qq-text-muted);
+  --dp-primary-color: var(--qq-primary);
+  --dp-primary-disabled-color: var(--qq-primary);
+  --dp-primary-text-color: var(--qq-white);
+  --dp-secondary-color: var(--qq-text-muted);
+  --dp-border-color: var(--qq-border-strong);
+  --dp-menu-border-color: var(--qq-border-strong);
+  --dp-border-color-hover: var(--qq-primary);
+  --dp-border-color-focus: var(--qq-primary);
+  --dp-disabled-color: var(--qq-surface-strong);
+  --dp-disabled-color-text: var(--qq-text-muted);
+  --dp-icon-color: var(--qq-text-muted);
+  --dp-danger-color: var(--qq-danger);
+  --dp-highlight-color: var(--qq-accent-soft);
+  --dp-font-family: var(--qq-font-base);
+  --dp-scroll-bar-background: var(--qq-surface-strong);
+  --dp-scroll-bar-color: var(--qq-surface-hover);
+}
+
+html .dp--theme-light {
+  --dp-primary-color: var(--qq-primary);
+  --dp-primary-text-color: var(--qq-white);
+  --dp-border-color-focus: var(--qq-primary);
+  --dp-highlight-color: var(--qq-accent-soft);
+  --dp-font-family: var(--qq-font-base);
+}

--- a/frontend/src/views/AuditView.vue
+++ b/frontend/src/views/AuditView.vue
@@ -5,8 +5,8 @@
     <div class="fbar">
       <div class="f"><label>操作类型</label><select v-model="filters.action"><option value="">全部</option><option value="create">create</option><option value="update">update</option><option value="delete">delete</option><option value="toggle">toggle</option></select></div>
       <div class="f"><label>目标类型</label><select v-model="filters.target_type"><option value="">全部</option><option value="rule">rule</option><option value="group">group</option><option value="memory">memory</option><option value="persona">persona</option><option value="config">config</option><option value="llm_about">llm_about</option><option value="group_setting">group_setting</option></select></div>
-      <div class="f"><label>起始</label><input v-model="filters.since" type="date" /></div>
-      <div class="f"><label>结束</label><input v-model="filters.until" type="date" /></div>
+      <div class="f"><label>起始</label><UiDatePicker v-model="filters.since" placeholder="开始日期" /></div>
+      <div class="f"><label>结束</label><UiDatePicker v-model="filters.until" placeholder="结束日期" /></div>
       <div class="f f-act"><UiButton icon="Search" @click="search">查询</UiButton><UiButton variant="ghost" size="sm" icon="RefreshCw" @click="reset">重置</UiButton></div>
     </div>
     <UiCard padding="md" shadow="sm">
@@ -24,6 +24,7 @@
 <script setup lang="ts">
 import { onMounted, ref, reactive, computed } from 'vue'
 import UiPageHeader from '../components/ui/UiPageHeader.vue'; import UiButton from '../components/ui/UiButton.vue'; import UiCard from '../components/ui/UiCard.vue'; import UiTag from '../components/ui/UiTag.vue'; import UiLoading from '../components/ui/UiLoading.vue'; import UiEmpty from '../components/ui/UiEmpty.vue'; import UiSkeleton from '../components/ui/UiSkeleton.vue'; import UiStatStrip from '../components/ui/UiStatStrip.vue'
+import UiDatePicker from '../components/ui/UiDatePicker.vue'
 import { fetchAuditEntries, type AuditEntry, type AuditQueryParams } from '../api/audit'
 
 const loading = ref(true); const error = ref<string | null>(null); const items = ref<AuditEntry[]>([]); const total = ref(0); const page = ref(1); const limit = 50; const exp = ref(new Set<number>())

--- a/frontend/src/views/ScheduledMessagesView.vue
+++ b/frontend/src/views/ScheduledMessagesView.vue
@@ -56,12 +56,12 @@
           <label v-if="simple.frequency === 'once'" class="field">
             <span>触发日期时间（北京时间）<em class="hint">到点触发一次后自动删除；必须选择未来的时间</em></span>
             <div class="once-row">
-              <input v-model="onceDate" type="date" aria-label="触发日期（北京时间）" />
-              <input v-model="onceTime" type="time" aria-label="触发时间（北京时间）" />
+              <UiDatePicker v-model="onceDate" mode="date" placeholder="选择日期" aria-label="触发日期（北京时间）" />
+              <UiDatePicker v-model="onceTime" mode="time" placeholder="选择时间" aria-label="触发时间（北京时间）" />
             </div>
           </label>
           <template v-else>
-            <label class="field"><span>触发时间（北京时间）</span><input v-model="simple.time" type="time" /></label>
+            <label class="field"><span>触发时间（北京时间）</span><UiDatePicker v-model="simple.time" mode="time" placeholder="选择时间" /></label>
             <label v-if="simple.frequency === 'weekly'" class="field"><span>星期</span>
               <select v-model="simple.weekday">
                 <option v-for="(name, i) in weekdayNames" :key="i" :value="i">{{ name }}</option>
@@ -119,6 +119,7 @@ import UiPageHeader from '../components/ui/UiPageHeader.vue'; import UiButton fr
 import UiCard from '../components/ui/UiCard.vue'; import UiTag from '../components/ui/UiTag.vue'
 import UiToggle from '../components/ui/UiToggle.vue'; import UiEmpty from '../components/ui/UiEmpty.vue'
 import UiSkeleton from '../components/ui/UiSkeleton.vue'; import UiSegmented from '../components/ui/UiSegmented.vue'
+import UiDatePicker from '../components/ui/UiDatePicker.vue'
 import { fetchScheduledMessages, createScheduledMessage, updateScheduledMessage, deleteScheduledMessage, type ScheduledMessageJob, type ScheduledMessagePatch } from '../api/scheduledMessages'
 import { fetchKnownGroups } from '../api/groups'
 import { assembleCron, parseCronToSimple, onceAtInFuture, DEFAULT_SIMPLE_FIELDS, WEEKDAY_NAMES, type SimpleFields } from '../lib/scheduledCron'
@@ -139,10 +140,11 @@ const originalCron = ref(''); const originalRecurring = ref(true)
 const modeOptions: { value: FormMode; label: string }[] = [{ value: 'simple', label: '简易模式' }, { value: 'advanced', label: '高级模式' }]
 const weekdayNames = WEEKDAY_NAMES
 const isOnce = computed(() => mode.value === 'simple' && simple.value.frequency === 'once')
-// 「仅一次」触发时间拆为日期+时间两个原生选择器（#198）：datetime-local 在中文
-// 环境的空值占位符是「yyyy/mm/日 --:--」混合格式。simple.onceAt 契约不变——
-// 恒为 '' 或完整 "YYYY-MM-DDTHH:MM"，部分填写归一为空，交给「请选择」校验兜底。
-// 不用裸 computed 拆装：先选时间再选日期时 setter 互踩会丢已选部分。
+// 「仅一次」触发时间拆为日期+时间两个选择器（#198 起拆分；原生 date 控件在中文
+// Chromium 的空值占位符固化为「yyyy/mm/日」且无法用 placeholder 定制，后改为
+// UiDatePicker）。字符串契约不变：onceDate/onceTime 为 '' 或 "YYYY-MM-DD"/"HH:MM"，
+// simple.onceAt 恒为 '' 或完整 "YYYY-MM-DDTHH:MM"，部分填写归一为空，交给「请选择」
+// 校验兜底。不用裸 computed 拆装：先选时间再选日期时 setter 互踩会丢已选部分。
 const onceDate = ref(''); const onceTime = ref('')
 watch([onceDate, onceTime], ([d, t]) => {
   const composed = d && t ? `${d}T${t}` : ''
@@ -272,7 +274,7 @@ onMounted(loadJobs)
 .field { display: flex; flex-direction: column; gap: var(--qq-gap-xs); font-size: var(--qq-text-sm); color: var(--qq-text-muted); }
 .field--row { flex-direction: row; align-items: center; justify-content: space-between; }
 .once-row { display: flex; gap: var(--qq-gap-xs); }
-.once-row input { flex: 1; }
+.once-row .ui-date-picker { flex: 1; min-width: 0; }
 .field input, .field textarea, .field select { background: var(--qq-surface-strong); color: var(--qq-text); border: 1px solid var(--qq-border); border-radius: var(--qq-radius-sm); padding: var(--qq-gap-xs) var(--qq-gap-sm); font-family: var(--qq-font-base); font-size: var(--qq-text-sm); outline: none; }
 .field input:focus, .field textarea:focus, .field select:focus { border-color: var(--qq-primary); }
 .field-label { font-size: var(--qq-text-sm); color: var(--qq-text-muted); }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickquip"
-version = "1.14.1"
+version = "1.15.0-dev.0"
 requires-python = ">=3.11"
 dynamic = ["dependencies"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickquip"
-version = "1.15.0-dev.0"
+version = "1.14.2-dev.0"
 requires-python = ">=3.11"
 dynamic = ["dependencies"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "quickquip"
-version = "1.14.2-dev.0"
+version = "1.14.2"
 requires-python = ">=3.11"
 dynamic = ["dependencies"]
 

--- a/src/quickquip/adapters/nonebot/awakening_plugin.py
+++ b/src/quickquip/adapters/nonebot/awakening_plugin.py
@@ -104,6 +104,7 @@ def register_boredom_scan_job(sched=None) -> int | None:
         "interval",
         seconds=interval,
         id=job_id,
+        name=job_id,
         replace_existing=True,
     )
     logger.info("awakening: boredom scan job registered (interval=%ds)", interval)

--- a/src/quickquip/adapters/nonebot/cron_status_sync.py
+++ b/src/quickquip/adapters/nonebot/cron_status_sync.py
@@ -105,6 +105,7 @@ def register_cron_status_sync(scheduler, job_results: dict) -> None:
         "interval",
         seconds=30,
         id=CRON_STATUS_SYNC_JOB_ID,
+        name=CRON_STATUS_SYNC_JOB_ID,
         replace_existing=True,
     )
     logger.info("cron_status: sync job registered (every 30s)")

--- a/src/quickquip/adapters/nonebot/daily_briefing_plugin.py
+++ b/src/quickquip/adapters/nonebot/daily_briefing_plugin.py
@@ -241,6 +241,7 @@ def _register_scheduler_jobs() -> None:
             _wrapped_send,
             "cron",
             id=job_id,
+            name=job_id,
             replace_existing=True,
             **parse_cron(getattr(cfg, f"{period}_cron"), fallback_hour="8"),
         )

--- a/src/quickquip/adapters/nonebot/daily_summary_plugin.py
+++ b/src/quickquip/adapters/nonebot/daily_summary_plugin.py
@@ -253,6 +253,7 @@ def _register_scheduler_jobs() -> None:
         _wrapped_generate,
         "cron",
         id="daily_summary_generate",
+        name="daily_summary_generate",
         replace_existing=True,
         **parse_cron(daily_cfg.generate_cron, fallback_hour="6"),
     )
@@ -260,6 +261,7 @@ def _register_scheduler_jobs() -> None:
         _wrapped_publish,
         "cron",
         id="daily_summary_publish",
+        name="daily_summary_publish",
         replace_existing=True,
         **parse_cron(daily_cfg.publish_cron, fallback_hour="6"),
     )
@@ -463,11 +465,11 @@ def _register_period_jobs() -> None:
         pub_id = f"{period_type}_report_publish"
         scheduler.add_job(
             _make_wrapped(gen_id, lambda pt=period_type: _job_generate_period_reports(pt)),
-            "cron", id=gen_id, replace_existing=True, **parse_cron(cfg.generate_cron, fallback_hour="6"),
+            "cron", id=gen_id, name=gen_id, replace_existing=True, **parse_cron(cfg.generate_cron, fallback_hour="6"),
         )
         scheduler.add_job(
             _make_wrapped(pub_id, lambda pt=period_type: _job_publish_period_reports(pt)),
-            "cron", id=pub_id, replace_existing=True, **parse_cron(cfg.publish_cron, fallback_hour="6"),
+            "cron", id=pub_id, name=pub_id, replace_existing=True, **parse_cron(cfg.publish_cron, fallback_hour="6"),
         )
         logger.info(
             "period_report[%s]: jobs registered (generate=%s, publish=%s)",

--- a/src/quickquip/adapters/nonebot/lifecycle.py
+++ b/src/quickquip/adapters/nonebot/lifecycle.py
@@ -150,6 +150,7 @@ def register_lifecycle(driver) -> None:
             "interval",
             minutes=5,
             id="persistence_auto_save",
+            name="persistence_auto_save",
             replace_existing=True,
         )
         scheduler.add_job(
@@ -157,6 +158,7 @@ def register_lifecycle(driver) -> None:
             "interval",
             seconds=30,
             id="web_admin_state_sync",
+            name="web_admin_state_sync",
             replace_existing=True,
         )
         scheduler.add_job(
@@ -164,6 +166,7 @@ def register_lifecycle(driver) -> None:
             "interval",
             seconds=5,
             id="web_admin_action_queue",
+            name="web_admin_action_queue",
             replace_existing=True,
         )
     except ModuleNotFoundError:

--- a/src/quickquip/adapters/nonebot/scheduler_plugin.py
+++ b/src/quickquip/adapters/nonebot/scheduler_plugin.py
@@ -215,6 +215,7 @@ def reload_scheduled_message_jobs(store: ScheduledMessageStore | None = None) ->
                 _make_send_task(job, bot_getter, store),
                 "cron",
                 id=f"{_JOB_ID_PREFIX}{job.id}",
+                name=f"{_JOB_ID_PREFIX}{job.id}",
                 replace_existing=True,
                 **cron_kwargs,
             )
@@ -292,6 +293,7 @@ def _register_festival_job() -> None:
         _check_and_greet,
         "cron",
         id="festival_check",
+        name="festival_check",
         replace_existing=True,
         hour="1",
         minute="0",

--- a/tests/unit/adapters/test_awakening_plugin.py
+++ b/tests/unit/adapters/test_awakening_plugin.py
@@ -16,7 +16,7 @@ class FakeScheduler:
     def __init__(self) -> None:
         self.jobs: dict[str, dict] = {}
 
-    def add_job(self, func, trigger, *, seconds, id, name, replace_existing):
+    def add_job(self, func, trigger, *, seconds, id, name=None, replace_existing):
         assert trigger == "interval"
         assert name == id, "#179: 任务可读名应与 id 一致"
         self.jobs[id] = {

--- a/tests/unit/adapters/test_awakening_plugin.py
+++ b/tests/unit/adapters/test_awakening_plugin.py
@@ -16,8 +16,9 @@ class FakeScheduler:
     def __init__(self) -> None:
         self.jobs: dict[str, dict] = {}
 
-    def add_job(self, func, trigger, *, seconds, id, replace_existing):
+    def add_job(self, func, trigger, *, seconds, id, name, replace_existing):
         assert trigger == "interval"
+        assert name == id, "#179: 任务可读名应与 id 一致"
         self.jobs[id] = {
             "func": func,
             "seconds": seconds,

--- a/tests/unit/adapters/test_lifecycle.py
+++ b/tests/unit/adapters/test_lifecycle.py
@@ -149,13 +149,15 @@ async def test_lifecycle_jobs_record_results(monkeypatch):
 
     driver = _FakeDriver()
     captured: dict[str, object] = {}
-    captured_names: dict[str, object] = {}
+    captured_names: dict[str, str | None] = {}
+
+    def _record_job(fn, kwargs):
+        captured[kwargs["id"]] = fn
+        captured_names[kwargs["id"]] = kwargs.get("name")
+
     fake_scheduler_module = types.ModuleType("nonebot_plugin_apscheduler")
     fake_scheduler_module.scheduler = types.SimpleNamespace(
-        add_job=lambda fn, *args, **kwargs: (
-            captured.__setitem__(kwargs["id"], fn),
-            captured_names.__setitem__(kwargs["id"], kwargs.get("name")),
-        )
+        add_job=lambda fn, *args, **kwargs: _record_job(fn, kwargs)
     )
     monkeypatch.setitem(sys.modules, "nonebot_plugin_apscheduler", fake_scheduler_module)
     monkeypatch.setattr(scheduler_plugin, "_job_run_results", {})

--- a/tests/unit/adapters/test_lifecycle.py
+++ b/tests/unit/adapters/test_lifecycle.py
@@ -149,9 +149,13 @@ async def test_lifecycle_jobs_record_results(monkeypatch):
 
     driver = _FakeDriver()
     captured: dict[str, object] = {}
+    captured_names: dict[str, object] = {}
     fake_scheduler_module = types.ModuleType("nonebot_plugin_apscheduler")
     fake_scheduler_module.scheduler = types.SimpleNamespace(
-        add_job=lambda fn, *args, **kwargs: captured.__setitem__(kwargs["id"], fn)
+        add_job=lambda fn, *args, **kwargs: (
+            captured.__setitem__(kwargs["id"], fn),
+            captured_names.__setitem__(kwargs["id"], kwargs.get("name")),
+        )
     )
     monkeypatch.setitem(sys.modules, "nonebot_plugin_apscheduler", fake_scheduler_module)
     monkeypatch.setattr(scheduler_plugin, "_job_run_results", {})
@@ -160,6 +164,7 @@ async def test_lifecycle_jobs_record_results(monkeypatch):
     assert set(captured) == {
         "persistence_auto_save", "web_admin_state_sync", "web_admin_action_queue",
     }
+    assert captured_names == {job_id: job_id for job_id in captured}, "#179: 任务可读名应与 id 一致"
 
     # ok 路径：三个任务全部记录 success
     monkeypatch.setattr(lifecycle, "save_all", lambda: None)

--- a/tests/unit/adapters/test_scheduler_plugin.py
+++ b/tests/unit/adapters/test_scheduler_plugin.py
@@ -17,7 +17,8 @@ class FakeCronScheduler:
     def __init__(self):
         self.jobs: dict[str, dict] = {}
 
-    def add_job(self, func, trigger, *, id, replace_existing, **cron_kwargs):
+    def add_job(self, func, trigger, *, id, name=None, replace_existing=True, **cron_kwargs):
+        assert name == id, "#179: 任务可读名应与 id 一致"
         self.jobs[id] = {"func": func, "trigger": trigger, "cron": cron_kwargs}
 
     def get_jobs(self):


### PR DESCRIPTION
## 发布内容

v1.14.2 补丁版，承接 dev 上 PR #209 的两波修复（基线 v1.14.1）：

### 🐛 修复 (Fixed)

- 调度器监控页的「任务名称」列此前显示的是内部函数名（如 `_auto_save_with_result` 这类下划线开头的闭包限定名）：全部后台定时任务注册时现在显式传入与任务 ID 一致的可读名称，监控页、状态文件与日志全链路同名，排查调度问题时不再需要「脑内翻译」。（Closes #179 由 #209 完成）
- Web 管理后台的全部原生日期/时间输入框（定时消息的「仅一次」触发日期时间、每日触发时间与审计页的起止筛选）替换为统一的日历/时间选择器组件：中文环境下原生日期控件的空值占位符是浏览器固化的「yyyy/mm/日」中英混合格式且无法用 placeholder 定制，新组件自带中文占位符、弹层日历、键盘输入与暗色主题适配，输入值格式与既有校验语义完全不变。

## 冻结说明

- 版本号 `1.14.2-dev.0` → `1.14.2`；CHANGELOG `[Unreleased]` 汇总 `dev/changelog/209-*.md` 两份草稿为 `[1.14.2]` 段并推进比较链接（草稿按惯例待发版成功后清理）。
- 本 PR 从 dev（509d164）拉出 `release/*` 分支承载冻结，合并后 dev 回灌并将版本 bump 至 `1.15.0-dev.0`。

## 验证

- 完整 pytest 1647 passed（-n auto）；ruff clean；`validate_toml_examples` 12 files OK；前端 type-check + build 通过。
- PR #209 四轮 Bot Review 全部 Approve；E2E 13/13（TZ=UTC+Asia/Shanghai 双时区）与 bundle +~20KB 已由 #209 记录。
- 发行 workflow 产物验证与消费者验收待 tag 后按流程执行。