### PR TITLE
feat: Agent Loop 记录、历史重放与逐 Turn 分段交付

### DIFF
--- a/config/llm.toml.example
+++ b/config/llm.toml.example
@@ -33,6 +33,24 @@ tool_max_calls_per_round = 16
 # recent_context_token_budget = 800
 # recent_context_floor_seconds = 300
 
+# 实际请求输入预算（应用侧估算口径，非模型平台上限）：每次 provider 请求前
+# 对最终 payload 估算，超限拒绝发起并提示清空上下文。provider 可单独覆盖。
+# request_input_token_budget = 96000
+
+# Agent 执行记录保留（按 scope，先触顶者触发整 Loop 清理）
+# agent_record_retention_days = 30
+# agent_record_max_loops_per_scope = 1000
+# agent_record_max_bytes_per_scope = 67108864
+
+# 逐 Turn 交付（默认关闭：安装新版本不改变群内消息量；记录与重放始终工作）
+# 开启后每次模型响应的普通正文先于工具执行分段外发；阈值/上限为 Unicode
+# code point 口径，独立于 OneBot 协议报文长度限制。
+# agent_delivery_enabled = false
+# reply_split_threshold_chars = 800
+# reply_chunk_max_chars = 1200
+# reply_send_interval_ms = 800
+# reply_max_chunks_per_loop = 64
+
 # 上游 429/5xx/网络错误的自动重试（所有 LLM 调用路径统一生效；探活/诊断不受影响）
 # retry_max_attempts 含首次调用；第 n 次重试延迟 = base_delay * 2^n * (1 + 随机抖动)
 retry_max_attempts = 3

--- a/config/llm.toml.example
+++ b/config/llm.toml.example
@@ -45,6 +45,7 @@ tool_max_calls_per_round = 16
 # 逐 Turn 交付（默认关闭：安装新版本不改变群内消息量；记录与重放始终工作）
 # 开启后每次模型响应的普通正文先于工具执行分段外发；阈值/上限为 Unicode
 # code point 口径，独立于 OneBot 协议报文长度限制。
+# agent_replay_loop_tokens = 4096
 # agent_delivery_enabled = false
 # reply_split_threshold_chars = 800
 # reply_chunk_max_chars = 1200

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -134,6 +134,15 @@ GHCR 分发镜像和 `prod.example/Dockerfile` 均基于 Playwright Python 镜�
 | `epoch_cap_tokens` | 窗口硬上限：超过即触发触顶重置（H_hot / cap） | `64000` |
 | `recent_context_token_budget` | 【现场】补丁每轮 token 预算：近期消息缓冲服役给 LLM 的上限（从最新往回截） | `800` |
 | `recent_context_floor_seconds` | 【现场】滑动保底窗秒数：窗内消息即使已服役过也会重附（增量语义之外的保底） | `300` |
+| `request_input_token_budget` | 实际请求输入预算（应用侧估算口径，非模型平台上限）：超限拒绝发起请求 | `96000` |
+| `agent_record_retention_days` | 已关闭对话轮（Loop）保留天数，按关闭时间计 | `30` |
+| `agent_record_max_loops_per_scope` | 每会话已关闭 Loop 数量上限，先触顶者触发清理最旧完整 Loop | `1000` |
+| `agent_record_max_bytes_per_scope` | 每会话 Loop 业务记录字节上限（UTF-8 计量） | `67108864` |
+| `agent_delivery_enabled` | 逐 Turn 交付开关：开启后每次模型响应的普通正文先于工具执行分段外发；关闭时仅最终正文单发，记录不受影响 | `false` |
+| `reply_split_threshold_chars` | 回复超过该长度（Unicode code point）才进行自然分段 | `800` |
+| `reply_chunk_max_chars` | 单段源文本上限，独立于 OneBot 协议报文长度 | `1200` |
+| `reply_send_interval_ms` | 同会话相邻发送开始时间的最小间隔（0-10000） | `800` |
+| `reply_max_chunks_per_loop` | 单次对话交付条目上限（含文字、媒体与通知，1-256） | `64` |
 
 以上 6 个 `epoch_*` 键均可在 `[[providers]]` 条目里同名覆盖（如 DeepSeek 的缓存存活更久，`epoch_cold_idle_seconds` 可放宽到 `21600`）；未覆盖的键继承 `[runtime]` 值。参数关系需满足 `0 < cold_target < cold_trigger ≤ hot_target < cap` 且 `context_tokens > 0`，非法时回退并记 warning。`recent_context_*` 两键仅全局，不支持 provider 覆盖。
 

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -134,10 +134,11 @@ GHCR 分发镜像和 `prod.example/Dockerfile` 均基于 Playwright Python 镜�
 | `epoch_cap_tokens` | 窗口硬上限：超过即触发触顶重置（H_hot / cap） | `64000` |
 | `recent_context_token_budget` | 【现场】补丁每轮 token 预算：近期消息缓冲服役给 LLM 的上限（从最新往回截） | `800` |
 | `recent_context_floor_seconds` | 【现场】滑动保底窗秒数：窗内消息即使已服役过也会重附（增量语义之外的保底） | `300` |
-| `request_input_token_budget` | 实际请求输入预算（应用侧估算口径，非模型平台上限）：超限拒绝发起请求 | `96000` |
+| `request_input_token_budget` | 实际请求输入预算（应用侧估算口径，非模型平台上限）：超限拒绝发起请求；可在 `[[providers]]` 段按 provider 覆盖 | `96000` |
 | `agent_record_retention_days` | 已关闭对话轮（Loop）保留天数，按关闭时间计 | `30` |
 | `agent_record_max_loops_per_scope` | 每会话已关闭 Loop 数量上限，先触顶者触发清理最旧完整 Loop | `1000` |
 | `agent_record_max_bytes_per_scope` | 每会话 Loop 业务记录字节上限（UTF-8 计量） | `67108864` |
+| `agent_replay_loop_tokens` | 单个历史 Loop 的重放投影预算（token 估算，512-65536）；超限按固定阶梯确定性精简 | `4096` |
 | `agent_delivery_enabled` | 逐 Turn 交付开关：开启后每次模型响应的普通正文先于工具执行分段外发；关闭时仅最终正文单发，记录不受影响 | `false` |
 | `reply_split_threshold_chars` | 回复超过该长度（Unicode code point）才进行自然分段 | `800` |
 | `reply_chunk_max_chars` | 单段源文本上限，独立于 OneBot 协议报文长度 | `1200` |

--- a/src/quickquip/adapters/nonebot/_llm_reply.py
+++ b/src/quickquip/adapters/nonebot/_llm_reply.py
@@ -1,11 +1,15 @@
-"""LLM 回复消息拼装：文本 + 工具外发图片。
+"""LLM 回复消息拼装：文本 + 工具外发图片 + 生产 DeliverySink。
 
 群聊两个触发路径与私聊路径共用，保证带图回复的拼装逻辑只写一份。
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+import asyncio
+import time
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from quickquip.llm.agent_records import DeliveryReceipt, DeliveryStatus
 
 if TYPE_CHECKING:
     from nonebot.adapters.onebot.v11 import Message as OneBotMessage
@@ -28,3 +32,124 @@ def build_llm_reply_message(
         MessageSegment.image(f"base64://{b64}") for b64 in result.get("images") or []
     )
     return Message(segments)
+
+
+# 同 scope 相邻发送开始时间的最小间隔（§6.2）：进程内节流表。
+_LAST_SEND_AT: dict[str, float] = {}
+
+_DEFAULT_INTERVAL_MS = 800
+
+
+def reply_interval_ms(svc: Any) -> int:
+    """读取 reply_send_interval_ms；svc 为测试桩时回落默认值。"""
+    try:
+        return int(getattr(svc.config.runtime, "reply_send_interval_ms", _DEFAULT_INTERVAL_MS))
+    except (AttributeError, TypeError, ValueError):
+        return _DEFAULT_INTERVAL_MS
+
+
+def reset_delivery_throttle() -> None:
+    """测试隔离用：清空节流表。"""
+    _LAST_SEND_AT.clear()
+
+
+class OneBotDeliverySink:
+    """生产 DeliverySink（§5.1/§6.2）。
+
+    ``send`` 是适配层注入的单条文本发送协程（matcher.send 或
+    bot.send_group_msg/send_private_msg 的薄包装），回执分类：
+
+    - dict 且含可信 ``message_id`` → ``sent``；
+    - 响应缺 message_id / 超时类异常 → ``unknown``（不自动重发）；
+    - 其余显式失败 → ``failed``。
+
+    正文经 ``MessageSegment.text`` 构造，不进 CQ 解析器。相邻发送按
+    ``reply_send_interval_ms`` 节流，不并发发送同一 scope 的片段。
+    """
+
+    def __init__(
+        self,
+        send: Callable[[str], Awaitable[Any]],
+        *,
+        scope_key: str,
+        interval_ms: int = 800,
+    ) -> None:
+        self._send = send
+        self._scope_key = scope_key
+        self._interval_seconds = max(0, int(interval_ms)) / 1000.0
+        self.sent_texts: list[str] = []
+
+    async def __call__(self, delivery_id: str, payload: dict[str, Any]) -> DeliveryReceipt:
+        text = str(payload.get("text", ""))
+        if self._interval_seconds:
+            last = _LAST_SEND_AT.get(self._scope_key)
+            if last is not None:
+                wait = self._interval_seconds - (time.monotonic() - last)
+                if wait > 0:
+                    await asyncio.sleep(wait)
+            _LAST_SEND_AT[self._scope_key] = time.monotonic()
+        try:
+            resp = await self._send(text)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.sent_texts.append("")
+            lowered = str(exc).lower()
+            if "timeout" in lowered or "timed out" in lowered:
+                return DeliveryReceipt(status=DeliveryStatus.UNKNOWN, error_code=type(exc).__name__)
+            return DeliveryReceipt(status=DeliveryStatus.FAILED, error_code=type(exc).__name__)
+        self.sent_texts.append(text)
+        message_id = ""
+        if isinstance(resp, dict):
+            message_id = str(resp.get("message_id", "") or "").strip()
+        if message_id:
+            return DeliveryReceipt(status=DeliveryStatus.SENT, message_id=message_id)
+        return DeliveryReceipt(status=DeliveryStatus.UNKNOWN, error_code="missing_message_id")
+
+
+def text_only_message(text: str, Message: type[OneBotMessage], MessageSegment: type[OneBotMessageSegment]) -> OneBotMessage:
+    """纯文本 Message（§6.2）：分段正文不经 CQ 解析器。"""
+    return Message([MessageSegment.text(text)])
+
+
+def make_matcher_sink(matcher, Message, MessageSegment, *, scope_key: str, interval_ms: int) -> OneBotDeliverySink:
+    return OneBotDeliverySink(
+        lambda text: matcher.send(text_only_message(text, Message, MessageSegment)),
+        scope_key=scope_key,
+        interval_ms=interval_ms,
+    )
+
+
+def make_group_bot_sink(bot, Message, MessageSegment, *, group_id: int | str, interval_ms: int) -> OneBotDeliverySink:
+    async def _send(text: str):
+        return await bot.send_group_msg(
+            group_id=int(group_id),
+            message=text_only_message(text, Message, MessageSegment),
+        )
+
+    return OneBotDeliverySink(_send, scope_key=str(group_id), interval_ms=interval_ms)
+
+
+def make_private_bot_sink(bot, Message, MessageSegment, *, user_id: int | str, interval_ms: int) -> OneBotDeliverySink:
+    async def _send(text: str):
+        return await bot.send_private_msg(
+            user_id=int(user_id),
+            message=text_only_message(text, Message, MessageSegment),
+        )
+
+    return OneBotDeliverySink(_send, scope_key=f"private:{user_id}", interval_ms=interval_ms)
+
+
+def record_final_receipt(svc, result: dict[str, Any], sent_msg_id: str) -> None:
+    """关闭开关模式下的最终单发回执：新链路用确切 row_id 回填兼容列（§4.1）。"""
+    row_id = result.get("agent_turn_row_id")
+    if row_id and sent_msg_id:
+        try:
+            svc.store.set_first_chunk_message_id(int(row_id), sent_msg_id)
+            return
+        except Exception:
+            return
+    if sent_msg_id:
+        scope_key = str(result.get("scope_key", "")) or None
+        if scope_key:
+            svc.store.update_last_assistant_message_id(scope_key, sent_msg_id)

--- a/src/quickquip/adapters/nonebot/_llm_reply.py
+++ b/src/quickquip/adapters/nonebot/_llm_reply.py
@@ -77,6 +77,8 @@ class OneBotDeliverySink:
         self._send = send
         self._scope_key = scope_key
         self._interval_seconds = max(0, int(interval_ms)) / 1000.0
+        # 仅成功回执的可见文本：供冷却缓存/trace 预览消费；失败不污染
+        # （零成功交付不得触发冷却确认）。
         self.sent_texts: list[str] = []
 
     async def __call__(self, delivery_id: str, payload: dict[str, Any]) -> DeliveryReceipt:
@@ -93,7 +95,6 @@ class OneBotDeliverySink:
         except asyncio.CancelledError:
             raise
         except Exception as exc:
-            self.sent_texts.append("")
             lowered = str(exc).lower()
             if "timeout" in lowered or "timed out" in lowered:
                 return DeliveryReceipt(status=DeliveryStatus.UNKNOWN, error_code=type(exc).__name__)
@@ -142,12 +143,17 @@ def make_private_bot_sink(bot, Message, MessageSegment, *, user_id: int | str, i
 
 def record_final_receipt(svc, result: dict[str, Any], sent_msg_id: str) -> None:
     """关闭开关模式下的最终单发回执：新链路用确切 row_id 回填兼容列（§4.1）。"""
+    import logging as _logging
+
     row_id = result.get("agent_turn_row_id")
     if row_id and sent_msg_id:
         try:
             svc.store.set_first_chunk_message_id(int(row_id), sent_msg_id)
             return
         except Exception:
+            _logging.getLogger(__name__).warning(
+                "final receipt backfill failed for row %s", row_id, exc_info=True
+            )
             return
     if sent_msg_id:
         scope_key = str(result.get("scope_key", "")) or None

--- a/src/quickquip/adapters/nonebot/awakening_plugin.py
+++ b/src/quickquip/adapters/nonebot/awakening_plugin.py
@@ -95,12 +95,12 @@ def register_boredom_scan_job(sched=None) -> int | None:
                         delivery_sink=sink,
                         trigger_kind=TriggerKind.BOREDOM,
                     )
-                    if not str(result.get("reply") or "").strip() and sink.sent_texts:
-                        # 逐 Turn 模式：可见文本已由 sink 交付，冷却缓存用
-                        # 末段实际文本（§10：唤醒 cooldown 在首次确认可见
-                        # 发送时更新一次）。
+                    # 逐 Turn 模式：正文已由 sink 交付（reply 为空）。可见
+                    # 文本走独立字段供冷却缓存/统计消费——绝不回填 reply，
+                    # 否则最终单发守卫被击穿造成末段双发（Deep-CR B1）。
+                    if sink.sent_texts:
                         patched = dict(result)
-                        patched["reply"] = sink.sent_texts[-1]
+                        patched["delivered_text"] = sink.sent_texts[-1]
                         return patched
                     return result
 

--- a/src/quickquip/adapters/nonebot/awakening_plugin.py
+++ b/src/quickquip/adapters/nonebot/awakening_plugin.py
@@ -11,7 +11,12 @@ except (ModuleNotFoundError, ValueError):
     scheduler = None
     Message = MessageSegment = None
 
-from quickquip.adapters.nonebot._llm_reply import build_llm_reply_message
+from quickquip.adapters.nonebot._llm_reply import (
+    build_llm_reply_message,
+    make_group_bot_sink,
+    record_final_receipt,
+    reply_interval_ms,
+)
 
 from quickquip.app.message_pipeline import (
     _ensure_llm_bindings,
@@ -72,17 +77,50 @@ def register_boredom_scan_job(sched=None) -> int | None:
             def _build_reply(result: dict):
                 return build_llm_reply_message(result, Message, MessageSegment)
 
-            # 发送循环归适配层：chat 层只产出待发送计划，传输成功后
-            # 回调 confirm_boredom_sent 确认冷却/统计/缓存。
+            # 发送循环归适配层：chat 层只产出待发送计划，统一生成/交付
+            # 流程（含 DeliverySink）由本层注入；传输成功后回调
+            # confirm_boredom_sent 确认冷却/统计/缓存。
+            from quickquip.llm.agent_records import TriggerKind
+
+            def _generate_with_delivery(**kwargs):
+                sink = make_group_bot_sink(
+                    bot, Message, MessageSegment,
+                    group_id=str(kwargs["group_id"]),
+                    interval_ms=reply_interval_ms(svc),
+                )
+
+                async def _call(**kw):
+                    result = await svc.generate_reply(
+                        **kw,
+                        delivery_sink=sink,
+                        trigger_kind=TriggerKind.BOREDOM,
+                    )
+                    if not str(result.get("reply") or "").strip() and sink.sent_texts:
+                        # 逐 Turn 模式：可见文本已由 sink 交付，冷却缓存用
+                        # 末段实际文本（§10：唤醒 cooldown 在首次确认可见
+                        # 发送时更新一次）。
+                        patched = dict(result)
+                        patched["reply"] = sink.sent_texts[-1]
+                        return patched
+                    return result
+
+                return _call(**kwargs)
+
             async for plan in iter_boredom_send_plans(
-                boredom_enabled_groups, rule_switch, svc, rate_limiter
+                boredom_enabled_groups, rule_switch, svc, rate_limiter,
+                generate=_generate_with_delivery,
             ):
                 try:
                     with bot_action_trace(**plan.trace_kwargs()):
-                        await bot.send_group_msg(
-                            group_id=int(plan.group_id),
-                            message=_build_reply(plan.reply_result),
-                        )
+                        if str(plan.reply_result.get("reply") or "").strip():
+                            resp = await bot.send_group_msg(
+                                group_id=int(plan.group_id),
+                                message=_build_reply(plan.reply_result),
+                            )
+                            sent_msg_id = (
+                                str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
+                            )
+                            record_final_receipt(svc, plan.reply_result, sent_msg_id)
                     confirm_boredom_sent(plan, stats_tracker)
                 except Exception:
                     logger.warning(

--- a/src/quickquip/adapters/nonebot/group_messages.py
+++ b/src/quickquip/adapters/nonebot/group_messages.py
@@ -289,7 +289,7 @@ def register_message_matcher(on_message, Message, MessageSegment):
                 user_id=user_id,
                 incoming_message_id=message_id,
                 incoming_preview=rendered_text,
-                reply_preview=result["reply"] or (delivery_sink.sent_texts[-1][:120] if delivery_sink.sent_texts else ""),
+                reply_preview=result["reply"] or (passive_sink.sent_texts[-1][:120] if passive_sink.sent_texts else ""),
                 llm_used=bool(result.get("llm_used")),
                 provider_id=str(result.get("provider_id", "")),
                 model=str(result.get("model", "")),

--- a/src/quickquip/adapters/nonebot/group_messages.py
+++ b/src/quickquip/adapters/nonebot/group_messages.py
@@ -217,7 +217,7 @@ def register_message_matcher(on_message, Message, MessageSegment):
                 user_id=user_id,
                 incoming_message_id=message_id,
                 incoming_preview=rendered_text,
-                reply_preview=result["reply"],
+                reply_preview=result["reply"] or (delivery_sink.sent_texts[-1][:120] if delivery_sink.sent_texts else ""),
                 llm_used=bool(result.get("llm_used")),
                 provider_id=str(result.get("provider_id", "")),
                 model=str(result.get("model", "")),
@@ -225,7 +225,7 @@ def register_message_matcher(on_message, Message, MessageSegment):
             ):
                 # 逐 Turn 模式正文已由 sink 交付（reply 为空），此处只处理
                 # 最终单发/错误提示路径，避免二次发送（§10）。
-                if str(result.get("reply") or "").strip():
+                if str(result.get("reply") or "").strip() or (result.get("images") or []):
                     resp = await matcher.send(build_llm_reply_message(result, Message, MessageSegment))
                     sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
                     record_final_receipt(svc, result, sent_msg_id)
@@ -289,13 +289,13 @@ def register_message_matcher(on_message, Message, MessageSegment):
                 user_id=user_id,
                 incoming_message_id=message_id,
                 incoming_preview=rendered_text,
-                reply_preview=result["reply"],
+                reply_preview=result["reply"] or (delivery_sink.sent_texts[-1][:120] if delivery_sink.sent_texts else ""),
                 llm_used=bool(result.get("llm_used")),
                 provider_id=str(result.get("provider_id", "")),
                 model=str(result.get("model", "")),
                 source="group_message.awakening",
             ):
-                if str(result.get("reply") or "").strip():
+                if str(result.get("reply") or "").strip() or (result.get("images") or []):
                     resp = await matcher.send(build_llm_reply_message(result, Message, MessageSegment))
                     sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
                     record_final_receipt(svc, result, sent_msg_id)

--- a/src/quickquip/adapters/nonebot/group_messages.py
+++ b/src/quickquip/adapters/nonebot/group_messages.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 from quickquip.llm.inputs import extract_llm_input
 from quickquip.llm.rendering import render_message_for_llm
 from quickquip.adapters.nonebot._forward import extract_forward_content
-from quickquip.adapters.nonebot._llm_reply import build_llm_reply_message
+from quickquip.adapters.nonebot._llm_reply import (
+    build_llm_reply_message,
+    make_matcher_sink,
+    record_final_receipt,
+    reply_interval_ms,
+)
 from quickquip.adapters.nonebot.voice import append_voice_transcripts, transcribe_message_records
 from quickquip.common.bot_action_trace import bot_action_trace
 from quickquip.chat.reply_probability import roll_reply
@@ -172,11 +177,20 @@ def register_message_matcher(on_message, Message, MessageSegment):
             _remember_recent_message(group_id, user_id, sender_name, canonical_name, rendered_text, message_id, image_urls=rendered_message.image_urls)
             if not roll_reply("llm_chat", group_id=group_id) or not rate_limiter.allow("llm_chat", user_id):
                 return
+            from quickquip.llm.agent_records import TriggerKind
+
+            delivery_sink = make_matcher_sink(
+                matcher, Message, MessageSegment,
+                scope_key=str(group_id),
+                interval_ms=reply_interval_ms(svc),
+            )
             result = await svc.generate_reply(
                 group_id=group_id,
                 user_id=user_id,
                 sender_name=sender_name,
                 prompt=llm_input.prompt,
+                delivery_sink=delivery_sink,
+                trigger_kind=TriggerKind.GROUP_DIRECT,
                 image_urls=llm_input.image_urls,
                 quoted_text=llm_input.quoted_text,
                 quoted_image_urls=llm_input.quoted_image_urls,
@@ -209,11 +223,12 @@ def register_message_matcher(on_message, Message, MessageSegment):
                 model=str(result.get("model", "")),
                 source="group_message.explicit_llm",
             ):
-                resp = await matcher.send(build_llm_reply_message(result, Message, MessageSegment))
-            sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
-            if sent_msg_id:
-                scope_key = str(group_id)
-                svc.store.update_last_assistant_message_id(scope_key, sent_msg_id)
+                # 逐 Turn 模式正文已由 sink 交付（reply 为空），此处只处理
+                # 最终单发/错误提示路径，避免二次发送（§10）。
+                if str(result.get("reply") or "").strip():
+                    resp = await matcher.send(build_llm_reply_message(result, Message, MessageSegment))
+                    sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
+                    record_final_receipt(svc, result, sent_msg_id)
             return
 
         from quickquip.chat.awakening import (
@@ -243,10 +258,19 @@ def register_message_matcher(on_message, Message, MessageSegment):
                 awakening_result,
                 rendered_message.image_urls,
             )
+            from quickquip.llm.agent_records import TriggerKind
+
+            passive_sink = make_matcher_sink(
+                matcher, Message, MessageSegment,
+                scope_key=str(group_id),
+                interval_ms=reply_interval_ms(svc),
+            )
             result = await svc.generate_reply(
                 group_id=group_id,
                 user_id=user_id,
                 sender_name=sender_name,
+                delivery_sink=passive_sink,
+                trigger_kind=TriggerKind.GROUP_PASSIVE,
                 prompt=build_awakening_prompt(awakening_result, passive_image_urls),
                 image_urls=passive_image_urls,
                 include_recent_images=allows_recent_images(awakening_result.rule_name),
@@ -271,11 +295,10 @@ def register_message_matcher(on_message, Message, MessageSegment):
                 model=str(result.get("model", "")),
                 source="group_message.awakening",
             ):
-                resp = await matcher.send(build_llm_reply_message(result, Message, MessageSegment))
-            sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
-            if sent_msg_id:
-                scope_key = str(group_id)
-                svc.store.update_last_assistant_message_id(scope_key, sent_msg_id)
+                if str(result.get("reply") or "").strip():
+                    resp = await matcher.send(build_llm_reply_message(result, Message, MessageSegment))
+                    sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
+                    record_final_receipt(svc, result, sent_msg_id)
             return
 
         result = await resolve_reply(

--- a/src/quickquip/adapters/nonebot/lifecycle.py
+++ b/src/quickquip/adapters/nonebot/lifecycle.py
@@ -77,6 +77,21 @@ def register_lifecycle(driver) -> None:
     async def _startup_llm_runtime():
         svc = get_llm_service()
         await svc.startup(background=True)
+        # 崩溃恢复（§5.5）：新 Bot 进程补齐未关闭 Loop 的缺失终态；
+        # Web 只做迁移/查询，不代替 Bot 宣判活跃 Loop。
+        try:
+            report = svc.store.recover_unfinished_loops()
+            if report.closed_loops:
+                logger.info(
+                    "agent loop recovery closed %d loops (tools=%d/%d, deliveries=%d/%d)",
+                    len(report.closed_loops),
+                    len(report.tools_not_executed),
+                    len(report.tools_indeterminate),
+                    len(report.deliveries_skipped),
+                    len(report.deliveries_unknown),
+                )
+        except Exception:
+            logger.exception("agent loop recovery failed")
         await tieba_service.startup()
         _init_mtimes()
 

--- a/src/quickquip/adapters/nonebot/private_messages.py
+++ b/src/quickquip/adapters/nonebot/private_messages.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from quickquip.adapters.nonebot._llm_reply import build_llm_reply_message
+from quickquip.adapters.nonebot._llm_reply import (
+    build_llm_reply_message,
+    make_matcher_sink,
+    record_final_receipt,
+    reply_interval_ms,
+)
 from quickquip.llm.inputs import extract_private_llm_input
 from quickquip.llm.rendering import render_message_for_llm
 from quickquip.adapters.nonebot._forward import extract_forward_content
@@ -90,9 +95,18 @@ def register_private_message_matcher(on_message):
         if not roll_reply("llm_chat", group_id=f"private:{user_id}") or not rate_limiter.allow("llm_chat", user_id):
             return
 
+        from quickquip.llm.agent_records import TriggerKind
+
+        delivery_sink = make_matcher_sink(
+            matcher, Message, MessageSegment,
+            scope_key=scope_key,
+            interval_ms=reply_interval_ms(svc),
+        )
         result = await svc.generate_private_reply(
             user_id=user_id,
             sender_name=sender_name,
+            delivery_sink=delivery_sink,
+            trigger_kind=TriggerKind.PRIVATE_DIRECT,
             prompt=llm_input.prompt,
             image_urls=llm_input.image_urls,
             recent_messages=None,
@@ -122,10 +136,10 @@ def register_private_message_matcher(on_message):
             model=str(result.get("model", "")),
             source="private_message.llm",
         ):
-            resp = await matcher.send(build_llm_reply_message(result, Message, MessageSegment))
-        sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
-        if sent_msg_id:
-            svc.store.update_last_assistant_message_id(scope_key, sent_msg_id)
+            if str(result.get("reply") or "").strip():
+                resp = await matcher.send(build_llm_reply_message(result, Message, MessageSegment))
+                sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
+                record_final_receipt(svc, result, sent_msg_id)
         return
 
     return matcher

--- a/src/quickquip/adapters/nonebot/private_messages.py
+++ b/src/quickquip/adapters/nonebot/private_messages.py
@@ -130,13 +130,13 @@ def register_private_message_matcher(on_message):
             user_id=user_id,
             incoming_message_id=message_id,
             incoming_preview=rendered_text,
-            reply_preview=result["reply"],
+            reply_preview=result["reply"] or (delivery_sink.sent_texts[-1][:120] if delivery_sink.sent_texts else ""),
             llm_used=bool(result.get("llm_used")),
             provider_id=str(result.get("provider_id", "")),
             model=str(result.get("model", "")),
             source="private_message.llm",
         ):
-            if str(result.get("reply") or "").strip():
+            if str(result.get("reply") or "").strip() or (result.get("images") or []):
                 resp = await matcher.send(build_llm_reply_message(result, Message, MessageSegment))
                 sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
                 record_final_receipt(svc, result, sent_msg_id)

--- a/src/quickquip/adapters/nonebot/scheduler_plugin.py
+++ b/src/quickquip/adapters/nonebot/scheduler_plugin.py
@@ -22,7 +22,12 @@ except ImportError:  # pragma: no cover - apscheduler 随 nonebot-plugin-apsched
         pass
 
 from quickquip.adapters.nonebot import cron_status_sync
-from quickquip.adapters.nonebot._llm_reply import build_llm_reply_message
+from quickquip.adapters.nonebot._llm_reply import (
+    build_llm_reply_message,
+    make_group_bot_sink,
+    record_final_receipt,
+    reply_interval_ms,
+)
 from quickquip.adapters.nonebot._safe_send import send_group_text
 from quickquip.adapters.nonebot._scheduling import parse_cron
 from quickquip.chat.scheduled_messages import ScheduledMessage, ScheduledMessageStore
@@ -87,10 +92,19 @@ async def _fire_llm_task(bot, job: ScheduledMessage, group_id: str, job_id: str)
         logger.info("scheduled_msg: llm job %s skipped in group %s (group LLM disabled)", job.id, group_id)
         return
 
+    from quickquip.llm.agent_records import TriggerKind
+
+    delivery_sink = make_group_bot_sink(
+        bot, Message, MessageSegment,
+        group_id=group_id,
+        interval_ms=reply_interval_ms(svc),
+    )
     result = await svc.generate_reply(
         group_id=group_id,
         user_id="scheduled_timer",
         sender_name="定时任务",
+        delivery_sink=delivery_sink,
+        trigger_kind=TriggerKind.SCHEDULED_LLM,
         prompt=_build_llm_task_prompt(job),
         image_urls=[],
         include_recent_images=True,
@@ -103,6 +117,7 @@ async def _fire_llm_task(bot, job: ScheduledMessage, group_id: str, job_id: str)
     )
     reply_text = str(result.get("reply") or "").strip()
     if not reply_text:
+        # 逐 Turn 模式：正文已由 sink 交付，one-shot 语义至此完成。
         return
     message = build_llm_reply_message(result, Message, MessageSegment)
     with bot_action_trace(
@@ -115,7 +130,9 @@ async def _fire_llm_task(bot, job: ScheduledMessage, group_id: str, job_id: str)
         reply_preview=reply_text[:100],
         source="scheduler.scheduled_message",
     ):
-        await bot.send_group_msg(group_id=int(group_id), message=message)
+        resp = await bot.send_group_msg(group_id=int(group_id), message=message)
+    sent_msg_id = str(resp.get("message_id", "")) if isinstance(resp, dict) else ""
+    record_final_receipt(svc, result, sent_msg_id)
 
 
 async def _fire_text_task(bot, job: ScheduledMessage, group_id: str, job_id: str) -> None:

--- a/src/quickquip/adapters/nonebot/scheduler_plugin.py
+++ b/src/quickquip/adapters/nonebot/scheduler_plugin.py
@@ -116,8 +116,9 @@ async def _fire_llm_task(bot, job: ScheduledMessage, group_id: str, job_id: str)
         message_id=None,
     )
     reply_text = str(result.get("reply") or "").strip()
-    if not reply_text:
-        # 逐 Turn 模式：正文已由 sink 交付，one-shot 语义至此完成。
+    has_images = bool(result.get("images") or [])
+    if not reply_text and not has_images:
+        # 逐 Turn 模式：正文已由 sink 交付且无外发图，one-shot 至此完成。
         return
     message = build_llm_reply_message(result, Message, MessageSegment)
     with bot_action_trace(

--- a/src/quickquip/adapters/nonebot/web_admin_actions.py
+++ b/src/quickquip/adapters/nonebot/web_admin_actions.py
@@ -98,6 +98,26 @@ async def _execute_runtime_action(action: WebAdminAction) -> dict[str, Any]:
         deleted = svc.delete_message_from_context(scope_key, message_id)
         return {"deleted": deleted}
 
+    if action.action_type == "delete_conversation_row":
+        # Web 会话视图的行删除（§9.3）：assistant 主行 = 删除该 Turn 全部
+        # 正文范围与交付内容；user 触发行 = 整 Loop 删除。经 action queue
+        # 由 Bot 进程执行领域操作，禁止 Web 侧原始单表 DELETE。
+        scope_key = _validate_scope(action.payload.get("scope_key"))
+        row_id = int(action.payload.get("row_id") or 0)
+        if row_id <= 0:
+            raise ValueError("row_id is required")
+        row = svc.store.conversation_row_by_id(scope_key, row_id)
+        if row is None:
+            return {"deleted": False}
+        if row["role"] == "user":
+            deleted = svc.store.delete_loop_by_anchor(scope_key, row_id)
+        else:
+            deleted = svc.store.delete_turn_by_message_row(scope_key, row_id)
+        if deleted:
+            _, revision = svc.store.agent_scope_state(scope_key)
+            svc.store.mutate_history(scope_key, revision, "delete")
+        return {"deleted": bool(deleted)}
+
     raise ValueError(f"unknown runtime action: {action.action_type}")
 
 

--- a/src/quickquip/app/web/routes/conversations.py
+++ b/src/quickquip/app/web/routes/conversations.py
@@ -54,6 +54,12 @@ def list_conversations():
             ORDER BY latest DESC
             """
         ).fetchall()
+        loop_counts = {
+            stat["scope_key"]: int(stat["loop_count"])
+            for stat in conn.execute(
+                "SELECT scope_key, COUNT(*) AS loop_count FROM agent_loops GROUP BY scope_key"
+            )
+        }
     return {
         "conversations": [
             {
@@ -62,6 +68,7 @@ def list_conversations():
                 "count": int(row["count"]),
                 "latest": row["latest"],
                 "earliest": row["earliest"],
+                "loop_count": loop_counts.get(row["group_id"], 0),
             }
             for row in rows
         ]
@@ -115,6 +122,78 @@ def list_messages(
 
 class DeleteResult(BaseModel):
     deleted: int
+
+
+@router.get("/conversations/{group_key}/loops/{loop_id}")
+def loop_detail(group_key: str, loop_id: str):
+    """Loop 有界详情（§10）：按 Turn 展开正文、工具状态与 Chunk receipt。
+
+    thinking/native 默认只显示是否存在及省略原因，不暴露签名正文。
+    """
+    _validate_group_key(group_key)
+    with _connect() as conn:
+        loop = conn.execute(
+            "SELECT * FROM agent_loops WHERE scope_key = ? AND loop_id = ?",
+            (group_key, loop_id),
+        ).fetchone()
+        if loop is None:
+            raise HTTPException(status_code=404, detail="loop not found")
+        turns = conn.execute(
+            """
+            SELECT t.turn_id, t.turn_index, t.text_policy, t.output_status,
+                   t.finish_reason, t.committed_at, t.native_omission_reason,
+                   (t.native_state_json IS NOT NULL) AS has_native,
+                   m.content AS text
+            FROM agent_turns t
+            LEFT JOIN conversation_messages m ON m.id = t.message_row_id
+            WHERE t.loop_id = ?
+            ORDER BY t.turn_index ASC
+            """,
+            (loop_id,),
+        ).fetchall()
+        tools = conn.execute(
+            """
+            SELECT e.execution_id, e.turn_id, e.tool_name, e.status,
+                   e.result_omission_reason, e.arguments_omission_reason
+            FROM agent_tool_executions e
+            JOIN agent_turns t ON t.turn_id = e.turn_id
+            WHERE t.loop_id = ?
+            ORDER BY e.turn_id, e.call_index
+            """,
+            (loop_id,),
+        ).fetchall()
+        deliveries = conn.execute(
+            """
+            SELECT d.delivery_id, d.turn_id, d.kind, d.chunk_index, d.status,
+                   d.recall_status, d.source_start, d.source_end, d.notice_text
+            FROM agent_deliveries d
+            WHERE d.loop_id = ?
+            ORDER BY d.delivery_index ASC
+            """,
+            (loop_id,),
+        ).fetchall()
+    turn_index: dict[str, dict] = {row["turn_id"]: dict(row) for row in turns}
+    for tool in tools:
+        turn_index.setdefault(tool["turn_id"], {}).setdefault("tools", []).append(dict(tool))
+    for delivery in deliveries:
+        turn_index.setdefault(delivery["turn_id"], {}).setdefault("deliveries", []).append(dict(delivery))
+    ordered = sorted(turn_index.values(), key=lambda t: t.get("turn_index") or 0)
+    return {
+        "loop": {
+            "loop_id": loop["loop_id"],
+            "scope_key": loop["scope_key"],
+            "trigger_kind": loop["trigger_kind"],
+            "status": loop["status"],
+            "terminal_reason": loop["terminal_reason"],
+            "started_at": loop["started_at"],
+            "closed_at": loop["closed_at"],
+            "legacy": bool(loop["legacy"]),
+            "replay_revision": int(loop["replay_revision"]),
+        },
+        "turns": ordered,
+        "turn_count": len(turns),
+        "delivery_count": len(deliveries),
+    }
 
 
 @router.delete("/conversations/{group_key}/messages/{msg_id}")

--- a/src/quickquip/app/web/routes/conversations.py
+++ b/src/quickquip/app/web/routes/conversations.py
@@ -119,13 +119,22 @@ class DeleteResult(BaseModel):
 
 @router.delete("/conversations/{group_key}/messages/{msg_id}")
 def delete_message(group_key: str, msg_id: int):
+    """行删除走 action queue（§9.3/§10）：Bot 进程执行领域操作。
+
+    assistant 主行 = 删除该 Turn 全部正文范围与交付内容；user 触发行 =
+    整 Loop 删除。Web 侧不再直接执行原始单表 DELETE——侧表与主表必须
+    在同一领域事务内收敛。
+    """
     _validate_group_key(group_key)
-    with _connect() as conn:
-        cursor = conn.execute(
-            "DELETE FROM conversation_messages WHERE group_id = ? AND id = ?",
-            (group_key, msg_id),
-        )
-        if cursor.rowcount == 0:
-            raise HTTPException(status_code=404, detail="message not found")
-    logger.warning("conversation message deleted: group=%s id=%d", group_key, msg_id)
-    return {"ok": True}
+    if group_key.startswith("archive:"):
+        raise HTTPException(status_code=409, detail="archive scope deletions use the archive API")
+    from quickquip.app.web.action_queue import action_queue
+
+    queued = action_queue.enqueue(
+        "delete_conversation_row", {"scope_key": group_key, "row_id": msg_id}
+    )
+    logger.warning(
+        "conversation row deletion queued: group=%s id=%d action=%s",
+        group_key, msg_id, queued.get("id"),
+    )
+    return {"ok": True, "action_id": queued.get("id"), "status": "queued"}

--- a/src/quickquip/chat/awakening.py
+++ b/src/quickquip/chat/awakening.py
@@ -1124,15 +1124,18 @@ async def iter_boredom_send_plans(
     rule_switch: Any,
     svc: Any,
     rate_limiter: Any | None = None,
+    generate: Any | None = None,
 ) -> AsyncIterator[BoredomSendPlan]:
     """无聊唤醒巡检的策略与生成阶段：逐群产出待发送计划。
 
     纯领域流程，不触碰传输（``int(gid)`` 协议转换与消息拼装归适配层）。
-    单群 ``generate_reply`` 异常记 warning 后跳过，循环继续后续群。
+    ``generate`` 由适配层注入统一生成/交付流程（携带 DeliverySink）；
+    缺省回落 ``svc.generate_reply``。单群生成异常记 warning 后跳过。
     """
     cfg = get_config()
     st = get_state()
     st.prune_stale()
+    generate = generate or svc.generate_reply
 
     for gid in boredom_enabled_groups.all_groups():
         if not rule_switch.is_enabled(gid, _RULE_BOREDOM):
@@ -1148,7 +1151,7 @@ async def iter_boredom_send_plans(
         if rate_limiter is not None and not rate_limiter.allow(_RULE_BOREDOM, "boredom_timer", group_id=gid):
             continue
         try:
-            reply_result = await svc.generate_reply(
+            reply_result = await generate(
                 group_id=gid,
                 user_id="boredom_timer",
                 sender_name="系统",

--- a/src/quickquip/chat/awakening.py
+++ b/src/quickquip/chat/awakening.py
@@ -1179,7 +1179,10 @@ def confirm_boredom_sent(plan: BoredomSendPlan, stats_tracker: Any | None = None
     """
     st = get_state()
     st.mark_boredom_triggered(plan.group_id)
-    st.bot_messages.add(plan.group_id, plan.reply_result["reply"])
+    visible = str(plan.reply_result.get("reply") or "").strip() or str(
+        plan.reply_result.get("delivered_text") or ""
+    )
+    st.bot_messages.add(plan.group_id, visible)
     if stats_tracker is not None:
         stats_tracker.record_trigger(plan.group_id, _RULE_BOREDOM)
     logger.info("awakening_boredom: sent to group %s (%s)", plan.group_id, plan.trigger.trigger_reason)

--- a/src/quickquip/llm/agent_records.py
+++ b/src/quickquip/llm/agent_records.py
@@ -72,6 +72,18 @@ class DeliveryStatus(enum.StrEnum):
     UNKNOWN = "unknown"
     SKIPPED = "skipped"
     SUPPRESSED = "suppressed"
+    # 仅迁移可写（§4.3.5）：旧 assistant 行无 QQ ID 时标记"发送事实未保留"，
+    # 不推断从未发送；运行期禁止产生该值。
+    LEGACY_UNTRACKED = "legacy_untracked"
+
+
+class ToolSkipReason(enum.StrEnum):
+    """not_executed 终态的有限原因（§5.3/§5.4/§5.5）。"""
+
+    ROUND_LIMIT = "limit"
+    BATCH_LIMIT = "batch_limit"
+    BLOCKED = "blocked"
+    RECOVERY = "recovery"
 
 
 class RecallStatus(enum.StrEnum):

--- a/src/quickquip/llm/agent_records.py
+++ b/src/quickquip/llm/agent_records.py
@@ -1,0 +1,249 @@
+"""Agent Loop 执行记录契约：身份、状态枚举、不可变 DTO 与版本化 JSON 结构。
+
+三视图契约（§3.2）：执行记录保存已提交的生成与工具事实；重放投影保存
+目标协议可用的表达；交付记录保存已计划与已尝试发送的内容。本模块只定义
+数据与有限枚举，不做 I/O——持久化归 ``store_parts/agent_records.py``，
+投影归 ``history_projection.py``，切分与交付状态机归 ``delivery.py``，
+scope 调度归 ``service_parts/agent_runtime.py``。
+
+所有枚举值即 SQLite 落库字符串；解析器必须拒绝未知值（§4.4），新增值
+只能在版本化结构升级时引入并保持旧值可读。
+"""
+from __future__ import annotations
+
+import enum
+import secrets
+from dataclasses import dataclass, field
+from typing import Any
+
+# 全部 agent JSON 载荷（parts/native/result/wrappers/owner）顶层 version。
+AGENT_RECORD_VERSION = 1
+
+# 单条持久化上限（§2 工程默认值；字节口径 = UTF-8）。
+MAX_PERSISTED_TOOL_RESULT_BYTES = 32_768
+MAX_PERSISTED_TOOL_ARGUMENT_BYTES = 32_768
+MAX_NATIVE_STATE_BYTES = 262_144
+MAX_LOOP_RECORD_BYTES = 8_388_608
+
+
+def new_agent_id(prefix: str) -> str:
+    """稳定随机 ID：前缀 + 24 hex（96 bit 熵），跨表可读可关联。"""
+    return f"{prefix}_{secrets.token_hex(12)}"
+
+
+class LoopStatus(enum.StrEnum):
+    RUNNING = "running"
+    COMPLETED = "completed"
+    INTERRUPTED = "interrupted"
+    FAILED = "failed"
+    LEGACY = "legacy"
+
+
+class TriggerKind(enum.StrEnum):
+    GROUP_DIRECT = "group_direct"
+    GROUP_PASSIVE = "group_passive"
+    PRIVATE_DIRECT = "private_direct"
+    SCHEDULED_LLM = "scheduled_llm"
+    BOREDOM = "boredom"
+    LEGACY = "legacy"
+    LEGACY_ORPHAN = "legacy_orphan"
+
+
+class ToolExecutionStatus(enum.StrEnum):
+    DECLARED = "declared"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    INDETERMINATE = "indeterminate"
+    NOT_EXECUTED = "not_executed"
+
+
+class DeliveryKind(enum.StrEnum):
+    TEXT_CHUNK = "text_chunk"
+    TOOL_MEDIA = "tool_media"
+    HOST_NOTICE = "host_notice"
+
+
+class DeliveryStatus(enum.StrEnum):
+    PLANNED = "planned"
+    SENDING = "sending"
+    SENT = "sent"
+    FAILED = "failed"
+    UNKNOWN = "unknown"
+    SKIPPED = "skipped"
+    SUPPRESSED = "suppressed"
+
+
+class RecallStatus(enum.StrEnum):
+    ACTIVE = "active"
+    RECALLED = "recalled"
+
+
+class DeliveryPolicy(enum.StrEnum):
+    ALL_TURNS = "all_turns"
+    FINAL_ONLY = "final_only"
+
+
+class TextPolicy(enum.StrEnum):
+    ALLOWED = "allowed"
+    REPLACED_BY_FILTER = "replaced_by_filter"
+    REDACTED = "redacted"
+
+
+class TurnOutputStatus(enum.StrEnum):
+    """Turn 普通正文的展示形态（§5.4）。"""
+
+    VISIBLE = "visible"
+    EMPTY = "empty"
+    NO_VISIBLE_OUTPUT = "no_visible_output"
+
+
+class ResultRetention(enum.StrEnum):
+    """工具结果保留政策（§8.4）：ephemeral 结果正文禁止进入业务持久层。"""
+
+    EPHEMERAL = "ephemeral"
+    BOUNDED = "bounded"
+
+
+class ResultOmissionReason(enum.StrEnum):
+    SIZE_LIMIT = "size_limit"
+    EPHEMERAL_POLICY = "ephemeral_policy"
+    LOOP_BUDGET = "loop_budget"
+    RECALL_CLEANUP = "recall_cleanup"
+
+
+class ArgumentsOmissionReason(enum.StrEnum):
+    SIZE_LIMIT = "size_limit"
+
+
+class NativeOmissionReason(enum.StrEnum):
+    SIZE_LIMIT = "size_limit"
+    SENSITIVE_BLOCK = "sensitive_block"
+    RECALL_CLEANUP = "recall_cleanup"
+    UNSUPPORTED_STRUCTURE = "unsupported_structure"
+
+
+class RecallCleanupState(enum.StrEnum):
+    """撤回清理后该 Loop 的投影形态（§9.2：固定为通用档案）。"""
+
+    CLEANED = "cleaned"
+
+
+@dataclass(frozen=True, slots=True)
+class ResponseOwner:
+    """一次成功 provider 请求的实际归属（§7.1）。
+
+    endpoint/profile 指纹为不可逆散列；API key、Authorization 与原始
+    headers 不入库、不入日志。``display_model`` 是请求展示 model，
+    ``wire_model`` 是 alias/extra_body 解析后的实际 wire model。
+    """
+
+    provider_id: str
+    protocol: str
+    wire_model: str
+    display_model: str
+    endpoint_fingerprint: str
+    profile_fingerprint: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class ToolDeclarationRecord:
+    """commit_turn 时声明的工具调用（§3.1 tool_execution_id 的来源）。"""
+
+    execution_id: str
+    call_index: int
+    provider_call_id: str
+    tool_name: str
+    arguments_json: str | None
+    arguments_omission_reason: ArgumentsOmissionReason | None
+
+
+@dataclass(frozen=True, slots=True)
+class ToolResultRecord:
+    """finish_tool 的结果载荷（§4.4 result_json 契约）。"""
+
+    content: str
+    is_error: bool
+    original_bytes: int
+    retained_ranges: list[tuple[int, int]] = field(default_factory=list)
+    media_descriptions: list[str] = field(default_factory=list)
+    status: ToolExecutionStatus = ToolExecutionStatus.SUCCEEDED
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkPlan:
+    """一个文字 Chunk 的冻结源范围（§3.3：[start,end) 对应已存正文）。"""
+
+    chunk_index: int
+    source_start: int
+    source_end: int
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryPlanItem:
+    """commit_turn 事务内写入的交付计划条目（§4.2 delivery_plan）。"""
+
+    delivery_id: str
+    kind: DeliveryKind
+    turn_id: str | None = None
+    tool_execution_id: str | None = None
+    chunk_index: int | None = None
+    source_start: int | None = None
+    source_end: int | None = None
+    wrappers: tuple[str, str] = ("", "")
+    attachment_refs: tuple[tuple[str, int], ...] = ()
+    notice_text: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TurnResponseRecord:
+    """commit_turn 的模型响应输入（§5.3 步骤 4-5：已过滤、已冻结）。"""
+
+    text: str
+    text_policy: TextPolicy
+    output_status: TurnOutputStatus
+    finish_reason: str | None
+    parts: tuple[dict[str, Any], ...] = ()
+    native_state: dict[str, Any] | None = None
+    native_omission_reason: NativeOmissionReason | None = None
+    owner: ResponseOwner | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DeliveryReceipt:
+    """一次交付尝试的回执（§6.2：仅可信成功回执归 sent）。"""
+
+    status: DeliveryStatus
+    message_id: str | None = None
+    error_code: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class DeliverySummary:
+    """Loop 关闭时的交付归纳（§5.1 AgentLoopResult.delivery_summary）。"""
+
+    total: int = 0
+    sent: int = 0
+    failed: int = 0
+    unknown: int = 0
+    skipped: int = 0
+    suppressed: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class AgentLoopResult:
+    """生成入口的统一返回（§5.1）。已发送内容不再作为 reply 二次发送。"""
+
+    loop_id: str
+    status: LoopStatus
+    delivery_summary: DeliverySummary
+    rule_name: str
+    rate_limit_key: str
+    provider_id: str
+    model: str
+    terminal_reason: str | None = None
+    # final_only 模式下仍由适配层单次发送的最终正文；空 = 全部经 sink 交付。
+    final_text: str = ""
+    # 关闭开关时随最终文字交付的工具图片（base64 列表，§6.3）。
+    final_images: tuple[str, ...] = ()

--- a/src/quickquip/llm/config.py
+++ b/src/quickquip/llm/config.py
@@ -786,6 +786,14 @@ def load_llm_config(path: str | Path) -> LLMConfig:
             '如需精确白名单请显式设置 enabled_mode = "replace"'
         )
 
+    if (
+        int(runtime_raw.get("reply_split_threshold_chars", 800))
+        > int(runtime_raw.get("reply_chunk_max_chars", 1200))
+    ):
+        return LLMConfig(
+            load_error="reply_split_threshold_chars 不能超过 reply_chunk_max_chars",
+            source_path=config_path,
+        )
     config = LLMConfig(
         runtime=RuntimeConfig(
             enabled=as_bool(runtime_raw.get("enabled", False), default=False),

--- a/src/quickquip/llm/config.py
+++ b/src/quickquip/llm/config.py
@@ -82,6 +82,13 @@ class RuntimeConfig:
     agent_record_retention_days: int = 30
     agent_record_max_loops_per_scope: int = 1000
     agent_record_max_bytes_per_scope: int = 67_108_864
+    # 逐 Turn 交付上线开关（§6.3）：默认关闭——安装新版本不立刻增加群内
+    # 消息数；记录与投影始终工作。
+    agent_delivery_enabled: bool = False
+    reply_split_threshold_chars: int = 800
+    reply_chunk_max_chars: int = 1200
+    reply_send_interval_ms: int = 800
+    reply_max_chunks_per_loop: int = 64
 
 
 @dataclass(slots=True)
@@ -814,6 +821,21 @@ def load_llm_config(path: str | Path) -> LLMConfig:
             ),
             agent_record_max_bytes_per_scope=max(
                 1024, int(runtime_raw.get("agent_record_max_bytes_per_scope", 67_108_864))
+            ),
+            agent_delivery_enabled=as_bool(
+                runtime_raw.get("agent_delivery_enabled"), default=False
+            ),
+            reply_split_threshold_chars=max(
+                1, int(runtime_raw.get("reply_split_threshold_chars", 800))
+            ),
+            reply_chunk_max_chars=max(
+                1, int(runtime_raw.get("reply_chunk_max_chars", 1200))
+            ),
+            reply_send_interval_ms=min(
+                10_000, max(0, int(runtime_raw.get("reply_send_interval_ms", 800)))
+            ),
+            reply_max_chunks_per_loop=min(
+                256, max(1, int(runtime_raw.get("reply_max_chunks_per_loop", 64)))
             ),
             recent_context_token_budget=recent_context_token_budget,
             recent_context_floor_seconds=recent_context_floor_seconds,

--- a/src/quickquip/llm/config.py
+++ b/src/quickquip/llm/config.py
@@ -85,6 +85,8 @@ class RuntimeConfig:
     # 逐 Turn 交付上线开关（§6.3）：默认关闭——安装新版本不立刻增加群内
     # 消息数；记录与投影始终工作。
     agent_delivery_enabled: bool = False
+    # 每个历史 Loop 的投影预算（§2：512..65536；可被更小的显式上下文预算收紧）。
+    agent_replay_loop_tokens: int = 4096
     reply_split_threshold_chars: int = 800
     reply_chunk_max_chars: int = 1200
     reply_send_interval_ms: int = 800
@@ -824,6 +826,9 @@ def load_llm_config(path: str | Path) -> LLMConfig:
             ),
             agent_delivery_enabled=as_bool(
                 runtime_raw.get("agent_delivery_enabled"), default=False
+            ),
+            agent_replay_loop_tokens=min(
+                65_536, max(512, int(runtime_raw.get("agent_replay_loop_tokens", 4096)))
             ),
             reply_split_threshold_chars=max(
                 1, int(runtime_raw.get("reply_split_threshold_chars", 800))

--- a/src/quickquip/llm/config.py
+++ b/src/quickquip/llm/config.py
@@ -74,6 +74,14 @@ class RuntimeConfig:
     # ── 【现场】补丁（近期消息缓冲的 LLM 服役口径；仅全局，无 provider 覆盖） ──
     recent_context_token_budget: int = 800
     recent_context_floor_seconds: int = 300
+    # 应用侧输入预算（§8.3）：所有 provider 的缺省，可被 provider 覆盖。
+    # 不能从 epoch cap 推导实际模型上下文大小；未配置模型容量时文档与
+    # 日志按 capacity unknown 处理。
+    request_input_token_budget: int = 96_000
+    # D5 关闭 Loop 保留三上限（§2）：先触顶者触发整 Loop 清理。
+    agent_record_retention_days: int = 30
+    agent_record_max_loops_per_scope: int = 1000
+    agent_record_max_bytes_per_scope: int = 67_108_864
 
 
 @dataclass(slots=True)
@@ -184,6 +192,11 @@ class ProviderConfig:
     epoch_cold_trigger_tokens: int | None = None
     epoch_hot_target_tokens: int | None = None
     epoch_cap_tokens: int | None = None
+    # 应用侧输入预算（§8.3）：provider 覆盖 None = 继承 runtime 缺省。
+    request_input_token_budget: int | None = None
+    # wire model -> token 容量；只能来自维护者配置或可信已核实资料，
+    # 不从模型名称猜测。未配置的模型按 capacity unknown 处理。
+    model_context_windows: dict[str, int] = field(default_factory=dict)
 
 
 def provider_builtin_search_active(provider: ProviderConfig) -> bool:
@@ -538,6 +551,11 @@ def _parse_single_provider(
         epoch_cold_trigger_tokens=_as_optional_int(entry.get("epoch_cold_trigger_tokens")),
         epoch_hot_target_tokens=_as_optional_int(entry.get("epoch_hot_target_tokens")),
         epoch_cap_tokens=_as_optional_int(entry.get("epoch_cap_tokens")),
+        request_input_token_budget=_as_optional_int(entry.get("request_input_token_budget")),
+        model_context_windows={
+            str(name): max(1024, int(size))
+            for name, size in as_dict(entry.get("model_context_windows")).items()
+        },
     )
 
 
@@ -785,6 +803,18 @@ def load_llm_config(path: str | Path) -> LLMConfig:
             epoch_cold_trigger_tokens=int(runtime_raw.get("epoch_cold_trigger_tokens", 5000)),
             epoch_hot_target_tokens=int(runtime_raw.get("epoch_hot_target_tokens", 32000)),
             epoch_cap_tokens=int(runtime_raw.get("epoch_cap_tokens", 64000)),
+            request_input_token_budget=max(
+                1024, int(runtime_raw.get("request_input_token_budget", 96_000))
+            ),
+            agent_record_retention_days=max(
+                1, int(runtime_raw.get("agent_record_retention_days", 30))
+            ),
+            agent_record_max_loops_per_scope=max(
+                1, int(runtime_raw.get("agent_record_max_loops_per_scope", 1000))
+            ),
+            agent_record_max_bytes_per_scope=max(
+                1024, int(runtime_raw.get("agent_record_max_bytes_per_scope", 67_108_864))
+            ),
             recent_context_token_budget=recent_context_token_budget,
             recent_context_floor_seconds=recent_context_floor_seconds,
         ),

--- a/src/quickquip/llm/delivery.py
+++ b/src/quickquip/llm/delivery.py
@@ -10,6 +10,7 @@ wrappers 只属于显示（超长代码块的闭合/重开围栏），不进入�
 from __future__ import annotations
 
 import re
+import unicodedata
 from dataclasses import dataclass
 
 # 切分算法版本（§6.1：版本固定；变更即行为变更，需评审）。
@@ -17,6 +18,14 @@ SPLIT_ALGORITHM_VERSION = 1
 
 # 句末标点边界（。！？.!? 后）。
 _SENTENCE_BOUNDARY = re.compile(r"(?<=[。！？.!?])\s*")
+
+
+class SplitLimitError(ValueError):
+    """单个 grapheme 超过单 Chunk 上限（§6.1.5）：拒绝该交付计划并明确终止。"""
+
+
+def _is_combining(index: int, text: str) -> bool:
+    return index < len(text) and unicodedata.combining(text[index]) != 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,6 +101,14 @@ def _split_long_segment(text: str, start: int, end: int, chunk_max: int) -> list
             candidates.append(space + 1)
         positive = [c for c in candidates if 0 < c <= chunk_max]
         cut = cursor + (max(positive) if positive else chunk_max)
+        # 硬切尽量避开 grapheme cluster（§6.1.5）：组合标记不作为新 Chunk 的
+        # 开头；调整后超出 max 说明单个 grapheme 本身超限，明确拒绝。
+        while _is_combining(cut, text) and cut < end:
+            cut += 1
+        if cut - cursor > chunk_max:
+            raise SplitLimitError(
+                f"单个 grapheme 超过单 Chunk 上限（{chunk_max} code point），拒绝该交付计划"
+            )
         segments.append((cursor, cut))
         cursor = cut
     if end > cursor:
@@ -156,9 +173,8 @@ def plan_text_chunks(
     if available <= 0:
         return [], "delivery_limit"
     # 收缩重切：把整段按可用条数均分上限收紧到 max。
-    tight = SplitParams(threshold=params.threshold, chunk_max=max(
-        params.chunk_max // available, 1
-    ))
+    tight_max = max(params.chunk_max // available, 1)
+    tight = SplitParams(threshold=min(params.threshold, tight_max), chunk_max=tight_max)
     try:
         squeezed = split_text_into_chunks(text, tight)
     except RuntimeError:

--- a/src/quickquip/llm/delivery.py
+++ b/src/quickquip/llm/delivery.py
@@ -1,0 +1,171 @@
+"""文本切分与交付计划（§6）：纯计算、版本固定。
+
+对整个 Turn 完成敏感扫描与清理后冻结的字符串 ``S`` 做确定性切分：
+同输入同输出；源范围连续、无重叠、无遗漏，满足
+``''.join(S[a:b] for a, b in ranges) == S``。参数只影响新建计划；重试、
+重放与撤回使用已存范围。
+
+wrappers 只属于显示（超长代码块的闭合/重开围栏），不进入模型正文。
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# 切分算法版本（§6.1：版本固定；变更即行为变更，需评审）。
+SPLIT_ALGORITHM_VERSION = 1
+
+# 句末标点边界（。！？.!? 后）。
+_SENTENCE_BOUNDARY = re.compile(r"(?<=[。！？.!?])\s*")
+
+
+@dataclass(frozen=True, slots=True)
+class SplitParams:
+    threshold: int  # 超过才自然分段
+    chunk_max: int  # 单 Chunk 源文本上限
+
+    def validate(self) -> None:
+        if self.threshold <= 0 or self.chunk_max <= 0:
+            raise ValueError("切分参数必须为正数")
+        if self.threshold > self.chunk_max:
+            raise ValueError("split_threshold 不能超过 chunk_max")
+
+
+@dataclass(frozen=True, slots=True)
+class ChunkRange:
+    chunk_index: int
+    start: int
+    end: int
+    prefix: str = ""
+    suffix: str = ""
+
+
+def _blank_line_boundaries(text: str) -> list[int]:
+    """空白行边界位置（切在 ``\n\n`` 的两个换行之间，分隔换行归前段）。"""
+    positions: list[int] = []
+    index = 0
+    while index < len(text):
+        if text[index] == "\n":
+            end = index
+            while end < len(text) and text[end] == "\n":
+                end += 1
+            if end - index >= 2:
+                positions.append(end)
+            index = end
+        else:
+            index += 1
+    return positions
+
+
+def _merge_short_segments(
+    text: str, segments: list[tuple[int, int]], threshold: int
+) -> list[tuple[int, int]]:
+    """连续短段按源顺序合并：选择不超过 threshold 的最后一个自然边界。"""
+    merged: list[tuple[int, int]] = []
+    for start, end in segments:
+        if merged:
+            prev_start, prev_end = merged[-1]
+            if end - prev_start <= threshold:
+                merged[-1] = (prev_start, end)
+                continue
+        merged.append((start, end))
+    return merged
+
+
+def _split_long_segment(text: str, start: int, end: int, chunk_max: int) -> list[tuple[int, int]]:
+    """超 max 段落：换行 → 句末标点 → 空白的优先级找不超过 max 的最后边界。"""
+    segments: list[tuple[int, int]] = []
+    cursor = start
+    while end - cursor > chunk_max:
+        window = text[cursor : cursor + chunk_max]
+        candidates: list[int] = []
+        newline = window.rfind("\n")
+        if newline >= 0:
+            candidates.append(newline + 1)
+        sentence_matches = list(_SENTENCE_BOUNDARY.finditer(window))
+        if sentence_matches:
+            boundary = sentence_matches[-1].end()
+            if boundary > 0:
+                candidates.append(boundary)
+        space = max(window.rfind(" "), window.rfind("　"))
+        if space >= 0:
+            candidates.append(space + 1)
+        positive = [c for c in candidates if 0 < c <= chunk_max]
+        cut = cursor + (max(positive) if positive else chunk_max)
+        segments.append((cursor, cut))
+        cursor = cut
+    if end > cursor:
+        segments.append((cursor, end))
+    return segments
+
+
+def split_text_into_chunks(text: str, params: SplitParams) -> list[ChunkRange]:
+    """确定性切分（§6.1）。空串返回空列表；还原恒等式必须成立。"""
+    params.validate()
+    if not text:
+        return []
+    if len(text) <= params.threshold and len(text) <= params.chunk_max:
+        return [ChunkRange(chunk_index=0, start=0, end=len(text))]
+
+    boundaries = _blank_line_boundaries(text)
+    segments: list[tuple[int, int]] = []
+    cursor = 0
+    for boundary in boundaries:
+        if boundary > cursor:
+            segments.append((cursor, boundary))
+            cursor = boundary
+    if cursor < len(text):
+        segments.append((cursor, len(text)))
+
+    merged = _merge_short_segments(text, segments, params.threshold)
+
+    final: list[tuple[int, int]] = []
+    for start, end in merged:
+        if end - start > params.chunk_max:
+            final.extend(_split_long_segment(text, start, end, params.chunk_max))
+        else:
+            final.append((start, end))
+
+    chunks = [
+        ChunkRange(chunk_index=index, start=start, end=end)
+        for index, (start, end) in enumerate(final)
+    ]
+    # 还原恒等式（§6.1.4）：任何输出都必须满足。
+    reconstructed = "".join(text[c.start : c.end] for c in chunks)
+    if reconstructed != text:
+        raise RuntimeError("切分算法破坏源范围还原恒等式")
+    return chunks
+
+
+def plan_text_chunks(
+    text: str,
+    params: SplitParams,
+    *,
+    reserved_delivery_slots: int = 0,
+    max_chunks: int = 64,
+) -> tuple[list[ChunkRange], str | None]:
+    """整个 Turn 先规划，预检剩余 Loop 交付条数（§6.1 尾段）。
+
+    自然分段超过可用条数时合并未提交短段到 max；仍超出返回
+    ``delivery_limit`` 原因（保存完整正文，不静默截尾）。
+    """
+    chunks = split_text_into_chunks(text, params)
+    available = max_chunks - reserved_delivery_slots
+    if len(chunks) <= available:
+        return chunks, None
+    if available <= 0:
+        return [], "delivery_limit"
+    # 收缩重切：把整段按可用条数均分上限收紧到 max。
+    tight = SplitParams(threshold=params.threshold, chunk_max=max(
+        params.chunk_max // available, 1
+    ))
+    try:
+        squeezed = split_text_into_chunks(text, tight)
+    except RuntimeError:
+        return [], "delivery_limit"
+    if len(squeezed) <= available:
+        return [
+            ChunkRange(chunk_index=index, start=c.start, end=c.end)
+            for index, c in enumerate(squeezed)
+        ], None
+    return [], "delivery_limit"

--- a/src/quickquip/llm/delivery.py
+++ b/src/quickquip/llm/delivery.py
@@ -172,12 +172,13 @@ def plan_text_chunks(
         return chunks, None
     if available <= 0:
         return [], "delivery_limit"
-    # 收缩重切：把整段按可用条数均分上限收紧到 max。
-    tight_max = max(params.chunk_max // available, 1)
-    tight = SplitParams(threshold=min(params.threshold, tight_max), chunk_max=tight_max)
+    # 收缩重切（§6.1 尾段）：把未提交的短段合并到 max——阈值抬到上限
+    # 才能最大化合并（参数变小只会产生更多分段）；最小分段数为
+    # ceil(len/chunk_max)，仍超出可用条数才整体拒付。
+    tight = SplitParams(threshold=params.chunk_max, chunk_max=params.chunk_max)
     try:
         squeezed = split_text_into_chunks(text, tight)
-    except RuntimeError:
+    except (RuntimeError, ValueError):
         return [], "delivery_limit"
     if len(squeezed) <= available:
         return [

--- a/src/quickquip/llm/history_projection.py
+++ b/src/quickquip/llm/history_projection.py
@@ -130,14 +130,23 @@ def _native_blocks_valid(protocol: str, blocks: Sequence[dict[str, Any]]) -> boo
 
 
 def _validate_tool_pairing(turn: LoadedTurn) -> None:
-    """配对校验（§7.4）：声明与结果必须成对，损坏在投影期失败。"""
+    """配对校验（§7.4）：声明与结果必须成对，损坏在投影期失败。
+
+    合法清理态豁免：撤回/删除/政策省略会把 ``result_json`` 置空但保留
+    终态与 ``result_omission_reason``（§9.2/§8.4）——这不是结构损坏，
+    由 ``missing_result_explanation`` 生成确定说明参与重放。
+    """
     for execution in turn.tools:
         terminal = execution.status in {"succeeded", "failed", "indeterminate", "not_executed"}
         if not terminal:
             raise HistoryProjectionError(
                 f"turn={turn.turn_id} execution={execution.execution_id} 无终态（{execution.status}）"
             )
-        if execution.status in {"succeeded", "failed"} and execution.result is None:
+        if (
+            execution.status in {"succeeded", "failed"}
+            and execution.result is None
+            and not execution.result_omission_reason
+        ):
             raise HistoryProjectionError(
                 f"turn={turn.turn_id} execution={execution.execution_id} 终态无结果记录"
             )
@@ -333,8 +342,12 @@ def project_loops(
             loop_messages = _project_loop_native(loop)
         elif path == PATH_STRUCTURED:
             loop_messages = [_user_trigger_message(loop)]
+            # 与 _decide_loop_path 同谓词：只对"有原生块"的 Turn 要求 owner
+            # 匹配（owner 缺失视为不匹配），杜绝未验证目标的签名块回放。
             owner_match = target is not None and all(
-                owner_matches(turn.owner, target) for turn in loop.turns if turn.owner
+                owner_matches(turn.owner, target)
+                for turn in loop.turns
+                if _turn_native_blocks(turn) is not None
             )
             for turn in loop.turns:
                 loop_messages.extend(_project_turn_structured(turn, loop.loop_id, native_owner_match=owner_match))
@@ -467,10 +480,11 @@ def project_loops_with_budget(
         )
 
     def _mark(loop_id: str, level: str) -> None:
+        original = decisions[loop_id].reason
+        # 叠加而非覆盖：保留路径决策的原始降级原因（§7.2 可观测性）。
+        reason = f"reduced:{level}" if original is None else f"{original}+reduced:{level}"
         decisions[loop_id] = LoopProjectionDecision(
-            loop_id=loop_id,
-            path=decisions[loop_id].path,
-            reason=f"reduced:{level}",
+            loop_id=loop_id, path=decisions[loop_id].path, reason=reason,
         )
 
     loops_by_id = {loop.loop_id: loop for loop in loops}
@@ -482,9 +496,8 @@ def project_loops_with_budget(
         if decisions[loop_id].path == PATH_NATIVE:
             demoted = project_loops([loop], target=None, protocol=protocol)
             segments[loop_id] = demoted.segments[loop_id]
-            decisions[loop_id] = demoted.decisions[0]
             _mark(loop_id, "native_dropped")
-            if _estimate_messages_tokens(segments[loop_id]) + _total() - _estimate_messages_tokens(segments[loop_id]) <= budget_tokens:
+            if _total() <= budget_tokens:
                 continue
         # 阶梯 2：工具结果逐档收紧。
         for tier in _RESULT_TIERS:

--- a/src/quickquip/llm/history_projection.py
+++ b/src/quickquip/llm/history_projection.py
@@ -344,3 +344,193 @@ def project_loops(
         segments[loop.loop_id] = loop_messages
         decisions.append(LoopProjectionDecision(loop_id=loop.loop_id, path=path, reason=reason))
     return ProjectionResult(messages=messages, decisions=tuple(decisions), segments=segments)
+
+
+# ── 确定性精简阶梯（§8.2） ─────────────────────────────────────────
+
+# 工具结果收紧阶梯（字符）。
+_RESULT_TIERS = (4096, 1024, 256, 0)
+
+
+def _estimate_messages_tokens(messages: list[LLMConversationMessage]) -> int:
+    from quickquip.llm.token_estimate import estimate_tokens
+
+    total = 0
+    for message in messages:
+        total += estimate_tokens(message.content)
+        for call in message.tool_calls:
+            total += estimate_tokens(call.arguments_json)
+    return total
+
+
+def _tighten_tool_results(
+    messages: list[LLMConversationMessage], tier_chars: int
+) -> list[LLMConversationMessage]:
+    tightened: list[LLMConversationMessage] = []
+    for message in messages:
+        if message.role == "tool" and len(message.content) > tier_chars:
+            half = tier_chars // 2
+            omitted = len(message.content) - 2 * half
+            content = (
+                message.content[:half] + f"…[省略 {omitted} 字符]…" + message.content[-half:]
+                if half
+                else "…[工具结果正文按预算未保留]…"
+            )
+            tightened.append(
+                LLMConversationMessage(
+                    role="tool", content=content,
+                    tool_call_id=message.tool_call_id, tool_name=message.tool_name,
+                    is_tool_error=message.is_tool_error,
+                )
+            )
+        else:
+            tightened.append(message)
+    return tightened
+
+
+def _project_loop_archive_bounded(
+    loop: LoadedLoop, char_budget: int | None
+) -> list[LLMConversationMessage]:
+    """档案投影的可选字符额度（§8.2.4：统一额度减半，首尾摘录冻结）。"""
+    if char_budget is None:
+        return _project_loop_archive(loop)
+
+    def _excerpt(text: str, budget: int) -> str:
+        if len(text) <= budget:
+            return text
+        half = max(1, budget // 2)
+        omitted = len(text) - 2 * half
+        return text[:half] + f"…[省略 {omitted} 字符]…" + text[-half:]
+
+    trigger = str(loop.user_row.get("content") or "") if loop.user_row else _ORPHAN_TRIGGER_NOTE
+    per_turn = max(64, char_budget // (len(loop.turns) + 1))
+    lines = [f"{_ARCHIVE_TAG} 以下为归档的历史会话记录（字符额度 {char_budget}）。"]
+    lines.append(f"用户：{_excerpt(trigger, per_turn)}")
+    for turn in loop.turns:
+        body = _excerpt(turn.text.strip(), per_turn) if turn.text.strip() else "（无普通正文）"
+        lines.append(f"Turn {turn.turn_index}：{body}")
+        if turn.tools:
+            counts: dict[str, int] = {}
+            for execution in turn.tools:
+                counts[execution.status] = counts.get(execution.status, 0) + 1
+            summary = "、".join(f"{name}×{count}" for name, count in counts.items())
+            lines.append(f"（Turn {turn.turn_index} 工具：{summary}，正文未保留）")
+    return [
+        LLMConversationMessage(role="user", content=trigger if char_budget >= len(trigger) else _excerpt(trigger, per_turn)),
+        LLMConversationMessage(role="assistant", content="\n".join(lines)),
+    ]
+
+
+def _project_loop_minimal(loop: LoadedLoop) -> list[LLMConversationMessage]:
+    """最小档案（§8.2.5）：Loop 身份、时间、触发类型、Turn 数、工具状态汇总。"""
+    counts: dict[str, int] = {}
+    for turn in loop.turns:
+        for execution in turn.tools:
+            counts[execution.status] = counts.get(execution.status, 0) + 1
+    summary = "、".join(f"{name}×{count}" for name, count in counts.items()) or "无工具"
+    text = (
+        f"{_ARCHIVE_TAG} 历史 Loop 摘要：时间 {loop.started_at[:19]}，触发 {loop.trigger_kind}，"
+        f"{len(loop.turns)} 个 Turn，工具 {summary}；正文因重放预算未保留。"
+    )
+    return [
+        LLMConversationMessage(role="user", content="[系统说明] 该段历史已按预算精简。"),
+        LLMConversationMessage(role="assistant", content=text),
+    ]
+
+
+def project_loops_with_budget(
+    loops: Sequence[LoadedLoop],
+    *,
+    target: ResponseOwner | None,
+    protocol: str,
+    budget_tokens: int,
+) -> ProjectionResult:
+    """带 §8.2 精简阶梯的投影：超预算时按固定顺序精简最旧 Loop。
+
+    阶梯：工具结果按 4096/1024/256/0 收紧 → 纯文本档案 → 档案字符额度
+    减半 → 最小档案 → 逐出最旧完整 Loop。所有精简只影响模型投影，完整
+    记录留在执行表；禁止空循环重试。
+    """
+    result = project_loops(loops, target=target, protocol=protocol)
+    if _estimate_messages_tokens(result.messages) <= budget_tokens or not loops:
+        return result
+
+    segments = {key: list(value) for key, value in result.segments.items()}
+    decisions = {d.loop_id: d for d in result.decisions}
+    order = [loop.loop_id for loop in loops]
+
+    def _total() -> int:
+        return sum(
+            _estimate_messages_tokens(segments[key])
+            for key in order
+            if key in segments
+        )
+
+    def _mark(loop_id: str, level: str) -> None:
+        decisions[loop_id] = LoopProjectionDecision(
+            loop_id=loop_id,
+            path=decisions[loop_id].path,
+            reason=f"reduced:{level}",
+        )
+
+    loops_by_id = {loop.loop_id: loop for loop in loops}
+    for loop_id in order:
+        if _total() <= budget_tokens:
+            break
+        loop = loops_by_id[loop_id]
+        # 阶梯 1：丢弃可选 native（重投影为无 target 的通用/档案形态）。
+        if decisions[loop_id].path == PATH_NATIVE:
+            demoted = project_loops([loop], target=None, protocol=protocol)
+            segments[loop_id] = demoted.segments[loop_id]
+            decisions[loop_id] = demoted.decisions[0]
+            _mark(loop_id, "native_dropped")
+            if _estimate_messages_tokens(segments[loop_id]) + _total() - _estimate_messages_tokens(segments[loop_id]) <= budget_tokens:
+                continue
+        # 阶梯 2：工具结果逐档收紧。
+        for tier in _RESULT_TIERS:
+            if _total() <= budget_tokens:
+                break
+            tightened = _tighten_tool_results(segments[loop_id], tier)
+            if tightened == segments[loop_id]:
+                continue
+            segments[loop_id] = tightened
+            _mark(loop_id, f"result_tier_{tier}")
+        if _total() <= budget_tokens:
+            break
+        # 阶梯 3：纯文本档案。
+        segments[loop_id] = _project_loop_archive(loop)
+        _mark(loop_id, "text_archive")
+        if _total() <= budget_tokens:
+            continue
+        # 阶梯 4：档案字符额度减半（按当前投影 token 的一半折算字符）。
+        half_chars = max(128, _estimate_messages_tokens(segments[loop_id]) // 2)
+        segments[loop_id] = _project_loop_archive_bounded(loop, half_chars)
+        _mark(loop_id, "archive_halved")
+        if _total() <= budget_tokens:
+            continue
+        # 阶梯 5：最小档案。
+        segments[loop_id] = _project_loop_minimal(loop)
+        _mark(loop_id, "minimal_archive")
+
+    # 阶梯 6：仍超限按完整 Loop 逐出（最旧先出），空 Loop 不重试。
+    index = 0
+    order_list = list(order)
+    while _total() > budget_tokens and index < len(order_list):
+        segments.pop(order_list[index], None)
+        decisions[order_list[index]] = LoopProjectionDecision(
+            loop_id=order_list[index], path=decisions[order_list[index]].path,
+            reason="reduced:evicted",
+        )
+        index += 1
+
+    final_messages: list[LLMConversationMessage] = []
+    final_decisions: list[LoopProjectionDecision] = []
+    for loop_id in order:
+        if loop_id in segments:
+            final_messages.extend(segments[loop_id])
+        final_decisions.append(decisions[loop_id])
+    return ProjectionResult(
+        messages=final_messages,
+        decisions=tuple(final_decisions),
+        segments={key: list(value) for key, value in segments.items()},
+    )

--- a/src/quickquip/llm/history_projection.py
+++ b/src/quickquip/llm/history_projection.py
@@ -285,8 +285,10 @@ def _project_turn_structured(
 
 def _omitted_arguments_json(execution: LoadedToolExecution) -> str:
     """参数被政策省略时的有界档案描述（§8.4）：不把摘录重用作函数参数。"""
+    import json
+
     reason = execution.arguments_omission_reason or "omitted"
-    return '{"_omitted": "参数正文未保留（' + reason + '）"}'
+    return json.dumps({"_omitted": f"参数正文未保留（{reason}）"}, ensure_ascii=False)
 
 
 def _tool_messages(turn: LoadedTurn, *, wire_id_for) -> list[LLMConversationMessage]:

--- a/src/quickquip/llm/history_projection.py
+++ b/src/quickquip/llm/history_projection.py
@@ -54,6 +54,8 @@ class LoopProjectionDecision:
 class ProjectionResult:
     messages: list[LLMConversationMessage]
     decisions: tuple[LoopProjectionDecision, ...]
+    # 按 Loop 边界切分的消息段（loop_id -> messages），与 decisions 同序。
+    segments: dict[str, list[LLMConversationMessage]]
 
 
 def stable_wire_tool_call_id(loop_id: str, turn_id: str, call_index: int) -> str:
@@ -322,20 +324,23 @@ def project_loops(
     """把完整已关闭 Loop 投影为目标协议消息序列（§7.2 两条合法路径 + 档案）。"""
     messages: list[LLMConversationMessage] = []
     decisions: list[LoopProjectionDecision] = []
+    segments: dict[str, list[LLMConversationMessage]] = {}
     for loop in loops:
         for turn in loop.turns:
             _validate_tool_pairing(turn)
         path, reason = _decide_loop_path(loop, target=target, protocol=protocol)
         if path == PATH_NATIVE:
-            messages.extend(_project_loop_native(loop))
+            loop_messages = _project_loop_native(loop)
         elif path == PATH_STRUCTURED:
-            messages.append(_user_trigger_message(loop))
+            loop_messages = [_user_trigger_message(loop)]
             owner_match = target is not None and all(
                 owner_matches(turn.owner, target) for turn in loop.turns if turn.owner
             )
             for turn in loop.turns:
-                messages.extend(_project_turn_structured(turn, loop.loop_id, native_owner_match=owner_match))
+                loop_messages.extend(_project_turn_structured(turn, loop.loop_id, native_owner_match=owner_match))
         else:
-            messages.extend(_project_loop_archive(loop))
+            loop_messages = _project_loop_archive(loop)
+        messages.extend(loop_messages)
+        segments[loop.loop_id] = loop_messages
         decisions.append(LoopProjectionDecision(loop_id=loop.loop_id, path=path, reason=reason))
-    return ProjectionResult(messages=messages, decisions=tuple(decisions))
+    return ProjectionResult(messages=messages, decisions=tuple(decisions), segments=segments)

--- a/src/quickquip/llm/history_projection.py
+++ b/src/quickquip/llm/history_projection.py
@@ -1,0 +1,341 @@
+"""历史重放投影（§7.2/§7.4）：归属选择、通用投影与冻结表达。
+
+输入是执行记录的完整已关闭 Loop（``store_parts.agent_records.LoadedLoop``），
+输出是目标协议可用的 ``LLMConversationMessage`` 序列。三条合法路径：
+
+- **native**：目标 owner 五元组精确匹配且协议结构校验通过时，原样使用
+  保存的有序原生块（Claude content / Gemini parts），保留签名与位置；
+  不追加通用副本。
+- **structured**：有序普通正文 + 工具名/稳定 wire ID/结果/终态；去掉
+  不具备有效来源的原生推理。Claude 带 thinking 的工具 Turn 不能走该路径
+  （签名不可伪造），自动降级档案。
+- **archive**：纯文本历史档案——每 Loop 一段 user 触发 + 一段 assistant
+  档案（Turn N 与工具状态）。工具内容是历史数据，不产生可执行调用。
+
+本模块是纯函数层：不做 I/O、不读配置、不改记录。降级理由通过
+``ProjectionResult.decisions`` 可观测（§7.2）。
+"""
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from quickquip.llm.agent_records import ResponseOwner
+from quickquip.llm.provider.owner import owner_matches
+from quickquip.llm.store_parts.agent_records import (
+    LoadedLoop,
+    LoadedToolExecution,
+    LoadedTurn,
+)
+from quickquip.llm.tools import LLMConversationMessage, LLMToolCall
+
+PATH_NATIVE = "native"
+PATH_STRUCTURED = "structured"
+PATH_ARCHIVE = "archive"
+
+_ARCHIVE_TAG = "[历史档案]"
+_ORPHAN_TRIGGER_NOTE = "[系统说明] 该段历史的原始触发消息未保留。"
+
+
+class HistoryProjectionError(RuntimeError):
+    """执行记录结构损坏（§7.4：孤立/重复/漏结果在发送请求前失败）。"""
+
+
+@dataclass(frozen=True, slots=True)
+class LoopProjectionDecision:
+    loop_id: str
+    path: str
+    reason: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionResult:
+    messages: list[LLMConversationMessage]
+    decisions: tuple[LoopProjectionDecision, ...]
+
+
+def stable_wire_tool_call_id(loop_id: str, turn_id: str, call_index: int) -> str:
+    """通用路径的稳定 wire ID（§7.4）：按 (loop, turn, call_index) 派生。
+
+    跨 Turn 重复的 provider call_id（如每轮都有的 call_0）在通用路径下
+    由此消歧；原生路径保持原 call ID 与签名关联不变。
+    """
+    digest = hashlib.sha1(f"{loop_id}:{turn_id}:{call_index}".encode("utf-8")).hexdigest()[:16]
+    return f"call_{digest}"
+
+
+def missing_result_explanation(execution: LoadedToolExecution) -> str:
+    """缺失/省略结果的确定说明（§5.5）：不虚构工具返回正文或成功结论。"""
+    result = execution.result or {}
+    detail = result.get("detail")
+    if execution.status == "not_executed":
+        return f"工具 {execution.tool_name} 未执行（原因：{detail or '未知'}）。"
+    if execution.status == "failed":
+        return f"工具 {execution.tool_name} 执行失败，无可用结果。"
+    if execution.status == "indeterminate":
+        return f"工具 {execution.tool_name} 的执行结果未知。"
+    if execution.status == "succeeded":
+        return f"工具 {execution.tool_name} 已成功执行，结果正文按政策未保留。"
+    return f"工具 {execution.tool_name} 状态为 {execution.status}，无结果正文。"
+
+
+def _turn_native_blocks(turn: LoadedTurn) -> list[dict[str, Any]] | None:
+    native = turn.native_state
+    if not native or turn.native_omission_reason is not None:
+        return None
+    blocks = native.get("blocks")
+    if not isinstance(blocks, list) or not blocks:
+        return None
+    return blocks
+
+
+def _native_blocks_valid(protocol: str, blocks: Sequence[dict[str, Any]]) -> bool:
+    """协议结构校验（§7.2）：签名缺失/损坏、未知块形态都判无效并降级。"""
+    for block in blocks:
+        if not isinstance(block, dict):
+            return False
+        kind = block.get("type")
+        if protocol == "claude":
+            if kind == "thinking":
+                if not isinstance(block.get("signature"), str) or not block["signature"].strip():
+                    return False
+            elif kind == "redacted_thinking":
+                if not isinstance(block.get("data"), str) or not block["data"].strip():
+                    return False
+            elif kind == "text":
+                if not isinstance(block.get("text"), str):
+                    return False
+            elif kind == "tool_use":
+                if not str(block.get("id", "")).strip() or not str(block.get("name", "")).strip():
+                    return False
+                if not isinstance(block.get("input"), dict):
+                    return False
+            else:
+                return False
+        elif protocol == "gemini":
+            # parts 形态：text / functionCall（thought 与 thoughtSignature 可选）。
+            if "functionCall" in block:
+                call = block.get("functionCall")
+                if not isinstance(call, dict) or not str(call.get("name", "")).strip():
+                    return False
+            elif "text" not in block and "inlineData" not in block and "fileData" not in block:
+                return False
+        else:
+            return False
+    return True
+
+
+def _validate_tool_pairing(turn: LoadedTurn) -> None:
+    """配对校验（§7.4）：声明与结果必须成对，损坏在投影期失败。"""
+    for execution in turn.tools:
+        terminal = execution.status in {"succeeded", "failed", "indeterminate", "not_executed"}
+        if not terminal:
+            raise HistoryProjectionError(
+                f"turn={turn.turn_id} execution={execution.execution_id} 无终态（{execution.status}）"
+            )
+        if execution.status in {"succeeded", "failed"} and execution.result is None:
+            raise HistoryProjectionError(
+                f"turn={turn.turn_id} execution={execution.execution_id} 终态无结果记录"
+            )
+
+
+def _tool_result_content(execution: LoadedToolExecution) -> str:
+    result = execution.result or {}
+    content = str(result.get("content") or "")
+    if content:
+        return content
+    return missing_result_explanation(execution)
+
+
+def _decide_loop_path(
+    loop: LoadedLoop,
+    *,
+    target: ResponseOwner | None,
+    protocol: str,
+) -> tuple[str, str | None]:
+    """单 Loop 路径决策。返回 (path, 降级原因)。
+
+    Claude 的通用工具历史需要合法 thinking 签名；签名不可伪造（§7.2），
+    因此只有当每个带工具的 Turn 都能"证明无 thinking"（原生块在场且
+    不含 thinking 块）时才允许 structured，否则降级档案。
+    """
+    native_turn_blocks = {
+        turn.turn_id: _turn_native_blocks(turn) for turn in loop.turns
+    }
+    has_any_native = any(blocks is not None for blocks in native_turn_blocks.values())
+    owner_matched = all(
+        owner_matches(turn.owner, target)
+        for turn in loop.turns
+        if _turn_native_blocks(turn) is not None
+    )
+    if protocol in ("claude", "gemini") and has_any_native and target is not None and owner_matched:
+        for blocks in native_turn_blocks.values():
+            if blocks is not None and not _native_blocks_valid(protocol, blocks):
+                return PATH_ARCHIVE, "native_structure_invalid"
+        return PATH_NATIVE, None
+    if protocol == "claude":
+        for turn in loop.turns:
+            if not turn.tools:
+                continue
+            blocks = native_turn_blocks[turn.turn_id]
+            proves_no_thinking = blocks is not None and not any(
+                block.get("type") in {"thinking", "redacted_thinking"} for block in blocks
+            )
+            if not proves_no_thinking:
+                reason = (
+                    "owner_unknown_claude_signed_history"
+                    if target is None
+                    else "owner_mismatch_claude_signed_history"
+                )
+                return PATH_ARCHIVE, reason
+    if has_any_native:
+        return PATH_STRUCTURED, "owner_mismatch"
+    return PATH_STRUCTURED, None
+
+
+def _user_trigger_message(loop: LoadedLoop) -> LLMConversationMessage:
+    if loop.user_row:
+        content = str(loop.user_row.get("content") or "")
+    else:
+        content = _ORPHAN_TRIGGER_NOTE
+    return LLMConversationMessage(role="user", content=content)
+
+
+def _project_loop_native(
+    loop: LoadedLoop,
+) -> list[LLMConversationMessage]:
+    messages = [_user_trigger_message(loop)]
+    for turn in loop.turns:
+        blocks = _turn_native_blocks(turn)
+        if blocks is None:
+            # 同 Loop 内个别 Turn 无原生副本：该 Turn 退通用表达，
+            # 其余 Turn 保持原生（Loop 级路径已由决策保证合法）。
+            messages.extend(_project_turn_structured(turn, loop.loop_id, native_owner_match=False))
+            continue
+        messages.append(
+            LLMConversationMessage(role="assistant", content=turn.text, native_content=list(blocks))
+        )
+        for execution in turn.tools:
+            wire_id = execution.provider_call_id or stable_wire_tool_call_id(
+                loop.loop_id, turn.turn_id, execution.call_index
+            )
+            messages.append(
+                LLMConversationMessage(
+                    role="tool",
+                    content=_tool_result_content(execution),
+                    tool_call_id=wire_id,
+                    tool_name=execution.tool_name,
+                    is_tool_error=execution.status == "failed",
+                )
+            )
+    return messages
+
+
+def _project_turn_structured(
+    turn: LoadedTurn,
+    loop_id: str,
+    *,
+    native_owner_match: bool,
+) -> list[LLMConversationMessage]:
+    tool_calls = [
+        LLMToolCall(
+            id=stable_wire_tool_call_id(loop_id, turn.turn_id, execution.call_index),
+            name=execution.tool_name,
+            arguments_json=execution.arguments_json
+            or _omitted_arguments_json(execution),
+        )
+        for execution in turn.tools
+    ]
+    thinking_blocks: list[Any] = []
+    if native_owner_match:
+        blocks = _turn_native_blocks(turn)
+        if blocks is not None:
+            thinking_blocks = [
+                block for block in blocks if block.get("type") in {"thinking", "redacted_thinking", "reasoning", "gemini_part"}
+            ]
+    messages = [
+        LLMConversationMessage(
+            role="assistant",
+            content=turn.text,
+            tool_calls=tool_calls,
+            thinking_blocks=thinking_blocks,
+        )
+    ]
+    messages.extend(
+        _tool_messages(
+            turn,
+            wire_id_for=lambda e: stable_wire_tool_call_id(loop_id, turn.turn_id, e.call_index),
+        )
+    )
+    return messages
+
+
+def _omitted_arguments_json(execution: LoadedToolExecution) -> str:
+    """参数被政策省略时的有界档案描述（§8.4）：不把摘录重用作函数参数。"""
+    reason = execution.arguments_omission_reason or "omitted"
+    return '{"_omitted": "参数正文未保留（' + reason + '）"}'
+
+
+def _tool_messages(turn: LoadedTurn, *, wire_id_for) -> list[LLMConversationMessage]:
+    messages: list[LLMConversationMessage] = []
+    for execution in turn.tools:
+        messages.append(
+            LLMConversationMessage(
+                role="tool",
+                content=_tool_result_content(execution),
+                tool_call_id=wire_id_for(execution),
+                tool_name=execution.tool_name,
+                is_tool_error=execution.status == "failed",
+            )
+        )
+    return messages
+
+
+def _project_loop_archive(loop: LoadedLoop) -> list[LLMConversationMessage]:
+    lines: list[str] = [f"{_ARCHIVE_TAG} 以下为归档的历史会话记录，工具内容为历史数据。"]
+    for turn in loop.turns:
+        body = turn.text.strip()
+        summary = f"Turn {turn.turn_index}：" + (body if body else "（无普通正文）")
+        lines.append(summary)
+        status_counts: dict[str, int] = {}
+        for execution in turn.tools:
+            status_counts[execution.status] = status_counts.get(execution.status, 0) + 1
+        if turn.tools:
+            tool_summary = "、".join(
+                f"{name}×{count}" for name, count in status_counts.items()
+            )
+            lines.append(f"（Turn {turn.turn_index} 工具：{tool_summary}，正文未保留）")
+    return [
+        _user_trigger_message(loop),
+        LLMConversationMessage(role="assistant", content="\n".join(lines)),
+    ]
+
+
+def project_loops(
+    loops: Sequence[LoadedLoop],
+    *,
+    target: ResponseOwner | None,
+    protocol: str,
+) -> ProjectionResult:
+    """把完整已关闭 Loop 投影为目标协议消息序列（§7.2 两条合法路径 + 档案）。"""
+    messages: list[LLMConversationMessage] = []
+    decisions: list[LoopProjectionDecision] = []
+    for loop in loops:
+        for turn in loop.turns:
+            _validate_tool_pairing(turn)
+        path, reason = _decide_loop_path(loop, target=target, protocol=protocol)
+        if path == PATH_NATIVE:
+            messages.extend(_project_loop_native(loop))
+        elif path == PATH_STRUCTURED:
+            messages.append(_user_trigger_message(loop))
+            owner_match = target is not None and all(
+                owner_matches(turn.owner, target) for turn in loop.turns if turn.owner
+            )
+            for turn in loop.turns:
+                messages.extend(_project_turn_structured(turn, loop.loop_id, native_owner_match=owner_match))
+        else:
+            messages.extend(_project_loop_archive(loop))
+        decisions.append(LoopProjectionDecision(loop_id=loop.loop_id, path=path, reason=reason))
+    return ProjectionResult(messages=messages, decisions=tuple(decisions))

--- a/src/quickquip/llm/prompting.py
+++ b/src/quickquip/llm/prompting.py
@@ -624,6 +624,7 @@ def build_messages(
     forward_image_urls: list[str] | None = None,
     image_descriptions: list[object] | None = None,
     turn_envelope: str = "",
+    projected_history_segments: dict[str, list[LLMConversationMessage]] | None = None,
 ) -> list[LLMConversationMessage]:
     """Build the final messages array using scene-based grouping.
 
@@ -636,6 +637,11 @@ def build_messages(
 
     ``turn_envelope``（通常由 build_turn_envelope 渲染）非空时 prepend
     到最终 user 消息文本头部；组装时渲染、不落库。
+
+    ``projected_history_segments``（§8.1 Loop 投影）：键为 agent_loop_id。
+    携带工具事实的 Loop 不能用纯文本行表达，命中时该 Loop 的全部行让位
+    给投影消息序列（含工具调用与结果配对），插入位置 = 该 Loop 首行的
+    位置；无工具的 Loop 保持行渲染，维持 1.14 的字节稳定前缀。
     """
     messages: list[LLMConversationMessage] = []
 
@@ -658,7 +664,18 @@ def build_messages(
         ))
         pending_speakers.clear()
 
+    projected = projected_history_segments or {}
+    projected_loop_ids = set(projected)
+    seen_projected: set[str] = set()
+
     for item in history:
+        loop_id = item.get("agent_loop_id")
+        if loop_id and loop_id in projected_loop_ids:
+            if loop_id not in seen_projected:
+                seen_projected.add(loop_id)
+                _flush_pending()
+                messages.extend(projected[loop_id])
+            continue
         if item["role"] not in {"user", "assistant"} or not _history_text(item).strip():
             continue
 

--- a/src/quickquip/llm/provider/base.py
+++ b/src/quickquip/llm/provider/base.py
@@ -22,6 +22,7 @@ from typing import Any
 import httpx
 
 from quickquip.llm.config import ProviderConfig
+from quickquip.llm.agent_records import ResponseOwner
 from quickquip.llm.provider.retry import RetryPolicy, backoff_delay
 from quickquip.llm.sanitize import MAX_SAFE_ERROR_LENGTH, sanitize_error_message
 from quickquip.llm.tools import (
@@ -219,6 +220,12 @@ class LLMResponse:
     thinking_tokens: int | None = None
     thinking_blocks: list[dict[str, Any]] = field(default_factory=list)
     web_search: LLMWebSearchReport | None = None
+    # 实际成功请求的归属（§7.1）：由 client 在成功路径按最终端点填充。
+    owner: "ResponseOwner | None" = None
+    # 协议原生的有序内容块（§4.4 保序表示）：Claude 的 content 序列 /
+    # Gemini 的 parts 序列，白名单深拷贝。OpenAI 无此结构（reasoning 单块
+    # 已由 thinking_blocks 承载）。供执行记录的 native_state 持久化。
+    native_blocks: list[dict[str, Any]] | None = None
 
 
 def _text_from_block_list(content: Any) -> str:
@@ -535,13 +542,18 @@ class BaseProviderClient:
         for fb in self.config.fallback_urls:
             yield self._swap_base_url(url, fb)
 
-    async def _execute_with_fallback(self, fn, url: str, headers: dict[str, str], payload: dict[str, Any]) -> Any:
+    async def _execute_with_fallback(self, fn, url: str, headers: dict[str, str], payload: dict[str, Any]) -> tuple[Any, str]:
+        """按候选端点链执行，返回 ``(结果, 实际成功的 URL)``（§7.3）。
+
+        失败的可重试错误切换下一候选；不可重试立即抛。调用方用返回的
+        URL 构造实际 owner，不共享可变"最后成功端点"字段。
+        """
         if not self.config.fallback_urls:
-            return await fn(url, headers, payload)
+            return await fn(url, headers, payload), url
         last_exc: LLMProviderError | None = None
         for candidate in self._candidate_urls(url):
             try:
-                return await fn(candidate, headers, payload)
+                return await fn(candidate, headers, payload), candidate
             except LLMProviderError as exc:
                 if not _is_retryable(exc):
                     raise
@@ -549,9 +561,18 @@ class BaseProviderClient:
         raise last_exc  # type: ignore[misc]
 
     async def _post_json_with_fallback(self, url: str, headers: dict[str, str], payload: dict[str, Any]) -> dict[str, Any]:
-        return await self._execute_with_fallback(self._post_json, url, headers, payload)
+        data, _ = await self._execute_with_fallback(self._post_json, url, headers, payload)
+        return data
 
     async def _post_stream_sse_with_fallback(self, url: str, headers: dict[str, str], payload: dict[str, Any]) -> list[dict[str, Any]]:
+        events, _ = await self._execute_with_fallback(self._post_stream_sse, url, headers, payload)
+        return events
+
+    async def _post_json_candidate(self, url: str, headers: dict[str, str], payload: dict[str, Any]) -> tuple[dict[str, Any], str]:
+        """``_post_json_with_fallback`` 的候选可观测变体：带回实际端点。"""
+        return await self._execute_with_fallback(self._post_json, url, headers, payload)
+
+    async def _post_stream_sse_candidate(self, url: str, headers: dict[str, str], payload: dict[str, Any]) -> tuple[list[dict[str, Any]], str]:
         return await self._execute_with_fallback(self._post_stream_sse, url, headers, payload)
 
     def _combine_stream_trace(

--- a/src/quickquip/llm/provider/claude.py
+++ b/src/quickquip/llm/provider/claude.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import json
 import platform
+from copy import deepcopy
 from typing import Any
 
 from quickquip.llm.tools import LLMConversationMessage, LLMToolCall
+from quickquip.llm.provider.owner import build_response_owner
 from quickquip.llm.provider.base import (
     BaseProviderClient,
     LLMRequest,
@@ -132,6 +134,13 @@ class ClaudeProviderClient(BaseProviderClient):
 
             await _flush_tool_results()
             if message.role == "assistant":
+                if message.native_content is not None:
+                    # 原生路径（§7.2）：历史记录的原样 content 块深拷贝回放，
+                    # 不再从 text/tool_calls/thinking_blocks 重建（避免双写）。
+                    serialized.append(
+                        {"role": "assistant", "content": [deepcopy(block) for block in message.native_content]}
+                    )
+                    continue
                 content: list[dict[str, Any]] = [*message.thinking_blocks]
                 if message.content:
                     content.append({"type": "text", "text": message.content})
@@ -274,23 +283,39 @@ class ClaudeProviderClient(BaseProviderClient):
         text_parts: list[str] = []
         tool_calls: list[LLMToolCall] = []
         thinking_blocks: list[dict[str, Any]] = []
+        native_blocks: list[dict[str, Any]] = []
         for index, item in enumerate(content if isinstance(content, list) else [], 1):
             if not isinstance(item, dict):
                 continue
             t = item.get("type")
             if t == "thinking":
-                thinking_blocks.append({"type": "thinking", "thinking": item.get("thinking", ""), "signature": item.get("signature", "")})
+                block = {"type": "thinking", "thinking": item.get("thinking", ""), "signature": item.get("signature", "")}
+                thinking_blocks.append(block)
+                native_blocks.append(dict(block))
             elif t == "redacted_thinking":
-                thinking_blocks.append({"type": "redacted_thinking", "data": item.get("data", "")})
+                block = {"type": "redacted_thinking", "data": item.get("data", "")}
+                thinking_blocks.append(block)
+                native_blocks.append(dict(block))
             elif t == "text":
                 text_parts.append(str(item.get("text", "")))
+                native_blocks.append({"type": "text", "text": str(item.get("text", ""))})
             elif t == "tool_use":
+                call_id = str(item.get("id", "")).strip() or f"tool_{index}"
+                call_name = str(item.get("name", "")).strip()
                 tool_calls.append(
                     LLMToolCall(
-                        id=str(item.get("id", "")).strip() or f"tool_{index}",
-                        name=str(item.get("name", "")).strip(),
+                        id=call_id,
+                        name=call_name,
                         arguments_json=_json_string(item.get("input", {})),
                     )
+                )
+                native_blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": call_id,
+                        "name": call_name,
+                        "input": deepcopy(item.get("input", {})),
+                    }
                 )
 
         usage = data.get("usage", {})
@@ -304,11 +329,12 @@ class ClaudeProviderClient(BaseProviderClient):
             cache_creation_tokens=_cache_creation_tokens(usage),
             cache_read_tokens=usage.get("cache_read_input_tokens"),
             thinking_blocks=thinking_blocks,
+            native_blocks=native_blocks or None,
         )
 
     @staticmethod
     def _assemble_stream_response(chunks: list[dict[str, Any]], fallback_model: str) -> LLMResponse:
-        text_parts: list[str] = []
+        text_acc: dict[int, str] = {}  # block_index -> 累积文本（保序表示需要）
         tool_calls_acc: dict[int, dict[str, str]] = {}  # block_index -> {id, name, input_json}
         thinking_acc: dict[int, dict[str, str]] = {}    # block_index -> {type, thinking, signature} 或 redacted {type, data}
         finish_reason: str | None = None
@@ -351,12 +377,15 @@ class ClaudeProviderClient(BaseProviderClient):
                         "type": "redacted_thinking",
                         "data": str(block.get("data", "")),
                     }
+                elif block.get("type") == "text":
+                    text_acc.setdefault(current_block_index, "")
 
             elif event == "content_block_delta":
                 delta = chunk.get("delta", {})
                 idx = chunk.get("index", current_block_index)
                 if delta.get("type") == "text_delta":
-                    text_parts.append(str(delta.get("text", "")))
+                    text_acc.setdefault(idx, "")
+                    text_acc[idx] += str(delta.get("text", ""))
                 elif delta.get("type") == "input_json_delta":
                     if idx in tool_calls_acc:
                         tool_calls_acc[idx]["input_json"] += str(delta.get("partial_json", ""))
@@ -391,11 +420,33 @@ class ClaudeProviderClient(BaseProviderClient):
             )
             for _, acc in sorted(thinking_acc.items())
         ]
+        # 保序原生块（§4.4）：与 _parse_response 的非流式形态等价，
+        # thinking/text/tool_use 按 block index 还原原始交错顺序。
+        indexed_blocks: list[tuple[int, dict[str, Any]]] = []
+        for idx, acc in thinking_acc.items():
+            if acc.get("type") == "redacted_thinking":
+                indexed_blocks.append((idx, {"type": "redacted_thinking", "data": acc["data"]}))
+            else:
+                indexed_blocks.append(
+                    (idx, {"type": "thinking", "thinking": acc["thinking"], "signature": acc["signature"]})
+                )
+        for idx, text in text_acc.items():
+            indexed_blocks.append((idx, {"type": "text", "text": text}))
+        for idx, acc in tool_calls_acc.items():
+            try:
+                tool_input = json.loads(acc["input_json"] or "{}")
+            except json.JSONDecodeError:
+                tool_input = {}
+            indexed_blocks.append(
+                (idx, {"type": "tool_use", "id": acc["id"] or f"tool_{idx + 1}", "name": acc["name"], "input": tool_input})
+            )
+        native_blocks = [block for _, block in sorted(indexed_blocks, key=lambda pair: pair[0])]
         return LLMResponse(
-            text="".join(text_parts).strip(),
+            text="".join(text for _, text in sorted(text_acc.items())).strip(),
             model=model,
             tool_calls=tool_calls,
             thinking_blocks=thinking_blocks,
+            native_blocks=native_blocks or None,
             finish_reason=finish_reason,
             input_tokens=input_tokens,
             output_tokens=output_tokens,
@@ -471,11 +522,15 @@ class ClaudeProviderClient(BaseProviderClient):
 
     async def _complete_non_stream(self, request: LLMRequest) -> LLMResponse:
         url, headers, payload = await self._build_request_parts(request)
-        data = await self._post_json_with_fallback(url, headers, payload)
-        return self._parse_response(data, request.model)
+        data, final_url = await self._post_json_candidate(url, headers, payload)
+        response = self._parse_response(data, request.model)
+        response.owner = build_response_owner(self.config, final_url, request.model)
+        return response
 
     async def _complete_stream(self, request: LLMRequest) -> LLMResponse:
         url, headers, payload = await self._build_request_parts(request)
         payload["stream"] = True
-        chunks = await self._post_stream_sse_with_fallback(url, headers, payload)
-        return self._assemble_stream_response(chunks, request.model)
+        chunks, final_url = await self._post_stream_sse_candidate(url, headers, payload)
+        response = self._assemble_stream_response(chunks, request.model)
+        response.owner = build_response_owner(self.config, final_url, request.model)
+        return response

--- a/src/quickquip/llm/provider/gemini.py
+++ b/src/quickquip/llm/provider/gemini.py
@@ -7,6 +7,7 @@ from typing import Any
 from urllib import parse
 
 from quickquip.llm.tools import LLMConversationMessage, LLMToolCall
+from quickquip.llm.provider.owner import build_response_owner
 from quickquip.llm.provider.base import (
     BaseProviderClient,
     LLMRequest,
@@ -68,6 +69,13 @@ class GeminiProviderClient(BaseProviderClient):
 
             await _flush_tool_results()
             if message.role == "assistant":
+                if message.native_content is not None:
+                    # 原生路径（§7.2）：历史记录的原样 parts 深拷贝回放，
+                    # 保留 functionCall 与 thoughtSignature 的原始位置。
+                    serialized.append(
+                        {"role": "model", "parts": [deepcopy(part) for part in message.native_content]}
+                    )
+                    continue
                 parts = self._replay_parts(message.thinking_blocks)
                 if not parts:
                     if message.content:
@@ -240,6 +248,7 @@ class GeminiProviderClient(BaseProviderClient):
             tool_calls=tool_calls,
             finish_reason=str(candidate.get("finishReason", "")).strip() or None,
             thinking_blocks=thinking_blocks,
+            native_blocks=[deepcopy(part) for part in normalized_parts] or None,
             web_search=web_search,
         )
 
@@ -353,7 +362,7 @@ class GeminiProviderClient(BaseProviderClient):
 
     async def _complete_non_stream(self, request: LLMRequest) -> LLMResponse:
         url, headers, payload = await self._build_request_parts(request)
-        data = await self._post_json_with_fallback(url, headers, payload)
+        data, final_url = await self._post_json_candidate(url, headers, payload)
         candidates = data.get("candidates", [])
         candidate = candidates[0] if isinstance(candidates, list) and candidates else {}
         response = self._parse_candidate(candidate, request.model)
@@ -362,9 +371,12 @@ class GeminiProviderClient(BaseProviderClient):
         response.output_tokens = usage.get("candidatesTokenCount")
         response.cache_read_tokens = usage.get("cachedContentTokenCount")
         response.thinking_tokens = usage.get("thoughtsTokenCount")
+        response.owner = build_response_owner(self.config, final_url, request.model)
         return response
 
     async def _complete_stream(self, request: LLMRequest) -> LLMResponse:
         url, headers, payload = await self._build_request_parts(request, stream=True)
-        chunks = await self._post_stream_sse_with_fallback(url, headers, payload)
-        return self._assemble_stream_response(chunks, request.model)
+        chunks, final_url = await self._post_stream_sse_candidate(url, headers, payload)
+        response = self._assemble_stream_response(chunks, request.model)
+        response.owner = build_response_owner(self.config, final_url, request.model)
+        return response

--- a/src/quickquip/llm/provider/openai.py
+++ b/src/quickquip/llm/provider/openai.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any
 
 from quickquip.llm.tools import LLMConversationMessage, LLMToolCall
+from quickquip.llm.provider.owner import build_response_owner
 from quickquip.llm.provider.base import (
     BaseProviderClient,
     LLMRequest,
@@ -352,12 +353,16 @@ class OpenAIProviderClient(BaseProviderClient):
 
     async def _complete_non_stream(self, request: LLMRequest) -> LLMResponse:
         url, headers, payload = await self._build_request_parts(request)
-        data = await self._post_json_with_fallback(url, headers, payload)
-        return self._parse_response(data, request.model)
+        data, final_url = await self._post_json_candidate(url, headers, payload)
+        response = self._parse_response(data, request.model)
+        response.owner = build_response_owner(self.config, final_url, request.model)
+        return response
 
     async def _complete_stream(self, request: LLMRequest) -> LLMResponse:
         url, headers, payload = await self._build_request_parts(request)
         payload["stream"] = True
         payload["stream_options"] = {"include_usage": True}
-        chunks = await self._post_stream_sse_with_fallback(url, headers, payload)
-        return self._assemble_stream_response(chunks, request.model)
+        chunks, final_url = await self._post_stream_sse_candidate(url, headers, payload)
+        response = self._assemble_stream_response(chunks, request.model)
+        response.owner = build_response_owner(self.config, final_url, request.model)
+        return response

--- a/src/quickquip/llm/provider/owner.py
+++ b/src/quickquip/llm/provider/owner.py
@@ -1,0 +1,102 @@
+"""Provider 请求归属（owner）解析与不可逆指纹（§7.1）。
+
+owner 捕获一次成功请求的实际端点、wire model 与协议 profile。API key、
+Authorization 与原始 headers 不入库、不入日志、不参与指纹；含敏感路由
+参数的 URL 先剔除敏感参数再散列，持久值不可反推原参数。
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
+
+from quickquip.llm.agent_records import ResponseOwner
+from quickquip.llm.config import ProviderConfig
+from quickquip.llm.tools import LLMToolSpec
+
+# URL query 中的敏感参数名（小写）：绝不进入指纹或持久化 owner。
+SENSITIVE_QUERY_KEYS = frozenset(
+    {"key", "api_key", "apikey", "token", "access_token", "signature", "sig", "auth"}
+)
+
+# 影响协议序列化形状的配置面（profile 指纹输入）。stream 开关不参与：
+# 流式/非流式必须产生等价 block（§4.4），不构成 profile 差异。
+_PROFILE_FIELDS = ("protocol", "prompt_caching", "cache_ttl", "auth_method", "builtin_search")
+
+
+def normalize_endpoint(url: str) -> str:
+    """规范化端点：scheme/host/path + 排序后的非敏感 query 参数。"""
+    try:
+        split = urlsplit(url.strip())
+    except ValueError:
+        return url.strip()
+    query = sorted(
+        (key, value)
+        for key, value in parse_qsl(split.query, keep_blank_values=True)
+        if key.lower() not in SENSITIVE_QUERY_KEYS
+    )
+    return urlunsplit(
+        (split.scheme.lower(), split.netloc.lower(), split.path, urlencode(query), "")
+    )
+
+
+def _short_digest(payload: str) -> str:
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+
+
+def endpoint_fingerprint(url: str) -> str:
+    return _short_digest(f"endpoint:{normalize_endpoint(url)}")
+
+
+def profile_fingerprint(config: ProviderConfig) -> str:
+    parts = [f"{field}={getattr(config, field, None)!r}" for field in _PROFILE_FIELDS]
+    return _short_digest(f"profile:{'|'.join(parts)}")
+
+
+def resolve_wire_model(config: ProviderConfig, request_model: str) -> str:
+    """实际 wire model：extra_body 的 model 覆盖优先（§7.3）。
+
+    禁止 owner 记录 model A 而最终请求被 extra_body 改为 model B——
+    序列化端把 extra_body update 到 payload 之后，此函数与最终 payload
+    的 model 字段同源。
+    """
+    override = config.extra_body.get("model") if config.extra_body else None
+    return str(override) if isinstance(override, str) and override.strip() else request_model
+
+
+def build_response_owner(
+    config: ProviderConfig, url: str, request_model: str
+) -> ResponseOwner:
+    """从实际成功的端点构造 owner（只含不可逆指纹与非敏感元数据）。"""
+    return ResponseOwner(
+        provider_id=config.id,
+        protocol=config.protocol,
+        wire_model=resolve_wire_model(config, request_model),
+        display_model=request_model,
+        endpoint_fingerprint=endpoint_fingerprint(url),
+        profile_fingerprint=profile_fingerprint(config),
+    )
+
+
+def tools_schema_fingerprint(specs: list[LLMToolSpec]) -> str:
+    """工具 schema 指纹（§7.1：单独记录，参与 epoch projection profile）。"""
+    payload = [
+        {"name": spec.name, "description": spec.description, "schema": spec.input_schema}
+        for spec in specs
+    ]
+    return _short_digest(f"tools:{json.dumps(payload, ensure_ascii=False, sort_keys=True)}")
+
+
+def owner_matches(stored: dict | None, target: ResponseOwner | None) -> bool:
+    """owner 精确匹配（§7.2）：五元组全等才允许原生路径。"""
+    if stored is None or target is None:
+        return False
+    if not isinstance(stored, dict):
+        return False
+    return (
+        stored.get("provider_id") == target.provider_id
+        and stored.get("protocol") == target.protocol
+        and stored.get("wire_model") == target.wire_model
+        and stored.get("endpoint_fingerprint") == target.endpoint_fingerprint
+        and stored.get("profile_fingerprint") == target.profile_fingerprint
+    )

--- a/src/quickquip/llm/provider/owner.py
+++ b/src/quickquip/llm/provider/owner.py
@@ -25,18 +25,24 @@ _PROFILE_FIELDS = ("protocol", "prompt_caching", "cache_ttl", "auth_method", "bu
 
 
 def normalize_endpoint(url: str) -> str:
-    """规范化端点：scheme/host/path + 排序后的非敏感 query 参数。"""
+    """规范化端点：scheme/host/path + 排序后的非敏感 query 参数。
+
+    流式/非流式动作归一（gemini 的 ``:streamGenerateContent?alt=sse`` →
+    ``:generateContent``）：两者必须产生等价 block（§4.4），不构成端点
+    身份差异；``alt`` 传输参数同理剔除。
+    """
     try:
         split = urlsplit(url.strip())
     except ValueError:
         return url.strip()
+    path = split.path.replace(":streamGenerateContent", ":generateContent")
     query = sorted(
         (key, value)
         for key, value in parse_qsl(split.query, keep_blank_values=True)
-        if key.lower() not in SENSITIVE_QUERY_KEYS
+        if key.lower() not in SENSITIVE_QUERY_KEYS and key.lower() != "alt"
     )
     return urlunsplit(
-        (split.scheme.lower(), split.netloc.lower(), split.path, urlencode(query), "")
+        (split.scheme.lower(), split.netloc.lower(), path, urlencode(query), "")
     )
 
 

--- a/src/quickquip/llm/provider/owner.py
+++ b/src/quickquip/llm/provider/owner.py
@@ -78,6 +78,20 @@ def build_response_owner(
     )
 
 
+def primary_endpoint_url(config: ProviderConfig, model: str) -> str:
+    """主端点 URL（与各 client 的 _build_request_parts 同构）。
+
+    供历史投影在请求前构造目标 owner；敏感 query（gemini 的 key）不参与
+    指纹，可省略。
+    """
+    base = config.base_url.rstrip("/")
+    if config.protocol == "openai":
+        return f"{base}/chat/completions"
+    if config.protocol == "claude":
+        return f"{base}/messages?beta=true"
+    return f"{base}/models/{model}:generateContent"
+
+
 def tools_schema_fingerprint(specs: list[LLMToolSpec]) -> str:
     """工具 schema 指纹（§7.1：单独记录，参与 epoch projection profile）。"""
     payload = [

--- a/src/quickquip/llm/request_budget.py
+++ b/src/quickquip/llm/request_budget.py
@@ -1,0 +1,127 @@
+"""实际请求预算检查（§8.3）：应用侧输入预算 + 模型上下文窗口。
+
+每次 provider HTTP 尝试开始前对最终 payload 估算：system、tools、历史
+正文/工具/原生块、当前 Loop、信封、现场和媒体均计入；媒体按已知协议
+成本估算。预算不足的处置（容量 reset / 终止）由调用方按契约执行，本
+模块只做检查与分类。
+
+``capacity unknown``：未配置模型容量时只保证应用估算预算，不得宣称
+不会触发上游 context-limit。
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from quickquip.llm.config import LLMConfig, ProviderConfig
+from quickquip.llm.provider import LLMRequest
+from quickquip.llm.token_estimate import estimate_tokens
+
+# 预留估算余量（§8.3：至少 1,024 token）。
+_RESERVE_TOKENS = 1024
+# wire 消息/part 数的应用兜底（不替代供应商真实限制）。
+MAX_WIRE_ITEMS = 1024
+
+
+class RequestBudgetExceeded(RuntimeError):
+    """最终 payload 超出可执行预算（§8.3 request_budget_exceeded）。"""
+
+    def __init__(self, message: str, *, capacity_unknown: bool = False):
+        super().__init__(message)
+        self.capacity_unknown = capacity_unknown
+
+
+@dataclass(frozen=True, slots=True)
+class RequestBudgetCheck:
+    estimated_input_tokens: int
+    budget_limit: int
+    context_window: int | None
+    wire_items: int
+    capacity_unknown: bool
+
+    @property
+    def ok(self) -> bool:
+        within_budget = self.estimated_input_tokens <= self.budget_limit
+        within_window = (
+            self.context_window is None
+            or self.estimated_input_tokens + _RESERVE_TOKENS <= self.context_window
+        )
+        return within_budget and within_window and self.wire_items <= MAX_WIRE_ITEMS
+
+
+def estimate_request_tokens(request: LLMRequest) -> int:
+    """最终实际 payload 的输入估算：system/tools/messages 全量计入。"""
+    total = estimate_tokens(request.system_prompt)
+    for spec in request.tools:
+        total += estimate_tokens(spec.name) + estimate_tokens(spec.description)
+        total += estimate_tokens(str(spec.input_schema))
+    for message in request.messages:
+        total += estimate_tokens(message.content)
+        for call in message.tool_calls:
+            total += estimate_tokens(call.arguments_json)
+        for block in message.thinking_blocks or []:
+            total += estimate_tokens(str(block))
+        # 媒体按已知协议成本粗估：每图固定档位（保守）。
+        total += 1200 * len(message.image_urls)
+    return total
+
+
+def count_wire_items(request: LLMRequest) -> int:
+    """wire 消息/part 数应用兜底（§8.3：统计最终 serializer 产物口径）。"""
+    count = 0
+    for message in request.messages:
+        count += 1
+        count += len(message.tool_calls)
+        count += len(message.image_urls)
+    count += len(request.tools)
+    return count
+
+
+def check_request_budget(
+    config: LLMConfig,
+    provider: ProviderConfig,
+    request: LLMRequest,
+    *,
+    max_output_tokens: int | None = None,
+) -> RequestBudgetCheck:
+    budget_limit = provider.request_input_token_budget or config.runtime.request_input_token_budget
+    wire_model = request.model
+    context_window = provider.model_context_windows.get(wire_model)
+    output_reserve = (max_output_tokens or provider.max_output_tokens) + _RESERVE_TOKENS
+    estimated = estimate_request_tokens(request)
+    effective_window = None if context_window is None else max(0, context_window - output_reserve)
+    return RequestBudgetCheck(
+        estimated_input_tokens=estimated,
+        budget_limit=budget_limit,
+        context_window=effective_window,
+        wire_items=count_wire_items(request),
+        capacity_unknown=context_window is None,
+    )
+
+
+def enforce_request_budget(
+    config: LLMConfig,
+    provider: ProviderConfig,
+    request: LLMRequest,
+    *,
+    max_output_tokens: int | None = None,
+) -> RequestBudgetCheck:
+    check = check_request_budget(
+        config, provider, request, max_output_tokens=max_output_tokens
+    )
+    if check.ok:
+        return check
+    if check.wire_items > MAX_WIRE_ITEMS:
+        raise RequestBudgetExceeded(
+            f"wire 消息/工具条目数 {check.wire_items} 超过应用兜底 {MAX_WIRE_ITEMS}",
+            capacity_unknown=check.capacity_unknown,
+        )
+    if check.context_window is not None and check.estimated_input_tokens > check.context_window:
+        raise RequestBudgetExceeded(
+            f"估算输入 {check.estimated_input_tokens} token 超出模型上下文余量 "
+            f"{check.context_window}",
+            capacity_unknown=check.capacity_unknown,
+        )
+    raise RequestBudgetExceeded(
+        f"估算输入 {check.estimated_input_tokens} token 超出应用输入预算 {check.budget_limit}",
+        capacity_unknown=check.capacity_unknown,
+    )

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -38,6 +38,8 @@ from quickquip.llm.config import (
     provider_builtin_search_active,
 )
 from quickquip.llm.rendering import append_web_search_source_block
+from quickquip.llm.history_projection import project_loops
+from quickquip.llm.request_budget import RequestBudgetExceeded, enforce_request_budget
 from quickquip.sts.config import (
     DEFECTIFY_RATE_LIMIT_KEY,
     DEFECTIFY_RULE_NAME,
@@ -78,6 +80,7 @@ from quickquip.llm.provider import (
     build_provider_client,
     strip_leading_reasoning_content,
 )
+from quickquip.llm.provider.owner import build_response_owner, primary_endpoint_url
 from quickquip.llm.quick_judge import (
     QuickJudgeResult as QuickJudgeResult,  # noqa: F401 — re-exported for callers/tests
     run_quick_judge,
@@ -427,6 +430,36 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             self.config, prompt, max_tokens, client_builder=build_provider_client
         )
 
+    def maintain_agent_retention(self, scope_key: str) -> None:
+        """D5 保留维护（§8.4）：Loop 关闭后调用，按三上限清理最旧完整 Loop。
+
+        硬上限要求删除活动纪元覆盖的记录时返回的 blocked 锚点只记日志；
+        推进纪元由 epoch 管理按容量 reset 路径处理。
+        """
+        from quickquip.llm.store_parts.agent_records import RetentionPolicy
+
+        policy = RetentionPolicy(
+            retention_days=self.config.runtime.agent_record_retention_days,
+            max_loops=self.config.runtime.agent_record_max_loops_per_scope,
+            max_bytes=self.config.runtime.agent_record_max_bytes_per_scope,
+        )
+        active_anchors = [
+            anchor
+            for anchor in [self._epochs.oldest_anchor(scope_key)]
+            if anchor is not None
+        ]
+        report = self.store.prune_closed_loops(scope_key, active_anchors, policy)
+        if report.deleted_loop_ids:
+            logger.info(
+                "agent record pruned scope=%s loops=%d",
+                scope_key, len(report.deleted_loop_ids),
+            )
+        if report.blocked_active_anchors:
+            logger.info(
+                "agent record hard cap blocked by active epoch scope=%s anchors=%s",
+                scope_key, list(report.blocked_active_anchors),
+            )
+
     def _merge_image_urls(self, *collections: list[str]) -> list[str]:
         return merge_image_urls(*collections)
 
@@ -453,6 +486,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         include_recent_images: bool = False,
         recent_images_messages: list[dict[str, str]] | None = None,
         turn_envelope: str = "",
+        projected_history_segments: dict[str, list[LLMConversationMessage]] | None = None,
     ) -> list[LLMConversationMessage]:
         return build_messages(
             prompt=prompt,
@@ -475,6 +509,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             image_descriptions=image_descriptions,
             include_recent_images=include_recent_images,
             turn_envelope=turn_envelope,
+            projected_history_segments=projected_history_segments,
         )
 
     async def generate_defectify_reply(
@@ -799,7 +834,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         quoted_user_id: str,
         epoch_key: EpochKey,
         epoch_params: EpochParams,
-    ) -> tuple[list[dict[str, object]], list[dict[str, str]], list[dict[str, str]] | None]:
+        provider: ProviderConfig | None = None,
+    ) -> tuple[list[dict[str, object]], list[dict[str, str]], list[dict[str, str]] | None, dict[str, list[LLMConversationMessage]]]:
         # 会话纪元读取：只追加锚点窗口（懒初始化/冷场/触顶/行数兜底的推进判定
         # 全部在 EpochManager 内），纪元内前缀逐字节稳定。auto_memory 仍走
         # list_recent_conversation_messages 的 DESC LIMIT 尾读——两个消费者
@@ -862,7 +898,52 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             quoted_user_id=quoted_user_id,
             group_id=str(chat_id),
         )
-        return history, participants, recent_messages
+        projected_segments: dict[str, list[LLMConversationMessage]] = {}
+        if provider is not None:
+            projected_segments = self._projected_history_segments(
+                scope_key=scope_key,
+                history=history,
+                provider=provider,
+                model=epoch_key.model,
+            )
+        return history, participants, recent_messages, projected_segments
+
+    def _projected_history_segments(
+        self,
+        *,
+        scope_key: str,
+        history: list[dict[str, object]],
+        provider: ProviderConfig,
+        model: str,
+    ) -> dict[str, list[LLMConversationMessage]]:
+        """携带工具事实的 Loop 用投影替换行渲染（§8.1/§5.3.2）。
+
+        无工具的 Loop 保持行渲染（1.14 字节稳定前缀契约）。目标 owner 取
+        主端点；配置了 fallback_urls 的 provider 不启用原生路径（§7.3 的
+        逐候选重投影属后置增强，跨端点签名泄露风险先收紧为保守降级）。
+        """
+        loop_ids = {
+            str(row["agent_loop_id"])
+            for row in history
+            if row.get("agent_loop_id")
+        }
+        if not loop_ids:
+            return {}
+        tool_loop_ids = self.store.loops_with_tools(scope_key, loop_ids)
+        if not tool_loop_ids:
+            return {}
+        loaded = self.store.load_closed_loops_by_ids(scope_key, tool_loop_ids)
+        target = None
+        if not provider.fallback_urls:
+            target = build_response_owner(provider, primary_endpoint_url(provider, model), model)
+        result = project_loops(loaded, target=target, protocol=provider.protocol)
+        for decision in result.decisions:
+            if decision.reason is not None:
+                logger.info(
+                    "history projection degraded scope=%s loop=%s path=%s reason=%s",
+                    scope_key, decision.loop_id, decision.path, decision.reason,
+                )
+        return result.segments
 
     def _persist_turn_and_build_reply(
         self,
@@ -925,6 +1006,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         )
 
         if trigger_auto_memory and settings.auto_memory_enabled and settings.memory_enabled:
+            generation_at_schedule, _ = self.store.agent_scope_state(scope_key)
             asyncio.create_task(
                 self._extract_auto_memory(
                     scope_key=scope_key,
@@ -934,6 +1016,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                     user_text=stored_prompt,
                     assistant_text=text,
                     persona_id=settings.persona_id,
+                    expected_generation=generation_at_schedule,
                 )
             )
 
@@ -1077,7 +1160,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             provider_id=provider.id,
             model=settings.model or provider.default_model,
         )
-        history, participants, scene_patch = self._load_scrubbed_history_and_participants(
+        history, participants, scene_patch, projected_segments = self._load_scrubbed_history_and_participants(
             chat_id=chat_id,
             chat_type=chat_type,
             scope_key=scope_key,
@@ -1091,6 +1174,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             quoted_user_id=quoted_user_id,
             epoch_key=epoch_key,
             epoch_params=self.config.resolve_epoch_params(provider),
+            provider=provider,
         )
 
         # ── image preprocessing & non-VLM stripping ──────────────────
@@ -1203,6 +1287,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             image_descriptions=image_descriptions or None,
             include_recent_images=include_recent_images and not is_non_vision,
             turn_envelope=turn_envelope,
+            projected_history_segments=projected_segments,
         )
         request = LLMRequest(
             model=settings.model or provider.default_model,
@@ -1215,6 +1300,21 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             tool_choice="auto",
             builtin_search=builtin_search_active,
         )
+        try:
+            enforce_request_budget(self.config, provider, request)
+        except RequestBudgetExceeded as exc:
+            logger.warning(
+                "request budget exceeded scope=%s provider=%s model=%s: %s",
+                scope_key, provider.id, request.model, exc,
+            )
+            return {
+                "reply": "这次对话的上下文已经太长，无法安全发起模型请求，请用清空上下文命令重置后再试。",
+                "rate_limit_key": LLM_RULE_NAME,
+                "rule_name": LLM_RULE_NAME,
+                "llm_used": False,
+                "provider_id": provider.id,
+                "model": request.model,
+            }
         tool_context = ToolExecutionContext(
             group_id=chat_id,
             user_id=user_id,

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -673,6 +673,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         normalized_forward_text: str,
         normalized_forward_image_urls: list[str],
         image_descriptions: list[ImageDescription] | None,
+        delivery_sink=None,
+        trigger_kind: TriggerKind | None = None,
     ):
         """创建 Loop 与 user 触发行（§5.3.1），返回 TurnRecorder。
 
@@ -702,9 +704,12 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 raw_turn_parts.append(f"[图片 {caption_count} 张：{caption_blob}]")
         raw_turn_parts.append(stored_prompt)
         generation, _ = self.store.agent_scope_state(scope_key)
-        trigger = (
-            TriggerKind.PRIVATE_DIRECT if chat_type == "private" else TriggerKind.GROUP_DIRECT
-        )
+        if trigger_kind is not None:
+            trigger = trigger_kind
+        else:
+            trigger = (
+                TriggerKind.PRIVATE_DIRECT if chat_type == "private" else TriggerKind.GROUP_DIRECT
+            )
         try:
             handle = self.store.begin_loop(
                 scope_key,
@@ -732,7 +737,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 reply_chunk_max_chars=runtime.reply_chunk_max_chars,
                 reply_max_chunks_per_loop=runtime.reply_max_chunks_per_loop,
             ),
-            sink=self._delivery_sink,
+            sink=delivery_sink or self._delivery_sink,
             sensitive_scan=_get_sensitive_filter().scan if _get_sensitive_filter().is_loaded else None,
         )
 
@@ -1145,6 +1150,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         trigger_auto_memory: bool = True,
         message_id: str | None = None,
         include_recent_images: bool = False,
+        delivery_sink=None,
+        trigger_kind: TriggerKind | None = None,
     ) -> dict[str, object]:
         prompt = prompt.strip()
         normalized_raw_user_text = None if raw_user_text is None else raw_user_text.strip()
@@ -1553,6 +1560,10 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         if recorder is not None:
             recorder.close(LoopStatus.COMPLETED, None)
             self.maintain_agent_retention(scope_key)
+            if recorder.final_turn_record is not None:
+                result_payload = dict(result_payload)
+                result_payload["agent_turn_row_id"] = recorder.final_turn_record.message_row_id
+                result_payload["scope_key"] = scope_key
         self._active_recorder = None
         if self.config.runtime.agent_delivery_enabled:
             # 逐 Turn 模式：正文已由 sink 交付，reply 不再二次发送（§5.1）。
@@ -1567,6 +1578,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         user_id: int | str,
         sender_name: str,
         prompt: str,
+        delivery_sink=None,
+        trigger_kind: TriggerKind | None = None,
         image_urls: list[str] | None = None,
         recent_messages: list[dict[str, str]] | None = None,
         quoted_text: str = "",
@@ -1605,6 +1618,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 trigger_auto_memory=trigger_auto_memory,
                 message_id=message_id,
                 include_recent_images=include_recent_images,
+                delivery_sink=delivery_sink,
+                trigger_kind=trigger_kind,
             )
 
     async def generate_private_reply(
@@ -1613,6 +1628,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         user_id: int | str,
         sender_name: str,
         prompt: str,
+        delivery_sink=None,
+        trigger_kind: TriggerKind | None = None,
         image_urls: list[str] | None = None,
         recent_messages: list[dict[str, str]] | None = None,
         quoted_text: str = "",
@@ -1651,6 +1668,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 trigger_auto_memory=trigger_auto_memory,
                 message_id=message_id,
                 include_recent_images=include_recent_images,
+                delivery_sink=delivery_sink,
+                trigger_kind=trigger_kind,
             )
 
 

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -1093,7 +1093,6 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         recorder_rows_written: bool = False,
     ) -> dict[str, object]:
         current_identity = self._resolve_identities(str(chat_id)).resolve_user(user_id, sender_name)
-        recorder_rows_written = recorder_rows_written
         if store_user_message and not recorder_rows_written:
             raw_turn_parts: list[str] = []
             if normalized_quoted_text or normalized_quoted_image_urls:

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -38,7 +38,7 @@ from quickquip.llm.config import (
     provider_builtin_search_active,
 )
 from quickquip.llm.rendering import append_web_search_source_block
-from quickquip.llm.history_projection import project_loops
+from quickquip.llm.history_projection import project_loops_with_budget
 from quickquip.llm.request_budget import RequestBudgetExceeded, enforce_request_budget
 from quickquip.llm.agent_records import LoopStatus, TriggerKind
 from quickquip.llm.service_parts.agent_runtime import DeliveryAborted, TurnRecorder
@@ -1030,7 +1030,10 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         target = None
         if not provider.fallback_urls:
             target = build_response_owner(provider, primary_endpoint_url(provider, model), model)
-        result = project_loops(loaded, target=target, protocol=provider.protocol)
+        result = project_loops_with_budget(
+            loaded, target=target, protocol=provider.protocol,
+            budget_tokens=self.config.runtime.agent_replay_loop_tokens,
+        )
         for decision in result.decisions:
             if decision.reason is not None:
                 logger.info(

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -38,7 +38,7 @@ from quickquip.llm.config import (
     provider_builtin_search_active,
 )
 from quickquip.llm.rendering import append_web_search_source_block
-from quickquip.llm.history_projection import project_loops_with_budget
+from quickquip.llm.history_projection import HistoryProjectionError, project_loops_with_budget
 from quickquip.llm.request_budget import RequestBudgetExceeded, enforce_request_budget
 from quickquip.llm.agent_records import LoopStatus, TriggerKind
 from quickquip.llm.service_parts.agent_runtime import DeliveryAborted, TurnRecorder
@@ -439,6 +439,22 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         """绑定逐 Turn 交付出口（adapters 装配时调用）。"""
         self._delivery_sink = sink
 
+    def _build_request_guard(self, provider: ProviderConfig):
+        """逐轮预算门禁闭包（§8.3）：超限以 DeliveryAborted 终止 Loop。"""
+        from quickquip.llm.service_parts.agent_runtime import DeliveryAborted
+
+        def _guard(request: LLMRequest) -> None:
+            try:
+                enforce_request_budget(self.config, provider, request)
+            except RequestBudgetExceeded as exc:
+                logger.warning(
+                    "request budget exceeded mid-loop provider=%s model=%s: %s",
+                    provider.id, request.model, exc,
+                )
+                raise DeliveryAborted("request_budget_exceeded") from exc
+
+        return _guard
+
     def maintain_agent_retention(self, scope_key: str) -> None:
         """D5 保留维护（§8.4）：Loop 关闭后调用，按三上限清理最旧完整 Loop。
 
@@ -748,12 +764,14 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         request: LLMRequest,
         context: ToolExecutionContext,
         turn_recorder: TurnRecorder | None = None,
+        request_guard=None,
     ):
         return await run_tool_call_loop(
             provider=provider,
             request=request,
             context=context,
             turn_recorder=turn_recorder,
+            request_guard=request_guard,
             build_provider_client=build_provider_client,
             tool_registry=self.tool_registry,
             runtime_config=self.config.runtime,
@@ -1030,10 +1048,19 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         target = None
         if not provider.fallback_urls:
             target = build_response_owner(provider, primary_endpoint_url(provider, model), model)
-        result = project_loops_with_budget(
-            loaded, target=target, protocol=provider.protocol,
-            budget_tokens=self.config.runtime.agent_replay_loop_tokens,
-        )
+        try:
+            result = project_loops_with_budget(
+                loaded, target=target, protocol=provider.protocol,
+                budget_tokens=self.config.runtime.agent_replay_loop_tokens,
+            )
+        except HistoryProjectionError:
+            # 结构损坏不砖化会话（Deep-CR 兜底）：该请求退回行渲染，损坏
+            # Loop 留待运维检查；工具事实本轮缺席属可观测降级。
+            logger.exception(
+                "history projection failed structurally scope=%s loops=%d；本轮退回行渲染",
+                scope_key, len(loaded),
+            )
+            return {}
         for decision in result.decisions:
             if decision.reason is not None:
                 logger.info(
@@ -1063,9 +1090,10 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         normalized_forward_image_urls: list[str],
         image_descriptions: list[ImageDescription] | None = None,
         tool_context: ToolExecutionContext,
+        recorder_rows_written: bool = False,
     ) -> dict[str, object]:
         current_identity = self._resolve_identities(str(chat_id)).resolve_user(user_id, sender_name)
-        recorder_rows_written = getattr(self, "_active_recorder", None) is not None
+        recorder_rows_written = recorder_rows_written
         if store_user_message and not recorder_rows_written:
             raw_turn_parts: list[str] = []
             if normalized_quoted_text or normalized_quoted_image_urls:
@@ -1447,8 +1475,6 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 # 同 _persist_turn_and_build_reply 的落库口径：他人近期图注不落触发者名下。
                 image_descriptions=[d for d in image_descriptions if not d.context_label.startswith(RECENT_IMAGE_CONTEXT_PREFIX)] or None,
             )
-            # 门控标记：_persist_turn_and_build_reply 据此跳过重复行写入。
-            self._active_recorder = recorder
             with (
                 usage_scope("chat", group_id=scope_key, persona_id=settings.persona_id or None),
                 envelope_meter(estimate_tokens(turn_envelope)),
@@ -1473,6 +1499,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                     request=request,
                     context=tool_context,
                     turn_recorder=recorder,
+                    request_guard=self._build_request_guard(provider),
                 )
         except DeliveryAborted as exc:
             if recorder is not None:
@@ -1559,6 +1586,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             # 当轮渲染仍走完整 image_descriptions（带「近期上下文图片 N」标签）
             image_descriptions=[d for d in image_descriptions if not d.context_label.startswith(RECENT_IMAGE_CONTEXT_PREFIX)] or None,
             tool_context=tool_context,
+            recorder_rows_written=recorder is not None,
         )
         if recorder is not None:
             recorder.close(LoopStatus.COMPLETED, None)
@@ -1567,7 +1595,6 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 result_payload = dict(result_payload)
                 result_payload["agent_turn_row_id"] = recorder.final_turn_record.message_row_id
                 result_payload["scope_key"] = scope_key
-        self._active_recorder = None
         if self.config.runtime.agent_delivery_enabled:
             # 逐 Turn 模式：正文已由 sink 交付，reply 不再二次发送（§5.1）。
             result_payload = dict(result_payload)

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -40,6 +40,9 @@ from quickquip.llm.config import (
 from quickquip.llm.rendering import append_web_search_source_block
 from quickquip.llm.history_projection import project_loops
 from quickquip.llm.request_budget import RequestBudgetExceeded, enforce_request_budget
+from quickquip.llm.agent_records import LoopStatus, TriggerKind
+from quickquip.llm.service_parts.agent_runtime import DeliveryAborted, TurnRecorder
+from quickquip.llm.store_parts.agent_records import AgentStoreError
 from quickquip.sts.config import (
     DEFECTIFY_RATE_LIMIT_KEY,
     DEFECTIFY_RULE_NAME,
@@ -230,6 +233,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         self.mcp_manager = MCPClientManager()
         self.image_preprocessor = image_preprocessor
         self.stats_tracker: "GroupStatsTracker | None" = None
+        # 逐 Turn 交付出口（§5.1）：由适配层绑定；enabled 且缺失时属编程错误。
+        self._delivery_sink = None
         self.rule_switch: "GroupRuleSwitch | None" = None
         self.recent_message_buffer: "RecentMessageBuffer | None" = None
         self._init_mcp_lifecycle()
@@ -429,6 +434,10 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         return await run_quick_judge_detailed(
             self.config, prompt, max_tokens, client_builder=build_provider_client
         )
+
+    def bind_delivery_sink(self, sink) -> None:
+        """绑定逐 Turn 交付出口（adapters 装配时调用）。"""
+        self._delivery_sink = sink
 
     def maintain_agent_retention(self, scope_key: str) -> None:
         """D5 保留维护（§8.4）：Loop 关闭后调用，按三上限清理最旧完整 Loop。
@@ -649,17 +658,97 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             _push(item.get("user_id", ""), item.get("sender_name", ""), item.get("canonical_name", ""))
         return participants
 
+    def _begin_agent_recorder(
+        self,
+        *,
+        scope_key: str,
+        chat_type: str,
+        user_id: int | str,
+        sender_name: str,
+        stored_prompt: str,
+        message_id: str | None,
+        store_user_message: bool,
+        normalized_quoted_text: str,
+        normalized_quoted_image_urls: list[str],
+        normalized_forward_text: str,
+        normalized_forward_image_urls: list[str],
+        image_descriptions: list[ImageDescription] | None,
+    ):
+        """创建 Loop 与 user 触发行（§5.3.1），返回 TurnRecorder。
+
+        合成触发（``store_user_message=False``）与 store 不可用时本期保持
+        旧路径（无 Loop 记录），属已记录的渐进边界。
+        """
+        from quickquip.llm.service_parts.agent_runtime import RecorderConfig, TurnRecorder
+        from quickquip.llm.store_parts.agent_records import UserTriggerPayload
+
+        if not store_user_message or self.store is None:
+            return None
+        current_identity = self._resolve_identities(scope_key.removeprefix("private:")).resolve_user(
+            user_id, sender_name
+        )
+        raw_turn_parts: list[str] = []
+        if normalized_quoted_text or normalized_quoted_image_urls:
+            q_text = normalized_quoted_text or f"[图片 {len(normalized_quoted_image_urls)} 张]"
+            q_suffix = f" [附图 {len(normalized_quoted_image_urls)} 张]" if normalized_quoted_image_urls else ""
+            raw_turn_parts.append(f"[引用] {q_text}{q_suffix}")
+        if normalized_forward_text or normalized_forward_image_urls:
+            fw_text = normalized_forward_text or "[合并转发消息]"
+            fw_suffix = f" [附图 {len(normalized_forward_image_urls)} 张]" if normalized_forward_image_urls else ""
+            raw_turn_parts.append(fw_text + fw_suffix)
+        if image_descriptions:
+            caption_count, caption_blob = _image_caption_blob(image_descriptions)
+            if caption_count:
+                raw_turn_parts.append(f"[图片 {caption_count} 张：{caption_blob}]")
+        raw_turn_parts.append(stored_prompt)
+        generation, _ = self.store.agent_scope_state(scope_key)
+        trigger = (
+            TriggerKind.PRIVATE_DIRECT if chat_type == "private" else TriggerKind.GROUP_DIRECT
+        )
+        try:
+            handle = self.store.begin_loop(
+                scope_key,
+                generation,
+                trigger,
+                UserTriggerPayload(
+                    user_id=str(user_id),
+                    sender_name=sender_name,
+                    canonical_name=current_identity.canonical_name,
+                    content=stored_prompt,
+                    raw_content="\n".join(raw_turn_parts),
+                    message_id=str(message_id) if message_id else None,
+                ),
+            )
+        except AgentStoreError:
+            logger.exception("begin_loop 失败 scope=%s，本轮退回无记录路径", scope_key)
+            return None
+        runtime = self.config.runtime
+        return TurnRecorder(
+            store=self.store,
+            handle=handle,
+            config=RecorderConfig(
+                agent_delivery_enabled=runtime.agent_delivery_enabled,
+                reply_split_threshold_chars=runtime.reply_split_threshold_chars,
+                reply_chunk_max_chars=runtime.reply_chunk_max_chars,
+                reply_max_chunks_per_loop=runtime.reply_max_chunks_per_loop,
+            ),
+            sink=self._delivery_sink,
+            sensitive_scan=_get_sensitive_filter().scan if _get_sensitive_filter().is_loaded else None,
+        )
+
     async def _run_tool_call_loop(
         self,
         *,
         provider: ProviderConfig,
         request: LLMRequest,
         context: ToolExecutionContext,
+        turn_recorder: TurnRecorder | None = None,
     ):
         return await run_tool_call_loop(
             provider=provider,
             request=request,
             context=context,
+            turn_recorder=turn_recorder,
             build_provider_client=build_provider_client,
             tool_registry=self.tool_registry,
             runtime_config=self.config.runtime,
@@ -968,7 +1057,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         tool_context: ToolExecutionContext,
     ) -> dict[str, object]:
         current_identity = self._resolve_identities(str(chat_id)).resolve_user(user_id, sender_name)
-        if store_user_message:
+        recorder_rows_written = getattr(self, "_active_recorder", None) is not None
+        if store_user_message and not recorder_rows_written:
             raw_turn_parts: list[str] = []
             if normalized_quoted_text or normalized_quoted_image_urls:
                 q_text = normalized_quoted_text or f"[图片 {len(normalized_quoted_image_urls)} 张]"
@@ -996,7 +1086,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 message_id=str(message_id) if message_id else None,
                 raw_content=raw_turn,
             )
-        self.store.append_conversation_message(scope_key, None, "assistant", text)
+        if not recorder_rows_written:
+            self.store.append_conversation_message(scope_key, None, "assistant", text)
         # 纪元裁剪：floor = 该 scope 所有纪元键的最老锚点（None = 只按硬上限兜底，
         # 绝不按窗口重估删行——重启后懒初始化还要读旧行）
         self.store.crop_conversation_messages(
@@ -1325,11 +1416,29 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             chat_type=chat_type,
         )
 
+        recorder: TurnRecorder | None = None
         try:
             # 拿到群级 persona 后把聊天主链路升级为带人格归因的 scope；
             # scope 生命周期与 provider 调用同处一个函数，退出即复位。
             # group_id 用 scope_key（群聊 = str(chat_id)，私聊 = private:{id}），
             # 与 auto_memory 等派生调用的归因口径一致。
+            recorder = self._begin_agent_recorder(
+                scope_key=scope_key,
+                chat_type=chat_type,
+                user_id=user_id,
+                sender_name=sender_name,
+                stored_prompt=stored_prompt,
+                message_id=message_id,
+                store_user_message=store_user_message,
+                normalized_quoted_text=normalized_quoted_text,
+                normalized_quoted_image_urls=normalized_quoted_image_urls,
+                normalized_forward_text=normalized_forward_text,
+                normalized_forward_image_urls=normalized_forward_image_urls,
+                # 同 _persist_turn_and_build_reply 的落库口径：他人近期图注不落触发者名下。
+                image_descriptions=[d for d in image_descriptions if not d.context_label.startswith(RECENT_IMAGE_CONTEXT_PREFIX)] or None,
+            )
+            # 门控标记：_persist_turn_and_build_reply 据此跳过重复行写入。
+            self._active_recorder = recorder
             with (
                 usage_scope("chat", group_id=scope_key, persona_id=settings.persona_id or None),
                 envelope_meter(estimate_tokens(turn_envelope)),
@@ -1353,8 +1462,22 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                     provider=provider,
                     request=request,
                     context=tool_context,
+                    turn_recorder=recorder,
                 )
+        except DeliveryAborted as exc:
+            if recorder is not None:
+                recorder.close(LoopStatus.INTERRUPTED, str(exc) or "delivery_aborted")
+            return {
+                "reply": "" if self.config.runtime.agent_delivery_enabled else "本次回复未确认送达，已停止后续生成。",
+                "rate_limit_key": LLM_RULE_NAME,
+                "rule_name": LLM_RULE_NAME,
+                "llm_used": True,
+                "provider_id": provider.id,
+                "model": request.model,
+            }
         except LLMProviderError as exc:
+            if recorder is not None:
+                recorder.close(LoopStatus.FAILED, "provider_error")
             return {
                 "reply": f"LLM 调用失败：{exc}",
                 "rate_limit_key": LLM_RULE_NAME,
@@ -1366,6 +1489,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 "images": outbound_images_payload(tool_context),
             }
         except Exception as exc:
+            if recorder is not None:
+                recorder.close(LoopStatus.FAILED, "exception")
             return {
                 "reply": f"LLM 调用异常：{exc}",
                 "rate_limit_key": LLM_RULE_NAME,
@@ -1402,7 +1527,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 text = DEFAULT_OUTPUT_FALLBACK
 
         # ── persistence + auto-memory dispatch + reply assembly ──────
-        return self._persist_turn_and_build_reply(
+        result_payload = self._persist_turn_and_build_reply(
             chat_id=chat_id,
             user_id=user_id,
             sender_name=sender_name,
@@ -1425,6 +1550,15 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             image_descriptions=[d for d in image_descriptions if not d.context_label.startswith(RECENT_IMAGE_CONTEXT_PREFIX)] or None,
             tool_context=tool_context,
         )
+        if recorder is not None:
+            recorder.close(LoopStatus.COMPLETED, None)
+            self.maintain_agent_retention(scope_key)
+        self._active_recorder = None
+        if self.config.runtime.agent_delivery_enabled:
+            # 逐 Turn 模式：正文已由 sink 交付，reply 不再二次发送（§5.1）。
+            result_payload = dict(result_payload)
+            result_payload["reply"] = ""
+        return result_payload
 
     async def generate_reply(
         self,

--- a/src/quickquip/llm/service_parts/agent_runtime.py
+++ b/src/quickquip/llm/service_parts/agent_runtime.py
@@ -1,0 +1,349 @@
+"""Agent Loop 运行时记录与交付（§5.3/§6）：service 接入层。
+
+一次外部触发 = 一个 Loop。每个完整模型响应形成一个 Turn：清理正文 →
+原子提交（Turn + 工具声明 + 交付计划）→ 按序发送文字 Chunk → 依模型
+原顺序执行工具 batch → 关闭。D3：首个 failed/unknown 交付即终止后续
+发送、工具启动与生成。
+
+上线开关（§6.3）：``agent_delivery_enabled=false`` 时仍记录全部 Turn 与
+工具，非最终正文标记 ``suppressed_by_policy``，最终正文由适配层按现有
+单次交付方式发送。
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Protocol
+
+from quickquip.llm.agent_records import (
+    AGENT_RECORD_VERSION,
+    DeliveryKind,
+    DeliveryPlanItem,
+    DeliveryReceipt,
+    DeliveryStatus,
+    DeliverySummary,
+    LoopStatus,
+    TextPolicy,
+    ToolDeclarationRecord,
+    ToolExecutionStatus,
+    ToolResultRecord,
+    ToolSkipReason,
+    TurnOutputStatus,
+    TurnResponseRecord,
+    new_agent_id,
+)
+from quickquip.llm.delivery import SplitParams, plan_text_chunks
+from quickquip.llm.provider import LLMResponse, strip_leading_reasoning_content
+from quickquip.llm.store_parts.agent_records import (
+    LoopHandle,
+    LoopRecordBudgetExceeded,
+    ScopeGenerationMismatch,
+    TurnRecord,
+)
+from quickquip.llm.tools import LLMToolResult
+
+if TYPE_CHECKING:
+    from quickquip.llm.store import LLMStore
+
+logger = logging.getLogger(__name__)
+
+
+class DeliverySink(Protocol):
+    """交付出口（§5.1）：接收稳定 delivery ID 与冻结 payload，返回回执。"""
+
+    async def __call__(self, delivery_id: str, payload: dict[str, Any]) -> DeliveryReceipt: ...
+
+
+class CollectingDeliverySink:
+    """测试用收集 sink；生产聊天路径缺失 sink 属编程错误。"""
+
+    def __init__(self) -> None:
+        self.deliveries: list[tuple[str, dict[str, Any]]] = []
+        self.receipts: list[DeliveryReceipt] = []
+
+    async def __call__(self, delivery_id: str, payload: dict[str, Any]) -> DeliveryReceipt:
+        self.deliveries.append((delivery_id, payload))
+        receipt = DeliveryReceipt(
+            status=DeliveryStatus.SENT, message_id=f"collect-{len(self.deliveries)}"
+        )
+        self.receipts.append(receipt)
+        return receipt
+
+
+class DeliveryAborted(RuntimeError):
+    """D3 终止信号：后续生成、工具启动与交付全部停止。"""
+
+
+@dataclass(slots=True)
+class RecorderConfig:
+    agent_delivery_enabled: bool = False
+    reply_split_threshold_chars: int = 800
+    reply_chunk_max_chars: int = 1200
+    reply_max_chunks_per_loop: int = 64
+
+    def split_params(self) -> SplitParams:
+        params = SplitParams(
+            threshold=self.reply_split_threshold_chars,
+            chunk_max=self.reply_chunk_max_chars,
+        )
+        params.validate()
+        return params
+
+
+class TurnRecorder:
+    """单 Loop 的记录器：由 service 持有，tool_loop 通过钩子驱动。
+
+    不做 scope 排队（沿用入口限流）；generation 屏障由 store 写入校验
+    兜底（ScopeGenerationMismatch → Loop 关闭为 interrupted）。
+    """
+
+    def __init__(
+        self,
+        *,
+        store: "LLMStore",
+        handle: LoopHandle,
+        config: RecorderConfig,
+        sink: DeliverySink | None,
+        sensitive_scan=None,
+    ):
+        self._store = store
+        self._handle = handle
+        self._config = config
+        self._sink = sink if config.agent_delivery_enabled else None
+        self._sensitive_scan = sensitive_scan
+        self._delivery_count = 0
+        self._delivery_stats = {"sent": 0, "failed": 0, "unknown": 0, "skipped": 0, "suppressed": 0}
+        self._committed_turns = 0
+        self._final_turn_record: TurnRecord | None = None
+        self._terminal_reason: str | None = None
+
+    @property
+    def handle(self) -> LoopHandle:
+        return self._handle
+
+    @property
+    def final_turn_record(self) -> TurnRecord | None:
+        return self._final_turn_record
+
+    def _clean_text(self, raw: str) -> str:
+        text = strip_leading_reasoning_content(raw or "")
+        text = re.sub(r"\n{3,}", "\n\n", text).strip()
+        return text
+
+    def _scrubbed_text(self, raw: str) -> tuple[str, TextPolicy]:
+        text = self._clean_text(raw)
+        if self._sensitive_scan is not None:
+            scan = self._sensitive_scan(text)
+            if scan.blocked:
+                return "本次回复内容未能通过安全检查，已替换。", TextPolicy.REPLACED_BY_FILTER
+        return text, TextPolicy.ALLOWED
+
+    def _plan_deliveries(
+        self, turn_id: str, text: str, *, is_final: bool
+    ) -> list[DeliveryPlanItem]:
+        policy = self._config
+        items: list[DeliveryPlanItem] = []
+        if not text:
+            return items
+        if not policy.agent_delivery_enabled and not is_final:
+            # 关闭开关：非最终正文只记 suppressed（§6.3）。
+            items.append(
+                DeliveryPlanItem(
+                    delivery_id=new_agent_id("dlv"), kind=DeliveryKind.TEXT_CHUNK,
+                    turn_id=turn_id, chunk_index=0, source_start=0, source_end=len(text),
+                )
+            )
+            self._delivery_stats["suppressed"] += 1
+            return items
+        if not policy.agent_delivery_enabled:
+            # 最终正文沿现有单次交付，交付记录由 receipt 回填阶段写入。
+            return items
+        if self._sink is None:
+            raise RuntimeError("agent_delivery_enabled=true 但缺少 DeliverySink（编程错误）")
+        chunks, limit_reason = plan_text_chunks(
+            text,
+            policy.split_params(),
+            reserved_delivery_slots=self._delivery_count,
+            max_chunks=policy.reply_max_chunks_per_loop,
+        )
+        if limit_reason == "delivery_limit":
+            self._terminal_reason = "delivery_limit"
+            return []
+        for chunk in chunks:
+            items.append(
+                DeliveryPlanItem(
+                    delivery_id=new_agent_id("dlv"),
+                    kind=DeliveryKind.TEXT_CHUNK,
+                    turn_id=turn_id,
+                    chunk_index=chunk.chunk_index,
+                    source_start=chunk.start,
+                    source_end=chunk.end,
+                )
+            )
+        return items
+
+    def on_turn(
+        self,
+        response: LLMResponse,
+        *,
+        declared_calls: list,
+        executable_calls: list,
+        has_more_rounds: bool,
+    ) -> dict[str, str]:
+        """完整响应到达后的原子提交（§5.3.4-5）。
+
+        ``declared_calls`` = 响应声明的全部调用（含超出执行预算的），
+        ``executable_calls`` = 本轮实际执行子集；差集由 ``on_tool_skipped``
+        记 not_executed。预算/字节触顶抛 ``DeliveryAborted``；文字交付由
+        ``deliver_turn`` 在工具执行前单独驱动（§5.3.6）。
+        """
+        text, text_policy = self._scrubbed_text(response.text)
+        is_final = not executable_calls or not has_more_rounds
+        turn_id = new_agent_id("turn")
+        output_status = (
+            TurnOutputStatus.VISIBLE if text else
+            (TurnOutputStatus.NO_VISIBLE_OUTPUT if is_final else TurnOutputStatus.EMPTY)
+        )
+        declarations = [
+            ToolDeclarationRecord(
+                execution_id=new_agent_id("exec"),
+                call_index=index,
+                provider_call_id=call.id,
+                tool_name=call.name,
+                arguments_json=call.arguments_json,
+                arguments_omission_reason=None,
+            )
+            for index, call in enumerate(declared_calls)
+        ]
+        execution_ids = {d.provider_call_id: d.execution_id for d in declarations}
+        parts: list[dict[str, Any]] = []
+        if text:
+            parts.append({"type": "text_ref", "start": 0, "end": len(text), "origin": "model"})
+        for declaration in declarations:
+            parts.append({"type": "tool_ref", "execution_id": declaration.execution_id})
+        native_state = None
+        if response.native_blocks:
+            native_state = {
+                "version": AGENT_RECORD_VERSION,
+                "owner": _owner_payload(response.owner),
+                "blocks": response.native_blocks,
+            }
+        plan = self._plan_deliveries(turn_id, text, is_final=is_final)
+        record = self._store.commit_turn(
+            self._handle,
+            TurnResponseRecord(
+                text=text,
+                text_policy=text_policy,
+                output_status=output_status,
+                finish_reason=response.finish_reason,
+                parts=tuple(parts),
+                native_state=native_state,
+                native_omission_reason=None,
+                owner=_owner_payload(response.owner),
+            ),
+            declarations,
+            plan,
+            turn_id=turn_id,
+        )
+        self._committed_turns += 1
+        if is_final or not has_more_rounds:
+            self._final_turn_record = record
+        # 关闭开关的非最终 suppressed 交付落 planned 即收敛为 suppressed。
+        if not self._config.agent_delivery_enabled and not is_final:
+            for delivery_id in record.delivery_ids:
+                self._store.suppress_delivery(self._handle, delivery_id)
+        if self._terminal_reason == "delivery_limit":
+            raise DeliveryAborted("delivery_limit")
+        self._pending_record = record
+        self._pending_text = text
+        self._pending_plan = {item.delivery_id: item for item in plan}
+        return execution_ids
+
+    async def deliver_turn(self) -> None:
+        """提交后的文字 Chunk 交付（§5.3.6）：先于所属工具执行。"""
+        record = getattr(self, "_pending_record", None)
+        text = getattr(self, "_pending_text", "")
+        plan = getattr(self, "_pending_plan", {})
+        self._pending_record = None
+        self._pending_text = ""
+        self._pending_plan = {}
+        if record is None or not self._config.agent_delivery_enabled or self._sink is None:
+            return
+        for delivery_id in record.delivery_ids:
+            if self._terminal_reason is not None:
+                break
+            item = plan.get(delivery_id)
+            chunk_text = text[item.source_start : item.source_end] if item else text
+            attempt = self._store.start_delivery(self._handle, delivery_id)
+            receipt = await self._sink(delivery_id, {"text": chunk_text})
+            if receipt.status == DeliveryStatus.SENT and receipt.message_id:
+                self._store.set_first_chunk_message_id(record.message_row_id, receipt.message_id)
+            self._store.finish_delivery(attempt, receipt)
+            self._delivery_stats[str(receipt.status)] = self._delivery_stats.get(str(receipt.status), 0) + 1
+            self._delivery_count += 1
+            if receipt.status in (DeliveryStatus.FAILED, DeliveryStatus.UNKNOWN):
+                # D3：终止当前 Loop 后续生成、工具启动和交付。
+                self._terminal_reason = f"delivery_{receipt.status}"
+                raise DeliveryAborted(self._terminal_reason)
+
+    def on_tool_started(self, execution_id: str) -> None:
+        try:
+            self._store.mark_tool_started(self._handle, execution_id)
+        except (ScopeGenerationMismatch, LoopRecordBudgetExceeded) as exc:
+            raise DeliveryAborted(str(exc)) from exc
+
+    def on_tool_finished(
+        self,
+        execution_id: str,
+        result: LLMToolResult | None,
+        *,
+        is_error: bool = False,
+        retention: str = "bounded",
+        media: tuple[dict[str, Any], ...] = (),
+    ) -> None:
+        if result is not None:
+            content_bytes = len(result.content.encode("utf-8"))
+            self._store.finish_tool(
+                self._handle,
+                execution_id,
+                ToolResultRecord(
+                    content=result.content,
+                    is_error=is_error or result.is_error,
+                    original_bytes=content_bytes,
+                ),
+                result_retention=retention,
+                outbound_media=media,
+            )
+        # not_executed 终态由 on_tool_skipped 显式写入。
+
+    def on_tool_skipped(self, execution_id: str, reason: ToolSkipReason) -> None:
+        self._store.finish_tool(
+            self._handle, execution_id, None,
+            status=ToolExecutionStatus.NOT_EXECUTED, skip_reason=reason,
+        )
+
+    def close(self, status: LoopStatus, reason: str | None) -> None:
+        try:
+            self._store.close_loop(self._handle, status, reason or self._terminal_reason)
+        except Exception:
+            logger.exception("close_loop 失败 loop=%s", self._handle.loop_id)
+
+    def summary(self) -> DeliverySummary:
+        return DeliverySummary(
+            total=self._delivery_count + self._delivery_stats["suppressed"],
+            **{k: v for k, v in self._delivery_stats.items()},
+        )
+
+
+def _owner_payload(owner) -> dict[str, Any] | None:
+    if owner is None:
+        return None
+    return {
+        "provider_id": owner.provider_id,
+        "protocol": owner.protocol,
+        "wire_model": owner.wire_model,
+        "display_model": owner.display_model,
+        "endpoint_fingerprint": owner.endpoint_fingerprint,
+        "profile_fingerprint": owner.profile_fingerprint,
+    }

--- a/src/quickquip/llm/service_parts/agent_runtime.py
+++ b/src/quickquip/llm/service_parts/agent_runtime.py
@@ -106,7 +106,6 @@ class TurnRecorder:
         self._sensitive_scan = sensitive_scan
         self._delivery_count = 0
         self._delivery_stats = {"sent": 0, "failed": 0, "unknown": 0, "skipped": 0, "suppressed": 0}
-        self._committed_turns = 0
         self._final_turn_record: TurnRecord | None = None
         self._terminal_reason: str | None = None
 
@@ -256,7 +255,6 @@ class TurnRecorder:
             plan,
             turn_id=turn_id,
         )
-        self._committed_turns += 1
         if is_final or not has_more_rounds:
             self._final_turn_record = record
         # 关闭开关的非最终 suppressed 交付落 planned 即收敛为 suppressed。

--- a/src/quickquip/llm/service_parts/agent_runtime.py
+++ b/src/quickquip/llm/service_parts/agent_runtime.py
@@ -16,6 +16,8 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
+import json
+
 from quickquip.llm.agent_records import (
     AGENT_RECORD_VERSION,
     DeliveryKind,
@@ -23,6 +25,8 @@ from quickquip.llm.agent_records import (
     DeliveryReceipt,
     DeliveryStatus,
     DeliverySummary,
+    MAX_NATIVE_STATE_BYTES,
+    NativeOmissionReason,
     LoopStatus,
     TextPolicy,
     ToolDeclarationRecord,
@@ -33,7 +37,7 @@ from quickquip.llm.agent_records import (
     TurnResponseRecord,
     new_agent_id,
 )
-from quickquip.llm.delivery import SplitParams, plan_text_chunks
+from quickquip.llm.delivery import SplitLimitError, SplitParams, plan_text_chunks
 from quickquip.llm.provider import LLMResponse, strip_leading_reasoning_content
 from quickquip.llm.store_parts.agent_records import (
     LoopHandle,
@@ -55,20 +59,8 @@ class DeliverySink(Protocol):
     async def __call__(self, delivery_id: str, payload: dict[str, Any]) -> DeliveryReceipt: ...
 
 
-class CollectingDeliverySink:
-    """测试用收集 sink；生产聊天路径缺失 sink 属编程错误。"""
-
-    def __init__(self) -> None:
-        self.deliveries: list[tuple[str, dict[str, Any]]] = []
-        self.receipts: list[DeliveryReceipt] = []
-
-    async def __call__(self, delivery_id: str, payload: dict[str, Any]) -> DeliveryReceipt:
-        self.deliveries.append((delivery_id, payload))
-        receipt = DeliveryReceipt(
-            status=DeliveryStatus.SENT, message_id=f"collect-{len(self.deliveries)}"
-        )
-        self.receipts.append(receipt)
-        return receipt
+def _dumps_compact(payload) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
 
 class DeliveryAborted(RuntimeError):
@@ -161,12 +153,18 @@ class TurnRecorder:
             return items
         if self._sink is None:
             raise RuntimeError("agent_delivery_enabled=true 但缺少 DeliverySink（编程错误）")
-        chunks, limit_reason = plan_text_chunks(
-            text,
-            policy.split_params(),
-            reserved_delivery_slots=self._delivery_count,
-            max_chunks=policy.reply_max_chunks_per_loop,
-        )
+        try:
+            chunks, limit_reason = plan_text_chunks(
+                text,
+                policy.split_params(),
+                reserved_delivery_slots=self._delivery_count,
+                max_chunks=policy.reply_max_chunks_per_loop,
+            )
+        except SplitLimitError:
+            # §6.1.5：单个 grapheme 超限——拒绝该交付计划并明确终止，
+            # 不让内部 ValueError 以「LLM 调用异常」面世。
+            self._terminal_reason = "split_limit"
+            raise DeliveryAborted("split_limit") from None
         if limit_reason == "delivery_limit":
             self._terminal_reason = "delivery_limit"
             return []
@@ -223,12 +221,24 @@ class TurnRecorder:
         for declaration in declarations:
             parts.append({"type": "tool_ref", "execution_id": declaration.execution_id})
         native_state = None
+        native_omission = None
         if response.native_blocks:
-            native_state = {
+            candidate = {
                 "version": AGENT_RECORD_VERSION,
                 "owner": _owner_payload(response.owner),
                 "blocks": response.native_blocks,
             }
+            encoded = _dumps_compact(candidate)
+            if len(encoded.encode("utf-8")) > MAX_NATIVE_STATE_BYTES:
+                # 存储契约预检（§2 MAX_NATIVE_STATE_BYTES）：超限省略原生
+                # 副本、保留通用事实，而不是让提交抛错炸掉整条回复。
+                native_omission = NativeOmissionReason.SIZE_LIMIT
+                logger.warning(
+                    "native state exceeds %d bytes; omitting blocks for turn %s",
+                    MAX_NATIVE_STATE_BYTES, turn_id,
+                )
+            else:
+                native_state = candidate
         plan = self._plan_deliveries(turn_id, text, is_final=is_final)
         record = self._store.commit_turn(
             self._handle,
@@ -239,7 +249,7 @@ class TurnRecorder:
                 finish_reason=response.finish_reason,
                 parts=tuple(parts),
                 native_state=native_state,
-                native_omission_reason=None,
+                native_omission_reason=native_omission,
                 owner=_owner_payload(response.owner),
             ),
             declarations,
@@ -304,13 +314,18 @@ class TurnRecorder:
     ) -> None:
         if result is not None:
             content_bytes = len(result.content.encode("utf-8"))
+            failed = is_error or result.is_error
             self._store.finish_tool(
                 self._handle,
                 execution_id,
                 ToolResultRecord(
                     content=result.content,
-                    is_error=is_error or result.is_error,
+                    is_error=failed,
                     original_bytes=content_bytes,
+                    # 重放按 status 区分 error 语义（§7.2 冻结表达）：
+                    # is_error 只进 result_json 会让 functionResponse 丢失
+                    # 原链路的 is_error 标记。
+                    status=ToolExecutionStatus.FAILED if failed else ToolExecutionStatus.SUCCEEDED,
                 ),
                 result_retention=retention,
                 outbound_media=media,

--- a/src/quickquip/llm/service_parts/auto_memory.py
+++ b/src/quickquip/llm/service_parts/auto_memory.py
@@ -111,11 +111,20 @@ class AutoMemoryMixin:
         user_text: str,
         assistant_text: str,
         persona_id: str = "",
+        expected_generation: int | None = None,
     ) -> None:
         # persona 由调用方显式传入：create_task 复制的父 context 会被下面的
         # set_usage_scope 覆盖，不能依赖任务外 ContextVar 残留。
         set_usage_scope("auto_memory", group_id=scope_key, persona_id=persona_id or None)
         try:
+            # ── generation fencing（§10）────────────────────────────
+            # 任务在途期间清空/撤回会提升 scope generation；写入前重验，
+            # 迟到结果不得写回已清空的会话。
+            if expected_generation is not None:
+                current_generation, _ = self.store.agent_scope_state(scope_key)
+                if current_generation != expected_generation:
+                    return
+
             # ── quality gates ──────────────────────────────────────
             if not (user_text.strip() and assistant_text.strip()):
                 return
@@ -202,6 +211,11 @@ class AutoMemoryMixin:
                     continue
                 if _is_duplicate_memory(content, existing_contents):
                     continue
+                if expected_generation is not None:
+                    # 写入侧二次重验（§10）：判定期可能又发生了清空/撤回。
+                    current_generation, _ = self.store.agent_scope_state(scope_key)
+                    if current_generation != expected_generation:
+                        return
                 self.store.add_memory(
                     scope_key,
                     content,

--- a/src/quickquip/llm/service_parts/state.py
+++ b/src/quickquip/llm/service_parts/state.py
@@ -327,16 +327,9 @@ class StateMixin:
         """撤回/删除入口（§9.2/§9.3）：先按 QQ receipt 定位确切 delivery。"""
         delivery = self.store.lookup_delivery(scope_key, message_id)
         if delivery is not None:
-            hit = False
-            if delivery.get("kind") == "text_chunk" and delivery.get("recall_status") == "active":
-                hit = self.store.recall_delivery_chunk(scope_key, str(delivery["delivery_id"]))
-                if hit:
-                    self._bump_scope_generation(scope_key, HistoryMutation.RECALL)
-            else:
-                hit = self.store.recall_delivery_chunk(scope_key, str(delivery["delivery_id"]))
-            if self.recent_message_buffer:
-                self.recent_message_buffer.remove_by_message_id(scope_key, message_id)
+            hit = self.store.recall_delivery_chunk(scope_key, str(delivery["delivery_id"]))
             if hit:
+                self._bump_scope_generation(scope_key, HistoryMutation.RECALL)
                 return True
         # 兼容回退：按平台 message_id 匹配主表行（legacy 行/兼容列）。
         rows = self.store.conversation_rows_by_message_id(scope_key, message_id)
@@ -351,7 +344,7 @@ class StateMixin:
             self._bump_scope_generation(scope_key, HistoryMutation.DELETE)
         buf_deleted = (
             self.recent_message_buffer.remove_by_message_id(scope_key, message_id)
-            if self.recent_message_buffer
+            if self.recent_message_buffer and not delivery
             else False
         )
         return deleted_any or buf_deleted

--- a/src/quickquip/llm/service_parts/state.py
+++ b/src/quickquip/llm/service_parts/state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from quickquip.llm.config import ProviderConfig
 from quickquip.llm.epoch import EpochKey
 from quickquip.llm.service_parts.constants import MAX_MEMORY_RETRIEVAL_ITEMS, MAX_STORED_MEMORY_ITEMS
+from quickquip.llm.store_parts.agent_records import HistoryMutation
 
 
 class StateMixin:
@@ -37,6 +38,12 @@ class StateMixin:
                 created_at=created_at,
             )
             self.store.archive_conversation_messages(user_id_str, archive_number)
+            # 整 Loop 迁移（§9.4）：Loop/Turn/delivery ID 与时间不变，
+            # 双侧 scope generation 增长，两侧 buffer/epoch 由 clear/调用方清理。
+            self.store.migrate_loops_between_scopes(
+                scope_key, f"archive:{user_id_str}:{archive_number}"
+            )
+            self._epochs.reset_scope(scope_key)
         else:
             self.clear_context(user_id, chat_type="private")
 
@@ -60,6 +67,10 @@ class StateMixin:
         self.clear_context(user_id, chat_type="private")
 
         self.store.restore_conversation_messages(user_id_str, archive_number)
+        # 恢复同样走整 Loop 迁移（§9.4）；clear_context 已清目标侧 buffer/epoch。
+        self.store.migrate_loops_between_scopes(
+            f"archive:{user_id_str}:{archive_number}", scope_key
+        )
         self._session_presets.pop(scope_key, None)
         preset = archive.get("preset") or ""
         if preset:
@@ -93,6 +104,8 @@ class StateMixin:
         return "\n".join(lines)
 
     def delete_session_archive_for_user(self, user_id: int | str, archive_number: int) -> bool:
+        archive_key = f"archive:{str(user_id)}:{archive_number}"
+        self.store.delete_loops_for_scope(archive_key)
         return self.store.delete_session_archive(str(user_id), archive_number)
 
     def get_session_preset(self, scope_key: str) -> str:
@@ -289,18 +302,54 @@ class StateMixin:
     def clear_context(self, group_id: int | str, chat_type: str = "group") -> int:
         scope_key = self.build_chat_scope_key(group_id, chat_type)
         deleted = self.store.clear_conversation_messages(scope_key)
+        # Agent 执行记录随域清理（§9.3）：主表行删除后侧表不能留孤儿。
+        self.store.delete_loops_for_scope(scope_key)
         # 短期上下文 = 持久会话库 + 进程内最近消息缓冲 + 会话纪元锚点；只清前者
         # 会让 build_messages 继续把缓冲拼进提示词，或让纪元锚点指向已删除的行，
         # 模型仍然"看得见"历史。三件齐清（私聊会话 start/end/resume 也走这里）。
         if self.recent_message_buffer:
             self.recent_message_buffer.clear_scope(scope_key)
         self._epochs.reset_scope(scope_key)
+        self._bump_scope_generation(scope_key, HistoryMutation.CLEAR)
         return deleted
+
+    def _bump_scope_generation(self, scope_key: str, mutation: str) -> None:
+        """generation/revision 屏障（§4.2）：清空后迟到结果不得新建内容。"""
+        _, revision = self.store.agent_scope_state(scope_key)
+        self.store.mutate_history(scope_key, revision, mutation)
 
     def clear_group_context(self, group_id: int | str) -> int:
         return self.clear_context(group_id, chat_type="group")
 
     def delete_message_from_context(self, scope_key: str, message_id: str) -> bool:
-        db_deleted = self.store.delete_conversation_message_by_message_id(scope_key, message_id)
-        buf_deleted = self.recent_message_buffer.remove_by_message_id(scope_key, message_id) if self.recent_message_buffer else False
-        return db_deleted > 0 or buf_deleted
+        """撤回/删除入口（§9.2/§9.3）：先按 QQ receipt 定位确切 delivery。"""
+        delivery = self.store.lookup_delivery(scope_key, message_id)
+        if delivery is not None:
+            hit = False
+            if delivery.get("kind") == "text_chunk" and delivery.get("recall_status") == "active":
+                hit = self.store.recall_delivery_chunk(scope_key, str(delivery["delivery_id"]))
+                if hit:
+                    self._bump_scope_generation(scope_key, HistoryMutation.RECALL)
+            else:
+                hit = self.store.recall_delivery_chunk(scope_key, str(delivery["delivery_id"]))
+            if self.recent_message_buffer:
+                self.recent_message_buffer.remove_by_message_id(scope_key, message_id)
+            if hit:
+                return True
+        # 兼容回退：按平台 message_id 匹配主表行（legacy 行/兼容列）。
+        rows = self.store.conversation_rows_by_message_id(scope_key, message_id)
+        deleted_any = False
+        for row in rows:
+            if row["role"] == "user":
+                # 群友撤回触发消息：按整 Loop 删除处理（§9.3）。
+                deleted_any = self.store.delete_loop_by_anchor(scope_key, int(row["id"])) or deleted_any
+            else:
+                deleted_any = self.store.delete_turn_by_message_row(scope_key, int(row["id"])) or deleted_any
+        if deleted_any:
+            self._bump_scope_generation(scope_key, HistoryMutation.DELETE)
+        buf_deleted = (
+            self.recent_message_buffer.remove_by_message_id(scope_key, message_id)
+            if self.recent_message_buffer
+            else False
+        )
+        return deleted_any or buf_deleted

--- a/src/quickquip/llm/service_parts/state.py
+++ b/src/quickquip/llm/service_parts/state.py
@@ -106,6 +106,8 @@ class StateMixin:
     def delete_session_archive_for_user(self, user_id: int | str, archive_number: int) -> bool:
         archive_key = f"archive:{str(user_id)}:{archive_number}"
         self.store.delete_loops_for_scope(archive_key)
+        _, revision = self.store.agent_scope_state(archive_key)
+        self.store.mutate_history(archive_key, revision, HistoryMutation.DELETE)
         return self.store.delete_session_archive(str(user_id), archive_number)
 
     def get_session_preset(self, scope_key: str) -> str:

--- a/src/quickquip/llm/store.py
+++ b/src/quickquip/llm/store.py
@@ -6,6 +6,7 @@
 - 长期记忆 → ``MemoryStoreMixin``
 - 私聊归档 → ``SessionArchiveMixin``
 - 群设置覆盖 → ``GroupSettingsMixin``
+- Agent 执行记录 → ``AgentRecordsStoreMixin``
 
 对外 import 路径不变：``from quickquip.llm.store import LLMStore, GroupSettingsOverride``。
 """
@@ -16,6 +17,7 @@ from quickquip.llm.store_parts._base import GroupSettingsOverride as GroupSettin
 from quickquip.llm.store_parts._base import _StoreBase
 from quickquip.llm.store_parts._base import _build_query_tokens as _build_query_tokens  # noqa: F401
 from quickquip.llm.store_parts._base import _utc_now as _utc_now  # noqa: F401
+from quickquip.llm.store_parts.agent_records import AgentRecordsStoreMixin
 from quickquip.llm.store_parts.conversation import ConversationStoreMixin
 from quickquip.llm.store_parts.group_settings import GroupSettingsMixin
 from quickquip.llm.store_parts.memory import MemoryStoreMixin
@@ -28,9 +30,10 @@ class LLMStore(
     MemoryStoreMixin,
     SessionArchiveMixin,
     GroupSettingsMixin,
+    AgentRecordsStoreMixin,
 ):
     """组合各域 mixin的 LLM 存储。
 
     MRO 顺序：``_StoreBase`` 必须第一位（提供 __init__ / _connect / _ensure_schema /
-    _unavailable / _safe_load_tags），四个域 mixin 互相独立，顺序不影响。
+    _unavailable / _safe_load_tags），各域 mixin 互相独立，顺序不影响。
     """

--- a/src/quickquip/llm/store_parts/_base.py
+++ b/src/quickquip/llm/store_parts/_base.py
@@ -80,6 +80,7 @@ class _StoreBase:
         self._unavailable = False
         try:
             self._ensure_schema()
+            self._ensure_agent_schema()
         except sqlite3.Error as exc:
             logger.error("LLMStore 数据库初始化失败 (%s)：%s", self.path, exc)
             self._unavailable = True
@@ -100,6 +101,9 @@ class _StoreBase:
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(self.path)
         conn.row_factory = sqlite3.Row
+        # agent 领域侧表使用 FK 级联（§4.2）；所有领域连接统一开启，
+        # 不依赖某个连接碰巧启用。
+        conn.execute("PRAGMA foreign_keys=ON")
         return conn
 
     def _ensure_schema(self) -> None:

--- a/src/quickquip/llm/store_parts/agent_records.py
+++ b/src/quickquip/llm/store_parts/agent_records.py
@@ -1751,3 +1751,261 @@ class AgentRecordsStoreMixin:
             "DELETE FROM conversation_messages WHERE agent_loop_id = ?", (loop_id,)
         )
         conn.execute("DELETE FROM agent_loops WHERE loop_id = ?", (loop_id,))
+
+    # ── 维护操作（§9 引用、撤回、删除和私聊会话） ──────────────────
+
+    def delete_loops_for_scope(self, scope_key: str) -> int:
+        """清空场景的整域删除（§9.3）：全部 Loop 及其主表行，返回删除数。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            loops = [
+                row["loop_id"]
+                for row in conn.execute(
+                    "SELECT loop_id FROM agent_loops WHERE scope_key = ?", (scope_key,)
+                )
+            ]
+            for loop_id in loops:
+                self._delete_whole_loop(conn, loop_id)
+            conn.commit()
+            return len(loops)
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def delete_loop_by_anchor(self, scope_key: str, anchor_row_id: int) -> bool:
+        """按 user 触发行删除整个 Loop（§9.3）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT loop_id FROM agent_loops WHERE scope_key = ? AND anchor_row_id = ?",
+                (scope_key, int(anchor_row_id)),
+            ).fetchone()
+            if row is None:
+                conn.commit()
+                return False
+            self._delete_whole_loop(conn, row["loop_id"])
+            conn.commit()
+            return True
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def delete_turn_by_message_row(self, scope_key: str, message_row_id: int) -> bool:
+        """删除一个 Turn 的全部正文范围与交付内容（§9.3）。
+
+        保留协议需要的状态占位：Turn 行与主表行移除，工具声明保留名称与
+        终态（结果正文清空），Loop 非公开证据（native/owner）清除。
+        """
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            turn = conn.execute(
+                """
+                SELECT t.turn_id, t.loop_id FROM agent_turns t
+                JOIN agent_loops l ON l.loop_id = t.loop_id
+                WHERE l.scope_key = ? AND t.message_row_id = ?
+                """,
+                (scope_key, int(message_row_id)),
+            ).fetchone()
+            if turn is None:
+                conn.commit()
+                return False
+            conn.execute(
+                "DELETE FROM conversation_messages WHERE id = ?", (int(message_row_id),)
+            )
+            conn.execute(
+                "DELETE FROM agent_deliveries WHERE turn_id = ?", (turn["turn_id"],)
+            )
+            conn.execute(
+                """
+                UPDATE agent_tool_executions
+                SET arguments_json = NULL, arguments_omission_reason = 'recall_cleanup',
+                    result_json = NULL, result_omission_reason = 'recall_cleanup',
+                    outbound_media_json = NULL
+                WHERE turn_id = ?
+                """,
+                (turn["turn_id"],),
+            )
+            conn.execute(
+                """
+                UPDATE agent_turns
+                SET native_state_json = NULL, native_omission_reason = 'recall_cleanup',
+                    owner_json = NULL, parts_json = ?, text_policy = 'redacted'
+                WHERE turn_id = ?
+                """,
+                (
+                    _dumps({"version": AGENT_RECORD_VERSION, "parts": []}),
+                    turn["turn_id"],
+                ),
+            )
+            conn.execute(
+                "UPDATE agent_loops SET replay_revision = replay_revision + 1 WHERE loop_id = ?",
+                (turn["loop_id"],),
+            )
+            conn.commit()
+            return True
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def recall_delivery_chunk(self, scope_key: str, delivery_id: str) -> bool:
+        """单 Chunk 撤回（§9.2）：遮蔽源范围并清除该 Loop 的工具/原生证据。
+
+        已确认发送的事实保留（recall_status=recalled）；其余 Chunk 正文
+        不动。返回是否命中。
+        """
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            delivery = conn.execute(
+                """
+                SELECT d.delivery_id, d.loop_id, d.turn_id, d.source_start, d.source_end
+                FROM agent_deliveries d
+                JOIN agent_loops l ON l.loop_id = d.loop_id
+                WHERE l.scope_key = ? AND d.delivery_id = ?
+                """,
+                (scope_key, delivery_id),
+            ).fetchone()
+            if delivery is None:
+                conn.commit()
+                return False
+            turn_id = delivery["turn_id"]
+            turn = conn.execute(
+                "SELECT message_row_id FROM agent_turns WHERE turn_id = ?", (turn_id,)
+            ).fetchone()
+            if turn is not None and turn["message_row_id"] is not None:
+                message = conn.execute(
+                    "SELECT content FROM conversation_messages WHERE id = ?",
+                    (turn["message_row_id"],),
+                ).fetchone()
+                if message is not None:
+                    text = message["content"] or ""
+                    start, end = int(delivery["source_start"] or 0), int(delivery["source_end"] or 0)
+                    # 等 code point 数遮蔽：保留坐标供后续撤回其他 Chunk。
+                    if 0 <= start <= end <= len(text):
+                        masked = text[:start] + "▇" * (end - start) + text[end:]
+                        conn.execute(
+                            "UPDATE conversation_messages SET content = ? WHERE id = ?",
+                            (masked, turn["message_row_id"]),
+                        )
+            conn.execute(
+                "UPDATE agent_deliveries SET recall_status = 'recalled' WHERE delivery_id = ?",
+                (delivery_id,),
+            )
+            # 该 Loop 的工具证据与原生状态整体清理（§9.2.3）。
+            conn.execute(
+                """
+                UPDATE agent_tool_executions
+                SET arguments_json = NULL, arguments_omission_reason = 'recall_cleanup',
+                    result_json = NULL, result_omission_reason = 'recall_cleanup',
+                    outbound_media_json = NULL
+                WHERE turn_id IN (SELECT turn_id FROM agent_turns WHERE loop_id = ?)
+                """,
+                (delivery["loop_id"],),
+            )
+            conn.execute(
+                """
+                UPDATE agent_turns
+                SET native_state_json = NULL, native_omission_reason = 'recall_cleanup',
+                    owner_json = NULL
+                WHERE loop_id = ?
+                """,
+                (delivery["loop_id"],),
+            )
+            conn.execute(
+                "UPDATE agent_loops SET replay_revision = replay_revision + 1 WHERE loop_id = ?",
+                (delivery["loop_id"],),
+            )
+            conn.commit()
+            return True
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def migrate_loops_between_scopes(self, from_scope: str, to_scope: str) -> int:
+        """私聊归档/恢复的整 Loop 迁移（§9.4）：ID 与时间不变，双侧 generation 增长。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute("INSERT OR IGNORE INTO agent_scopes (scope_key) VALUES (?)", (to_scope,))
+            moved = conn.execute(
+                "UPDATE agent_loops SET scope_key = ? WHERE scope_key = ?",
+                (to_scope, from_scope),
+            ).rowcount
+            if moved:
+                conn.execute(
+                    "UPDATE conversation_messages SET group_id = ? WHERE group_id = ?",
+                    (to_scope, from_scope),
+                )
+            for scope in (from_scope, to_scope):
+                conn.execute(
+                    """
+                    UPDATE agent_scopes
+                    SET generation = generation + 1, history_revision = history_revision + 1
+                    WHERE scope_key = ?
+                    """,
+                    (scope,),
+                )
+            conn.commit()
+            return int(moved or 0)
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def loops_with_tools(self, scope_key: str, loop_ids: Collection[str]) -> set[str]:
+        """判定哪些 Loop 携带工具事实（历史投影替换的门槛，§8.1）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        if not loop_ids:
+            return set()
+        with self._connect() as conn:
+            placeholders = ",".join("?" for _ in loop_ids)
+            rows = conn.execute(
+                f"""
+                SELECT DISTINCT t.loop_id AS loop_id FROM agent_turns t
+                JOIN agent_tool_executions e ON e.turn_id = t.turn_id
+                WHERE t.loop_id IN ({placeholders})
+                """,
+                tuple(loop_ids),
+            ).fetchall()
+        return {row["loop_id"] for row in rows}
+
+    def load_closed_loops_by_ids(self, scope_key: str, loop_ids: Collection[str]) -> list[LoadedLoop]:
+        """按 ID 读取完整已关闭 Loop（历史投影输入；顺序按 anchor ASC）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        if not loop_ids:
+            return []
+        with self._connect() as conn:
+            placeholders = ",".join("?" for _ in loop_ids)
+            loops = conn.execute(
+                f"""
+                SELECT * FROM agent_loops
+                WHERE scope_key = ? AND closed_at IS NOT NULL AND loop_id IN ({placeholders})
+                ORDER BY anchor_row_id ASC
+                """,
+                (scope_key, *loop_ids),
+            ).fetchall()
+            return [self._load_one_loop(conn, loop) for loop in loops]

--- a/src/quickquip/llm/store_parts/agent_records.py
+++ b/src/quickquip/llm/store_parts/agent_records.py
@@ -1,0 +1,1753 @@
+"""AgentRecordsStoreMixin：Agent Loop 执行记录领域的持久化（§4）。
+
+三视图契约（§3.2）中的「执行记录」与「交付记录」落在本 mixin：
+``agent_loops`` / ``agent_turns`` / ``agent_tool_executions`` /
+``agent_deliveries`` / ``agent_delivery_attempts`` 五张侧表加
+``conversation_messages`` 的 loop/turn 关联列。重放投影读取
+（``load_closed_loops``）只返回完整已关闭 Loop。
+
+写入纪律（§4.2）：
+
+- 同一业务提交的主表行、侧表行、字节账本在一个事务内完成；Turn 写入
+  与其全部工具声明、全部文字 Chunk 同事务，事务提交成功之后才允许
+  发送或执行工具。
+- 每次写入验证 ``scope_generation`` 与 Loop 仍可写；清空后迟到结果
+  不得新建内容。
+- 关键写路径用 ``BEGIN IMMEDIATE`` 取写锁后再校验，数据库
+  generation/revision 是跨进程（Bot/Web）的最终写入屏障。
+
+迁移（§4.3）：``BEGIN IMMEDIATE`` + ``agent_schema_migrations`` 版本表，
+旧库按 user 行分组回填 legacy Loop/Turn/delivery；不访问网络与 QQ。
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from collections import deque
+from collections.abc import Collection, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from quickquip.llm.agent_records import (
+    AGENT_RECORD_VERSION,
+    DeliveryKind,
+    DeliveryPlanItem,
+    DeliveryPolicy,
+    DeliveryReceipt,
+    DeliveryStatus,
+    LoopStatus,
+    MAX_LOOP_RECORD_BYTES,
+    MAX_NATIVE_STATE_BYTES,
+    MAX_PERSISTED_TOOL_ARGUMENT_BYTES,
+    MAX_PERSISTED_TOOL_RESULT_BYTES,
+    NativeOmissionReason,
+    ResultOmissionReason,
+    ResultRetention,
+    TextPolicy,
+    ToolDeclarationRecord,
+    ToolExecutionStatus,
+    ToolResultRecord,
+    ToolSkipReason,
+    TriggerKind,
+    TurnOutputStatus,
+    TurnResponseRecord,
+    new_agent_id,
+)
+from quickquip.llm.store_parts._base import _utc_now
+
+logger = logging.getLogger(__name__)
+
+_AGENT_SCHEMA_VERSION = 1
+
+# 逐条执行（§4.3.1：迁移事务内不得 executescript 隐式提交）。
+_AGENT_SCHEMA_DDL: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS agent_scopes (
+        scope_key TEXT PRIMARY KEY,
+        generation INTEGER NOT NULL DEFAULT 0,
+        history_revision INTEGER NOT NULL DEFAULT 0
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent_loops (
+        loop_id TEXT PRIMARY KEY,
+        scope_key TEXT NOT NULL,
+        bot_self_id TEXT,
+        scope_generation INTEGER NOT NULL,
+        anchor_row_id INTEGER UNIQUE,
+        trigger_kind TEXT NOT NULL,
+        started_at TEXT NOT NULL,
+        closed_at TEXT,
+        status TEXT NOT NULL,
+        terminal_reason TEXT,
+        record_version INTEGER NOT NULL,
+        record_bytes INTEGER NOT NULL DEFAULT 0,
+        replay_revision INTEGER NOT NULL DEFAULT 0,
+        legacy INTEGER NOT NULL DEFAULT 0,
+        FOREIGN KEY (scope_key) REFERENCES agent_scopes(scope_key)
+    )
+    """,
+    # 同 scope 最多一个未关闭 Loop（§4.1）。
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_loops_one_open
+    ON agent_loops(scope_key) WHERE closed_at IS NULL
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_agent_loops_scope_anchor
+    ON agent_loops(scope_key, anchor_row_id)
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_agent_loops_closed_at
+    ON agent_loops(scope_key, closed_at)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent_turns (
+        turn_id TEXT PRIMARY KEY,
+        loop_id TEXT NOT NULL,
+        turn_index INTEGER NOT NULL,
+        message_row_id INTEGER UNIQUE,
+        parts_json TEXT NOT NULL,
+        native_state_json TEXT,
+        native_omission_reason TEXT,
+        owner_json TEXT,
+        finish_reason TEXT,
+        committed_at TEXT NOT NULL,
+        delivery_policy TEXT NOT NULL,
+        text_policy TEXT NOT NULL,
+        output_status TEXT NOT NULL,
+        FOREIGN KEY (loop_id) REFERENCES agent_loops(loop_id) ON DELETE CASCADE,
+        UNIQUE (loop_id, turn_index)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent_tool_executions (
+        execution_id TEXT PRIMARY KEY,
+        turn_id TEXT NOT NULL,
+        call_index INTEGER NOT NULL,
+        provider_call_id TEXT,
+        tool_name TEXT NOT NULL,
+        arguments_json TEXT,
+        arguments_omission_reason TEXT,
+        status TEXT NOT NULL,
+        result_json TEXT,
+        result_retention TEXT NOT NULL,
+        result_omission_reason TEXT,
+        outbound_media_json TEXT,
+        started_at TEXT,
+        finished_at TEXT,
+        FOREIGN KEY (turn_id) REFERENCES agent_turns(turn_id) ON DELETE CASCADE,
+        UNIQUE (turn_id, call_index)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent_deliveries (
+        delivery_id TEXT PRIMARY KEY,
+        loop_id TEXT NOT NULL,
+        turn_id TEXT,
+        tool_execution_id TEXT,
+        kind TEXT NOT NULL,
+        delivery_index INTEGER NOT NULL,
+        chunk_index INTEGER,
+        source_start INTEGER,
+        source_end INTEGER,
+        wrappers_json TEXT,
+        attachment_refs_json TEXT,
+        notice_text TEXT,
+        status TEXT NOT NULL,
+        recall_status TEXT NOT NULL DEFAULT 'active',
+        planned_at TEXT NOT NULL,
+        FOREIGN KEY (loop_id) REFERENCES agent_loops(loop_id) ON DELETE CASCADE,
+        FOREIGN KEY (turn_id) REFERENCES agent_turns(turn_id) ON DELETE CASCADE,
+        FOREIGN KEY (tool_execution_id)
+            REFERENCES agent_tool_executions(execution_id) ON DELETE CASCADE,
+        UNIQUE (loop_id, delivery_index)
+    )
+    """,
+    # 文字 Chunk 专用：一个 Chunk 只属于一个 Turn（§3.2.1）。
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_deliveries_turn_chunk
+    ON agent_deliveries(turn_id, chunk_index)
+    WHERE turn_id IS NOT NULL AND chunk_index IS NOT NULL
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent_delivery_attempts (
+        attempt_id TEXT PRIMARY KEY,
+        delivery_id TEXT NOT NULL,
+        attempt_index INTEGER NOT NULL,
+        status TEXT NOT NULL,
+        started_at TEXT NOT NULL,
+        finished_at TEXT,
+        qq_message_id TEXT,
+        error_code TEXT,
+        FOREIGN KEY (delivery_id) REFERENCES agent_deliveries(delivery_id) ON DELETE CASCADE,
+        UNIQUE (delivery_id, attempt_index)
+    )
+    """,
+    # QQ ID 查询必须带 scope 谓词（§4.1），不假设跨群全局唯一。
+    """
+    CREATE INDEX IF NOT EXISTS idx_agent_attempts_qq_message_id
+    ON agent_delivery_attempts(qq_message_id)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS agent_schema_migrations (
+        version INTEGER PRIMARY KEY,
+        applied_at TEXT NOT NULL
+    )
+    """,
+)
+
+_TEXT_PART_ORIGINS = {"model", "source_annotation"}
+
+
+class AgentStoreError(RuntimeError):
+    """Agent 记录领域的基类错误。"""
+
+
+class ScopeGenerationMismatch(AgentStoreError):
+    """写入时的 scope generation 已失效（清空/撤回/切会话后迟到写入）。"""
+
+
+class LoopNotWritable(AgentStoreError):
+    """目标 Loop 已关闭或状态不允许该写入。"""
+
+
+class StaleRevision(AgentStoreError):
+    """mutate_history 的期望 revision 与库中不一致（并发编辑屏障）。"""
+
+
+class LoopRecordBudgetExceeded(AgentStoreError):
+    """单 Loop 业务记录字节触顶（§8.4）；调用方应终止 Loop 并记录事实。"""
+
+
+class HistoryMutation:
+    """历史失效语义（§4.1）：generation 类使旧写入屏障失效，revision 类只
+    表示内容编辑。调用方以数据库值为最终屏障，进程内缓存不算数。"""
+
+    CLEAR = "clear"  # generation+1 revision+1
+    SESSION_SWITCH = "session_switch"  # generation+1
+    RECALL = "recall"  # generation+1
+    EDIT = "edit"  # revision+1
+    DELETE = "delete"  # revision+1
+
+
+_GENERATION_MUTATIONS = {
+    HistoryMutation.CLEAR,
+    HistoryMutation.SESSION_SWITCH,
+    HistoryMutation.RECALL,
+}
+
+
+def _dumps(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+
+
+def _utf8_bytes(text: str | None) -> int:
+    return 0 if text is None else len(text.encode("utf-8"))
+
+
+def _utf8_head_tail(text: str, budget: int) -> tuple[str, list[tuple[int, int]]]:
+    """UTF-8 安全的首尾摘录（§8.4）：超限结果保留首尾，按 code point 边界切。
+
+    返回 ``(excerpt, retained_ranges)``，ranges 为原串 code point 区间。
+    摘录含省略标记，标记字节计入预算（预留 64 字节 + 位数余量）。
+    """
+    if _utf8_bytes(text) <= budget:
+        return text, [(0, len(text))]
+    marker_reserve = 64 + 16
+    half = max(0, (budget - marker_reserve) // 2)
+    head_end = len(text)
+    head_bytes = 0
+    for index, char in enumerate(text):
+        width = len(char.encode("utf-8"))
+        if head_bytes + width > half:
+            head_end = index
+            break
+        head_bytes += width
+    tail_start = len(text)
+    tail_bytes = 0
+    for index in range(len(text) - 1, -1, -1):
+        width = len(text[index].encode("utf-8"))
+        if tail_bytes + width > half or index <= head_end:
+            break
+        tail_bytes += width
+        tail_start = index
+    omitted = len(text) - head_end - (len(text) - tail_start)
+    excerpt = text[:head_end] + f"…[省略 {omitted} 字符]…" + text[tail_start:]
+    while _utf8_bytes(excerpt) > budget and tail_start < len(text):
+        # 极端兜底：标记位数超出预留时从尾部逐字符再收。
+        tail_start += 1
+        omitted = len(text) - head_end - (len(text) - tail_start)
+        excerpt = text[:head_end] + f"…[省略 {omitted} 字符]…" + text[tail_start:]
+    ranges = [(0, head_end), (tail_start, len(text))] if tail_start < len(text) else [(0, head_end)]
+    return excerpt, ranges
+
+
+@dataclass(frozen=True, slots=True)
+class UserTriggerPayload:
+    """新 Loop 的 user 触发行载荷（§5.3.1：过滤后冻结的 user 表达）。"""
+
+    user_id: str | None
+    sender_name: str = ""
+    canonical_name: str = ""
+    content: str = ""
+    raw_content: str = ""
+    message_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LoopHandle:
+    loop_id: str
+    scope_key: str
+    scope_generation: int
+    trigger_kind: TriggerKind
+
+
+@dataclass(frozen=True, slots=True)
+class TurnRecord:
+    turn_id: str
+    turn_index: int
+    message_row_id: int
+    delivery_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AttemptHandle:
+    attempt_id: str
+    delivery_id: str
+    attempt_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class RetentionPolicy:
+    """D5 三上限（§2 默认值由 runtime 配置解析提供）。"""
+
+    retention_days: int = 30
+    max_loops: int = 1000
+    max_bytes: int = 67_108_864
+
+
+@dataclass(frozen=True, slots=True)
+class PruneReport:
+    deleted_loop_ids: tuple[str, ...] = ()
+    # 硬上限仍无法满足时需要推进的活动纪元锚点（调用方负责 reset，§8.4）。
+    blocked_active_anchors: tuple[int, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryReport:
+    closed_loops: tuple[str, ...] = ()
+    tools_not_executed: tuple[str, ...] = ()
+    tools_indeterminate: tuple[str, ...] = ()
+    deliveries_skipped: tuple[str, ...] = ()
+    deliveries_unknown: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedToolExecution:
+    execution_id: str
+    call_index: int
+    provider_call_id: str | None
+    tool_name: str
+    arguments_json: str | None
+    arguments_omission_reason: str | None
+    status: str
+    result: dict[str, Any] | None
+    result_retention: str
+    result_omission_reason: str | None
+    outbound_media: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedDelivery:
+    delivery_id: str
+    kind: str
+    turn_id: str | None
+    tool_execution_id: str | None
+    chunk_index: int | None
+    source_start: int | None
+    source_end: int | None
+    status: str
+    recall_status: str
+    qq_message_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedTurn:
+    turn_id: str
+    turn_index: int
+    message_row_id: int
+    text: str
+    parts: tuple[dict[str, Any], ...]
+    native_state: dict[str, Any] | None
+    native_omission_reason: str | None
+    owner: dict[str, Any] | None
+    finish_reason: str | None
+    text_policy: str
+    output_status: str
+    delivery_policy: str
+    tools: tuple[LoadedToolExecution, ...]
+    deliveries: tuple[LoadedDelivery, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class LoadedLoop:
+    loop_id: str
+    scope_key: str
+    anchor_row_id: int
+    trigger_kind: str
+    started_at: str
+    closed_at: str | None
+    status: str
+    terminal_reason: str | None
+    legacy: bool
+    replay_revision: int
+    record_bytes: int
+    user_row: dict[str, Any]
+    turns: tuple[LoadedTurn, ...]
+    # Loop 级全部交付（含 turn 为空的 host_notice / 归因于他 Turn 的条目）。
+    deliveries: tuple[LoadedDelivery, ...] = ()
+
+
+class AgentRecordsStoreMixin:
+    """Agent 执行记录域。依赖 _StoreBase 的 _connect / _unavailable。"""
+
+    # ── schema 与迁移 ────────────────────────────────────────────
+
+    def _ensure_agent_schema(self) -> None:
+        """并发安全的 agent schema 迁移（§4.3.1-2）。
+
+        ``BEGIN IMMEDIATE`` 取写锁后检查版本表；Bot/Web 同时首开只有一方
+        执行迁移。失败回滚，不留半迁移。
+        """
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            applied = conn.execute(
+                "SELECT version FROM agent_schema_migrations"
+            ).fetchall() if self._agent_table_exists(conn, "agent_schema_migrations") else []
+            applied_versions = {int(row["version"]) for row in applied}
+            if _AGENT_SCHEMA_VERSION not in applied_versions:
+                for statement in _AGENT_SCHEMA_DDL:
+                    conn.execute(statement)
+                self._add_agent_conversation_columns(conn)
+                self._backfill_legacy_loops(conn)
+                conn.execute(
+                    "INSERT OR REPLACE INTO agent_schema_migrations (version, applied_at) VALUES (?, ?)",
+                    (_AGENT_SCHEMA_VERSION, _utc_now()),
+                )
+                self._verify_agent_schema(conn)
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _agent_table_exists(conn: sqlite3.Connection, table: str) -> bool:
+        row = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?", (table,)
+        ).fetchone()
+        return row is not None
+
+    @staticmethod
+    def _add_agent_conversation_columns(conn: sqlite3.Connection) -> None:
+        columns = {
+            row["name"] for row in conn.execute("PRAGMA table_info(conversation_messages)")
+        }
+        if "agent_loop_id" not in columns:
+            conn.execute("ALTER TABLE conversation_messages ADD COLUMN agent_loop_id TEXT")
+        if "agent_turn_id" not in columns:
+            conn.execute("ALTER TABLE conversation_messages ADD COLUMN agent_turn_id TEXT")
+
+    def _backfill_legacy_loops(self, conn: sqlite3.Connection) -> None:
+        """旧行按 user 锚点分组回填 legacy Loop/Turn/delivery（§4.3.3-6）。
+
+        每 scope 按 row ID 升序：一个 user 行及其后到下个 user 行前的
+        assistant 行为一个 legacy Loop；开头没有 user 的 assistant 连续段
+        归一个 ``legacy_orphan`` Loop。原行 ID、正文、身份与时间原样保留，
+        不制造历史工具、thinking 或 owner。
+        """
+        scopes = [
+            row["group_id"]
+            for row in conn.execute(
+                "SELECT DISTINCT group_id FROM conversation_messages ORDER BY group_id"
+            )
+        ]
+        for scope_key in scopes:
+            conn.execute(
+                "INSERT OR IGNORE INTO agent_scopes (scope_key) VALUES (?)", (scope_key,)
+            )
+            rows = conn.execute(
+                """
+                SELECT id, user_id, sender_name, canonical_name, role, content,
+                       message_id, raw_content, created_at
+                FROM conversation_messages
+                WHERE group_id = ?
+                ORDER BY id ASC
+                """,
+                (scope_key,),
+            ).fetchall()
+            groups: list[list[sqlite3.Row]] = []
+            current: list[sqlite3.Row] = []
+            for row in rows:
+                if row["role"] == "user":
+                    if current:
+                        groups.append(current)
+                    current = [row]
+                else:
+                    current.append(row)
+            if current:
+                groups.append(current)
+
+            for group in groups:
+                self._backfill_one_legacy_group(conn, scope_key, group)
+
+    @staticmethod
+    def _backfill_one_legacy_group(
+        conn: sqlite3.Connection, scope_key: str, group: list[sqlite3.Row]
+    ) -> None:
+        first = group[0]
+        is_orphan = first["role"] != "user"
+        if is_orphan:
+            loop_id = f"legacy_orphan_{int(first['id'])}"
+            trigger = TriggerKind.LEGACY_ORPHAN
+            anchor_row_id = None
+            started_at = first["created_at"]
+        else:
+            loop_id = f"legacy_{int(first['id'])}"
+            trigger = TriggerKind.LEGACY
+            anchor_row_id = int(first["id"])
+            started_at = first["created_at"]
+        closed_at = group[-1]["created_at"]
+        record_bytes = sum(
+            _utf8_bytes(row["content"]) + _utf8_bytes(row["raw_content"]) for row in group
+        )
+        conn.execute(
+            """
+            INSERT INTO agent_loops (loop_id, scope_key, bot_self_id, scope_generation,
+                                     anchor_row_id, trigger_kind, started_at, closed_at,
+                                     status, terminal_reason, record_version, record_bytes,
+                                     replay_revision, legacy)
+            VALUES (?, ?, NULL, 0, ?, ?, ?, ?, ?, NULL, ?, ?, 0, 1)
+            """,
+            (
+                loop_id, scope_key, anchor_row_id, trigger, started_at, closed_at,
+                LoopStatus.LEGACY, AGENT_RECORD_VERSION, record_bytes,
+            ),
+        )
+        if anchor_row_id is not None:
+            conn.execute(
+                "UPDATE conversation_messages SET agent_loop_id = ? WHERE id = ?",
+                (loop_id, anchor_row_id),
+            )
+
+        delivery_index = 0
+        for turn_index, row in enumerate(group):
+            if row["role"] != "assistant":
+                continue
+            turn_id = f"legacy_turn_{int(row['id'])}"
+            text = row["content"] or ""
+            parts = _dumps(
+                {
+                    "version": AGENT_RECORD_VERSION,
+                    "parts": [{"type": "text_ref", "start": 0, "end": len(text), "origin": "model"}],
+                }
+            )
+            conn.execute(
+                """
+                INSERT INTO agent_turns (turn_id, loop_id, turn_index, message_row_id,
+                                         parts_json, delivery_policy, text_policy,
+                                         output_status, committed_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    turn_id, loop_id, turn_index, int(row["id"]), parts,
+                    DeliveryPolicy.FINAL_ONLY, TextPolicy.ALLOWED,
+                    TurnOutputStatus.VISIBLE, row["created_at"],
+                ),
+            )
+            conn.execute(
+                "UPDATE conversation_messages SET agent_loop_id = ?, agent_turn_id = ? WHERE id = ?",
+                (loop_id, turn_id, int(row["id"])),
+            )
+            qq_id = row["message_id"]
+            status = DeliveryStatus.SENT if qq_id else DeliveryStatus.LEGACY_UNTRACKED
+            delivery_id = f"legacy_delivery_{int(row['id'])}"
+            conn.execute(
+                """
+                INSERT INTO agent_deliveries (delivery_id, loop_id, turn_id, kind,
+                                              delivery_index, chunk_index, source_start,
+                                              source_end, status, recall_status, planned_at)
+                VALUES (?, ?, ?, ?, ?, 0, 0, ?, ?, 'active', ?)
+                """,
+                (
+                    delivery_id, loop_id, turn_id, DeliveryKind.TEXT_CHUNK,
+                    delivery_index, len(text), status, row["created_at"],
+                ),
+            )
+            delivery_index += 1
+            if qq_id:
+                conn.execute(
+                    """
+                    INSERT INTO agent_delivery_attempts (attempt_id, delivery_id, attempt_index,
+                                                         status, started_at, finished_at, qq_message_id)
+                    VALUES (?, ?, 0, ?, ?, ?, ?)
+                    """,
+                    (
+                        f"legacy_attempt_{int(row['id'])}", delivery_id,
+                        DeliveryStatus.SENT, row["created_at"], row["created_at"], str(qq_id),
+                    ),
+                )
+
+    @staticmethod
+    def _verify_agent_schema(conn: sqlite3.Connection) -> None:
+        """迁移后完整性检查（§4.3.7）：FK、唯一约束抽查与侧表孤儿。"""
+        violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+        if violations:
+            raise sqlite3.IntegrityError(f"agent schema 迁移后 foreign_key_check 失败：{violations[:3]}")
+        orphans = conn.execute(
+            """
+            SELECT COUNT(*) AS c FROM agent_turns t
+            LEFT JOIN conversation_messages m ON m.id = t.message_row_id
+            WHERE t.message_row_id IS NOT NULL AND m.id IS NULL
+            """
+        ).fetchone()
+        if orphans and int(orphans["c"]):
+            raise sqlite3.IntegrityError("agent 迁移出现指向不存在主行的 Turn")
+
+    # ── scope 状态 ───────────────────────────────────────────────
+
+    def agent_scope_state(self, scope_key: str) -> tuple[int, int]:
+        """读取 (generation, history_revision)；scope 未见时为 (0, 0)。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT generation, history_revision FROM agent_scopes WHERE scope_key = ?",
+                (scope_key,),
+            ).fetchone()
+        if row is None:
+            return 0, 0
+        return int(row["generation"]), int(row["history_revision"])
+
+    def mutate_history(
+        self,
+        scope_key: str,
+        expected_revision: int,
+        mutation: str,
+    ) -> tuple[int, int]:
+        """历史失效屏障（§4.2）：返回新 (generation, revision)。
+
+        期望 revision 不一致抛 ``StaleRevision``——并发编辑在数据库层
+        串行化，进程内缓存不算数。
+        """
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "INSERT OR IGNORE INTO agent_scopes (scope_key) VALUES (?)", (scope_key,)
+            )
+            row = conn.execute(
+                "SELECT generation, history_revision FROM agent_scopes WHERE scope_key = ?",
+                (scope_key,),
+            ).fetchone()
+            generation, revision = int(row["generation"]), int(row["history_revision"])
+            if revision != expected_revision:
+                conn.rollback()
+                raise StaleRevision(
+                    f"scope={scope_key} 期望 revision={expected_revision} 实际={revision}"
+                )
+            if mutation in _GENERATION_MUTATIONS:
+                generation += 1
+            revision += 1
+            conn.execute(
+                "UPDATE agent_scopes SET generation = ?, history_revision = ? WHERE scope_key = ?",
+                (generation, revision, scope_key),
+            )
+            conn.commit()
+            return generation, revision
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    # ── Loop 生命周期 ────────────────────────────────────────────
+
+    def begin_loop(
+        self,
+        scope_key: str,
+        expected_generation: int,
+        trigger: TriggerKind,
+        user: UserTriggerPayload,
+        *,
+        bot_self_id: str | None = None,
+    ) -> LoopHandle:
+        """创建 Loop 与 user 触发行（§4.2：先临时空 anchor，再回填并验证）。
+
+        generation 失效时抛 ``ScopeGenerationMismatch``；同 scope 已有未
+        关闭 Loop 时抛 ``LoopNotWritable``。
+        """
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        loop_id = new_agent_id("loop")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute("INSERT OR IGNORE INTO agent_scopes (scope_key) VALUES (?)", (scope_key,))
+            scope = conn.execute(
+                "SELECT generation FROM agent_scopes WHERE scope_key = ?", (scope_key,)
+            ).fetchone()
+            generation = int(scope["generation"])
+            if generation != expected_generation:
+                conn.rollback()
+                raise ScopeGenerationMismatch(
+                    f"scope={scope_key} loop 创建被拒：generation {expected_generation} -> {generation}"
+                )
+            open_loop = conn.execute(
+                "SELECT loop_id FROM agent_loops WHERE scope_key = ? AND closed_at IS NULL",
+                (scope_key,),
+            ).fetchone()
+            if open_loop is not None:
+                conn.rollback()
+                raise LoopNotWritable(f"scope={scope_key} 已有未关闭 Loop {open_loop['loop_id']}")
+            conn.execute(
+                """
+                INSERT INTO agent_loops (loop_id, scope_key, bot_self_id, scope_generation,
+                                         trigger_kind, started_at, status, record_version)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    loop_id, scope_key, bot_self_id, generation, trigger,
+                    _utc_now(), LoopStatus.RUNNING, AGENT_RECORD_VERSION,
+                ),
+            )
+            anchor_row_id = self._insert_user_row(conn, scope_key, loop_id, user)
+            conn.execute(
+                "UPDATE agent_loops SET anchor_row_id = ? WHERE loop_id = ?",
+                (anchor_row_id, loop_id),
+            )
+            bound = conn.execute(
+                "SELECT anchor_row_id FROM agent_loops WHERE loop_id = ?", (loop_id,)
+            ).fetchone()
+            if bound is None or bound["anchor_row_id"] != anchor_row_id:
+                conn.rollback()
+                raise AgentStoreError(f"loop={loop_id} anchor 绑定验证失败")
+            conn.commit()
+            return LoopHandle(
+                loop_id=loop_id,
+                scope_key=scope_key,
+                scope_generation=generation,
+                trigger_kind=trigger,
+            )
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _insert_user_row(
+        conn: sqlite3.Connection, scope_key: str, loop_id: str, user: UserTriggerPayload
+    ) -> int:
+        cursor = conn.execute(
+            """
+            INSERT INTO conversation_messages
+                (group_id, user_id, sender_name, canonical_name, role, content,
+                 message_id, raw_content, created_at, agent_loop_id)
+            VALUES (?, ?, ?, ?, 'user', ?, ?, ?, ?, ?)
+            """,
+            (
+                scope_key,
+                user.user_id,
+                user.sender_name.strip() or None,
+                user.canonical_name.strip() or None,
+                user.content,
+                user.message_id,
+                user.raw_content or None,
+                _utc_now(),
+                loop_id,
+            ),
+        )
+        return int(cursor.lastrowid)
+
+    def _validate_loop_writable(
+        self, conn: sqlite3.Connection, handle: LoopHandle
+    ) -> None:
+        row = conn.execute(
+            "SELECT status, closed_at, scope_generation FROM agent_loops WHERE loop_id = ?",
+            (handle.loop_id,),
+        ).fetchone()
+        if row is None:
+            raise LoopNotWritable(f"loop={handle.loop_id} 不存在")
+        if row["closed_at"] is not None or row["status"] != LoopStatus.RUNNING:
+            raise LoopNotWritable(f"loop={handle.loop_id} 已关闭（{row['status']}）")
+        scope = conn.execute(
+            "SELECT generation FROM agent_scopes WHERE scope_key = ?",
+            (handle.scope_key,),
+        ).fetchone()
+        current = int(scope["generation"]) if scope is not None else 0
+        if current != handle.scope_generation:
+            raise ScopeGenerationMismatch(
+                f"loop={handle.loop_id} 写入被拒：scope generation "
+                f"{handle.scope_generation} -> {current}"
+            )
+
+    def commit_turn(
+        self,
+        handle: LoopHandle,
+        response: TurnResponseRecord,
+        tool_declarations: Sequence[ToolDeclarationRecord],
+        delivery_plan: Sequence[DeliveryPlanItem],
+        *,
+        delivery_policy: DeliveryPolicy = DeliveryPolicy.ALL_TURNS,
+        turn_id: str | None = None,
+    ) -> TurnRecord:
+        """原子提交一个 Turn：主表 assistant 行 + Turn + 工具声明 + 交付计划。
+
+        事务提交成功之后调用方才允许发送或执行工具（§5.3.5）。parts 的
+        文本范围/工具/native 引用在此验证（§4.4），缺失引用直接失败而非
+        静默吞掉。单 Loop 字节账本在此累加，触顶抛 ``LoopRecordBudgetExceeded``。
+        ``turn_id`` 可由调用方预生成（交付计划需要在提交前引用它）；缺省
+        由 store 生成。
+        """
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        turn_id = turn_id or new_agent_id("turn")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            self._validate_loop_writable(conn, handle)
+            text = response.text
+            parts_payload = self._validated_parts(
+                text, response.parts, tool_declarations, response.native_state,
+                response.native_omission_reason,
+            )
+            native_json = self._bounded_native_json(response)
+
+            index_row = conn.execute(
+                "SELECT COALESCE(MAX(turn_index), -1) + 1 AS next FROM agent_turns WHERE loop_id = ?",
+                (handle.loop_id,),
+            ).fetchone()
+            turn_index = int(index_row["next"])
+
+            cursor = conn.execute(
+                """
+                INSERT INTO conversation_messages
+                    (group_id, user_id, role, content, created_at, agent_loop_id, agent_turn_id)
+                VALUES (?, NULL, 'assistant', ?, ?, ?, ?)
+                """,
+                (handle.scope_key, text, _utc_now(), handle.loop_id, turn_id),
+            )
+            message_row_id = int(cursor.lastrowid)
+            conn.execute(
+                """
+                INSERT INTO agent_turns (turn_id, loop_id, turn_index, message_row_id,
+                                         parts_json, native_state_json, native_omission_reason,
+                                         owner_json, finish_reason, committed_at,
+                                         delivery_policy, text_policy, output_status)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    turn_id, handle.loop_id, turn_index, message_row_id,
+                    parts_payload, native_json,
+                    None if response.native_omission_reason is None else str(response.native_omission_reason),
+                    _dumps(response.owner) if response.owner is not None else None,
+                    response.finish_reason, _utc_now(),
+                    delivery_policy, response.text_policy, response.output_status,
+                ),
+            )
+            for declaration in tool_declarations:
+                self._insert_tool_declaration(conn, handle, turn_id, declaration)
+
+            delivery_ids = self._insert_delivery_plan(
+                conn, handle, turn_id, delivery_plan, text,
+            )
+
+            added_bytes = (
+                _utf8_bytes(text) + _utf8_bytes(parts_payload) + _utf8_bytes(native_json)
+                + sum(
+                    _utf8_bytes(d.arguments_json) + _utf8_bytes(d.tool_name)
+                    for d in tool_declarations
+                )
+                + sum(_utf8_bytes(p.notice_text or "") for p in delivery_plan)
+            )
+            loop_row = conn.execute(
+                "SELECT record_bytes FROM agent_loops WHERE loop_id = ?", (handle.loop_id,)
+            ).fetchone()
+            new_total = int(loop_row["record_bytes"]) + added_bytes
+            if new_total > MAX_LOOP_RECORD_BYTES:
+                conn.rollback()
+                raise LoopRecordBudgetExceeded(
+                    f"loop={handle.loop_id} 记录字节 {new_total} 超过 {MAX_LOOP_RECORD_BYTES}"
+                )
+            conn.execute(
+                "UPDATE agent_loops SET record_bytes = ? WHERE loop_id = ?",
+                (new_total, handle.loop_id),
+            )
+            conn.commit()
+            return TurnRecord(
+                turn_id=turn_id,
+                turn_index=turn_index,
+                message_row_id=message_row_id,
+                delivery_ids=tuple(delivery_ids),
+            )
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _validated_parts(
+        text: str,
+        parts: Sequence[dict[str, Any]],
+        tool_declarations: Sequence[ToolDeclarationRecord],
+        native_state: dict[str, Any] | None,
+        native_omission_reason: NativeOmissionReason | None,
+    ) -> str:
+        execution_ids = {d.execution_id for d in tool_declarations}
+        native_count = 0
+        if native_state is not None and native_omission_reason is None:
+            blocks = native_state.get("blocks")
+            if isinstance(blocks, list):
+                native_count = len(blocks)
+        validated: list[dict[str, Any]] = []
+        for part in parts:
+            kind = part.get("type")
+            if kind == "text_ref":
+                start, end, origin = int(part["start"]), int(part["end"]), part.get("origin", "model")
+                if not (0 <= start <= end <= len(text)):
+                    raise AgentStoreError(f"text_ref 范围 [{start},{end}) 超出已存正文长度 {len(text)}")
+                if origin not in _TEXT_PART_ORIGINS:
+                    raise AgentStoreError(f"text_ref origin 非法：{origin}")
+                validated.append({"type": "text_ref", "start": start, "end": end, "origin": origin})
+            elif kind == "tool_ref":
+                if part["execution_id"] not in execution_ids:
+                    raise AgentStoreError(f"tool_ref 指向未声明执行 {part['execution_id']}")
+                validated.append({"type": "tool_ref", "execution_id": part["execution_id"]})
+            elif kind == "native_ref":
+                index = int(part["index"])
+                if native_count == 0 or not (0 <= index < native_count):
+                    raise AgentStoreError(f"native_ref index {index} 超出原生块数量 {native_count}")
+                validated.append({"type": "native_ref", "index": index})
+            else:
+                raise AgentStoreError(f"parts 含未知类型：{kind}")
+        return _dumps({"version": AGENT_RECORD_VERSION, "parts": validated})
+
+    @staticmethod
+    def _bounded_native_json(response: TurnResponseRecord) -> str | None:
+        if response.native_state is None:
+            return None
+        if response.native_omission_reason is not None:
+            # 决策已由运行期做出：省略原生副本，保留通用事实（§2 MAX_NATIVE_STATE_BYTES）。
+            return None
+        payload = dict(response.native_state)
+        payload.setdefault("version", AGENT_RECORD_VERSION)
+        encoded = _dumps(payload)
+        if _utf8_bytes(encoded) > MAX_NATIVE_STATE_BYTES:
+            raise AgentStoreError(
+                "native_state 超限且未声明省略原因；调用方必须先按 MAX_NATIVE_STATE_BYTES 预检"
+            )
+        return encoded
+
+    @staticmethod
+    def _insert_tool_declaration(
+        conn: sqlite3.Connection,
+        handle: LoopHandle,
+        turn_id: str,
+        declaration: ToolDeclarationRecord,
+    ) -> None:
+        arguments_json = declaration.arguments_json
+        omission = declaration.arguments_omission_reason
+        if arguments_json is not None and _utf8_bytes(arguments_json) > MAX_PERSISTED_TOOL_ARGUMENT_BYTES:
+            arguments_json = None
+            omission = "size_limit"
+        conn.execute(
+            """
+            INSERT INTO agent_tool_executions (execution_id, turn_id, call_index,
+                                               provider_call_id, tool_name, arguments_json,
+                                               arguments_omission_reason, status,
+                                               result_retention)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                declaration.execution_id, turn_id, declaration.call_index,
+                declaration.provider_call_id, declaration.tool_name, arguments_json,
+                None if omission is None else str(omission),
+                ToolExecutionStatus.DECLARED, ResultRetention.BOUNDED,
+            ),
+        )
+
+    @staticmethod
+    def _insert_delivery_plan(
+        conn: sqlite3.Connection,
+        handle: LoopHandle,
+        turn_id: str,
+        delivery_plan: Sequence[DeliveryPlanItem],
+        turn_text: str,
+    ) -> list[str]:
+        index_row = conn.execute(
+            "SELECT COALESCE(MAX(delivery_index), -1) + 1 AS next FROM agent_deliveries WHERE loop_id = ?",
+            (handle.loop_id,),
+        ).fetchone()
+        delivery_index = int(index_row["next"])
+        delivery_ids: list[str] = []
+        for item in delivery_plan:
+            if item.kind == DeliveryKind.TEXT_CHUNK:
+                if item.turn_id is not None and item.turn_id != turn_id:
+                    raise AgentStoreError("文字 delivery 的 turn 归属与提交 Turn 不一致")
+                if item.source_start is None or item.source_end is None:
+                    raise AgentStoreError("文字 delivery 缺少源范围")
+                if not (0 <= item.source_start <= item.source_end <= len(turn_text)):
+                    raise AgentStoreError(
+                        f"文字 delivery 源范围 [{item.source_start},{item.source_end}) 超出正文"
+                    )
+            elif item.kind == DeliveryKind.TOOL_MEDIA:
+                if item.tool_execution_id is None:
+                    raise AgentStoreError("tool_media delivery 缺少 tool_execution_id")
+            elif item.kind == DeliveryKind.HOST_NOTICE:
+                if not (item.notice_text or "").strip():
+                    raise AgentStoreError("host_notice delivery 缺少 notice_text")
+            else:
+                raise AgentStoreError(f"未知交付类型：{item.kind}")
+            delivery_id = item.delivery_id or new_agent_id("dlv")
+            conn.execute(
+                """
+                INSERT INTO agent_deliveries (delivery_id, loop_id, turn_id, tool_execution_id,
+                                              kind, delivery_index, chunk_index, source_start,
+                                              source_end, wrappers_json, attachment_refs_json,
+                                              notice_text, status, recall_status, planned_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?)
+                """,
+                (
+                    delivery_id, handle.loop_id,
+                    turn_id if item.kind != DeliveryKind.HOST_NOTICE else item.turn_id,
+                    item.tool_execution_id, item.kind, delivery_index, item.chunk_index,
+                    item.source_start, item.source_end,
+                    _dumps({"version": AGENT_RECORD_VERSION, "prefix": item.wrappers[0], "suffix": item.wrappers[1]}),
+                    _dumps({"version": AGENT_RECORD_VERSION, "refs": [list(ref) for ref in item.attachment_refs]}),
+                    item.notice_text, DeliveryStatus.PLANNED, _utc_now(),
+                ),
+            )
+            delivery_ids.append(delivery_id)
+            delivery_index += 1
+        return delivery_ids
+
+    # ── 工具执行状态 ─────────────────────────────────────────────
+
+    def mark_tool_started(self, handle: LoopHandle, execution_id: str) -> None:
+        """执行前预写 running（§4.2：开始工具的预写状态事务）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            self._validate_loop_writable(conn, handle)
+            status = self._tool_status(conn, handle, execution_id)
+            if status != ToolExecutionStatus.DECLARED:
+                raise LoopNotWritable(f"execution={execution_id} 状态 {status} 不允许开始执行")
+            conn.execute(
+                "UPDATE agent_tool_executions SET status = ?, started_at = ? WHERE execution_id = ?",
+                (ToolExecutionStatus.RUNNING, _utc_now(), execution_id),
+            )
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def finish_tool(
+        self,
+        handle: LoopHandle,
+        execution_id: str,
+        result: ToolResultRecord | None,
+        *,
+        status: ToolExecutionStatus | None = None,
+        skip_reason: ToolSkipReason | None = None,
+        result_retention: ResultRetention = ResultRetention.BOUNDED,
+        outbound_media: Sequence[dict[str, Any]] = (),
+    ) -> None:
+        """工具终态写入（§4.2/§8.4）。
+
+        - ``result`` 非 None：按字节上限持久化（ephemeral 永不存正文，
+          D1）；超限走 UTF-8 安全首尾摘录并记 original_bytes 与省略原因。
+        - ``result=None`` + ``status=NOT_EXECUTED``：未执行终态（限额/
+          阻断/恢复），``skip_reason`` 记入 result_json 的 detail 字段。
+        - Loop 已关闭时的迟到结果：目标记录仍在则记录无正文的已知终态
+          并提升该 Loop 的 replay_revision（§4.2）。
+        """
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            closed = self._loop_closed(conn, handle)
+            if not closed:
+                self._validate_loop_writable(conn, handle)
+            exists = conn.execute(
+                "SELECT 1 FROM agent_tool_executions WHERE execution_id = ?", (execution_id,)
+            ).fetchone()
+            if exists is None:
+                # 目标记录已删除：只记脱敏诊断，不创建新历史（§4.2）。
+                logger.warning(
+                    "迟到工具结果指向已删除 execution=%s loop=%s（只记诊断）",
+                    execution_id, handle.loop_id,
+                )
+                conn.rollback()
+                return
+            current = self._tool_status(conn, handle, execution_id)
+            terminal_status = status if status is not None else (
+                result.status if result is not None else ToolExecutionStatus.NOT_EXECUTED
+            )
+            if current in (ToolExecutionStatus.SUCCEEDED, ToolExecutionStatus.FAILED,
+                           ToolExecutionStatus.NOT_EXECUTED):
+                conn.rollback()
+                raise LoopNotWritable(f"execution={execution_id} 已是终态 {current}")
+            result_json = self._bounded_result_json(
+                result, result_retention, skip_reason,
+            )
+            media_json = (
+                _dumps({"version": AGENT_RECORD_VERSION, "items": list(outbound_media)})
+                if outbound_media else None
+            )
+            added_bytes = _utf8_bytes(result_json) + _utf8_bytes(media_json)
+            conn.execute(
+                """
+                UPDATE agent_tool_executions
+                SET status = ?, result_json = ?, result_retention = ?,
+                    outbound_media_json = ?, finished_at = ?,
+                    result_omission_reason = COALESCE(result_omission_reason, ?)
+                WHERE execution_id = ?
+                """,
+                (
+                    terminal_status, result_json, result_retention, media_json,
+                    _utc_now(),
+                    self._result_omission(result, result_retention, skip_reason),
+                    execution_id,
+                ),
+            )
+            if closed:
+                conn.execute(
+                    "UPDATE agent_loops SET replay_revision = replay_revision + 1 WHERE loop_id = ?",
+                    (handle.loop_id,),
+                )
+            else:
+                conn.execute(
+                    "UPDATE agent_loops SET record_bytes = record_bytes + ? WHERE loop_id = ?",
+                    (added_bytes, handle.loop_id),
+                )
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _result_omission(
+        result: ToolResultRecord | None,
+        retention: ResultRetention,
+        skip_reason: ToolSkipReason | None,
+    ) -> str | None:
+        if skip_reason is not None:
+            return None
+        if result is None:
+            return None
+        if retention == ResultRetention.EPHEMERAL:
+            return str(ResultOmissionReason.EPHEMERAL_POLICY)
+        if _utf8_bytes(result.content) > MAX_PERSISTED_TOOL_RESULT_BYTES:
+            return str(ResultOmissionReason.SIZE_LIMIT)
+        return None
+
+    @staticmethod
+    def _bounded_result_json(
+        result: ToolResultRecord | None,
+        retention: ResultRetention,
+        skip_reason: ToolSkipReason | None,
+    ) -> str:
+        if skip_reason is not None:
+            payload: dict[str, Any] = {
+                "version": AGENT_RECORD_VERSION,
+                "content": "",
+                "is_error": False,
+                "original_bytes": 0,
+                "retained_ranges": [],
+                "media_descriptions": [],
+                "detail": str(skip_reason),
+            }
+            return _dumps(payload)
+        if result is None:
+            raise AgentStoreError("finish_tool 需要 result 或显式终态")
+        if retention == ResultRetention.EPHEMERAL:
+            # D1：查询正文/hits/cursor 禁止进入业务持久层，只留事实与省略说明。
+            payload = {
+                "version": AGENT_RECORD_VERSION,
+                "content": "",
+                "is_error": bool(result.is_error),
+                "original_bytes": int(result.original_bytes),
+                "retained_ranges": [],
+                "media_descriptions": [],
+                "retention": str(ResultRetention.EPHEMERAL),
+            }
+            return _dumps(payload)
+        content = result.content
+        retained = list(result.retained_ranges)
+        if _utf8_bytes(content) > MAX_PERSISTED_TOOL_RESULT_BYTES:
+            content, retained = _utf8_head_tail(content, MAX_PERSISTED_TOOL_RESULT_BYTES)
+        payload = {
+            "version": AGENT_RECORD_VERSION,
+            "content": content,
+            "is_error": bool(result.is_error),
+            "original_bytes": int(result.original_bytes),
+            "retained_ranges": [list(rng) for rng in retained],
+            "media_descriptions": list(result.media_descriptions),
+        }
+        return _dumps(payload)
+
+    @staticmethod
+    def _tool_status(conn: sqlite3.Connection, handle: LoopHandle, execution_id: str) -> str:
+        row = conn.execute(
+            """
+            SELECT e.status FROM agent_tool_executions e
+            JOIN agent_turns t ON t.turn_id = e.turn_id
+            WHERE e.execution_id = ? AND t.loop_id = ?
+            """,
+            (execution_id, handle.loop_id),
+        ).fetchone()
+        if row is None:
+            raise AgentStoreError(f"execution={execution_id} 不属于 loop={handle.loop_id}")
+        return str(row["status"])
+
+    # ── 交付 ─────────────────────────────────────────────────────
+
+    def start_delivery(self, handle: LoopHandle, delivery_id: str) -> AttemptHandle:
+        """发送前预写 sending + attempt 行（§4.2：开始发送的预写状态事务）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        attempt_id = new_agent_id("att")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            self._validate_loop_writable(conn, handle)
+            row = conn.execute(
+                "SELECT status FROM agent_deliveries WHERE delivery_id = ? AND loop_id = ?",
+                (delivery_id, handle.loop_id),
+            ).fetchone()
+            if row is None:
+                raise AgentStoreError(f"delivery={delivery_id} 不属于 loop={handle.loop_id}")
+            if row["status"] != DeliveryStatus.PLANNED:
+                raise LoopNotWritable(f"delivery={delivery_id} 状态 {row['status']} 不允许开始发送")
+            index_row = conn.execute(
+                "SELECT COALESCE(MAX(attempt_index), -1) + 1 AS next FROM agent_delivery_attempts WHERE delivery_id = ?",
+                (delivery_id,),
+            ).fetchone()
+            attempt_index = int(index_row["next"])
+            conn.execute(
+                "UPDATE agent_deliveries SET status = ? WHERE delivery_id = ?",
+                (DeliveryStatus.SENDING, delivery_id),
+            )
+            conn.execute(
+                """
+                INSERT INTO agent_delivery_attempts (attempt_id, delivery_id, attempt_index,
+                                                     status, started_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (attempt_id, delivery_id, attempt_index, DeliveryStatus.SENDING, _utc_now()),
+            )
+            conn.commit()
+            return AttemptHandle(
+                attempt_id=attempt_id, delivery_id=delivery_id, attempt_index=attempt_index,
+            )
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def finish_delivery(self, attempt: AttemptHandle, receipt: DeliveryReceipt) -> None:
+        """回执落库（§6.2/§4.2）。
+
+        attempt 终态不被后续尝试覆盖；``unknown`` 收到可信成功回执时允许
+        收敛为 ``sent``。目标已删除时只记脱敏诊断日志，不创建新历史。
+        Loop 已关闭时的迟到回执提升 replay_revision。
+        """
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            attempt_row = conn.execute(
+                "SELECT status, finished_at, delivery_id FROM agent_delivery_attempts WHERE attempt_id = ?",
+                (attempt.attempt_id,),
+            ).fetchone()
+            if attempt_row is None:
+                logger.warning(
+                    "迟到回执指向已删除 attempt=%s delivery=%s（只记诊断，不创建历史）",
+                    attempt.attempt_id, attempt.delivery_id,
+                )
+                conn.rollback()
+                return
+            delivery_row = conn.execute(
+                "SELECT loop_id, status FROM agent_deliveries WHERE delivery_id = ?",
+                (attempt_row["delivery_id"],),
+            ).fetchone()
+            if delivery_row is None:
+                logger.warning(
+                    "迟到回执指向已删除 delivery=%s（只记诊断，不创建历史）",
+                    attempt_row["delivery_id"],
+                )
+                conn.rollback()
+                return
+            current = str(attempt_row["status"])
+            new_status = receipt.status
+            if current in (DeliveryStatus.SENT, DeliveryStatus.FAILED):
+                # attempt 终态不可被后续回执覆盖（§4.1），只允许补记 qq id。
+                new_status = current
+            elif current == DeliveryStatus.UNKNOWN and receipt.status != DeliveryStatus.SENT:
+                # unknown 只允许被可信成功回执收敛（§5.5），失败回执不降级。
+                new_status = current
+            if attempt_row["finished_at"] is None or (
+                current == DeliveryStatus.UNKNOWN and new_status == DeliveryStatus.SENT
+            ):
+                conn.execute(
+                    """
+                    UPDATE agent_delivery_attempts
+                    SET status = ?, finished_at = COALESCE(finished_at, ?),
+                        qq_message_id = COALESCE(qq_message_id, ?),
+                        error_code = CASE WHEN ? = 'sent' THEN NULL ELSE ? END
+                    WHERE attempt_id = ?
+                    """,
+                    (
+                        new_status, _utc_now(),
+                        receipt.message_id if new_status == DeliveryStatus.SENT else None,
+                        new_status, receipt.error_code, attempt.attempt_id,
+                    ),
+                )
+            loop_row = conn.execute(
+                "SELECT closed_at FROM agent_loops WHERE loop_id = ?",
+                (delivery_row["loop_id"],),
+            ).fetchone()
+            if loop_row is not None and loop_row["closed_at"] is not None:
+                conn.execute(
+                    "UPDATE agent_loops SET replay_revision = replay_revision + 1 WHERE loop_id = ?",
+                    (delivery_row["loop_id"],),
+                )
+            conn.execute(
+                "UPDATE agent_deliveries SET status = ? WHERE delivery_id = ? AND status != 'sent'",
+                (new_status, attempt_row["delivery_id"]),
+            )
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    def close_loop(
+        self, handle: LoopHandle, status: LoopStatus, reason: str | None
+    ) -> None:
+        """幂等关闭（§4.2/§5.5：基于已提交子项补齐缺失终态后关闭一次）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                "SELECT closed_at FROM agent_loops WHERE loop_id = ?", (handle.loop_id,)
+            ).fetchone()
+            if row is None:
+                raise AgentStoreError(f"loop={handle.loop_id} 不存在")
+            if row["closed_at"] is not None:
+                conn.commit()
+                return
+            # 收敛在途子项（§5.5）：未开始的交付 skipped、未落库回执 unknown。
+            conn.execute(
+                """
+                UPDATE agent_deliveries SET status = ?
+                WHERE loop_id = ? AND status = ?
+                """,
+                (DeliveryStatus.SKIPPED, handle.loop_id, DeliveryStatus.PLANNED),
+            )
+            conn.execute(
+                """
+                UPDATE agent_delivery_attempts SET status = ?, finished_at = COALESCE(finished_at, ?)
+                WHERE status = ?
+                  AND delivery_id IN (SELECT delivery_id FROM agent_deliveries WHERE loop_id = ?)
+                """,
+                (DeliveryStatus.UNKNOWN, _utc_now(), DeliveryStatus.SENDING, handle.loop_id),
+            )
+            conn.execute(
+                """
+                UPDATE agent_deliveries SET status = ?
+                WHERE loop_id = ? AND status = ?
+                """,
+                (DeliveryStatus.UNKNOWN, handle.loop_id, DeliveryStatus.SENDING),
+            )
+            conn.execute(
+                "UPDATE agent_loops SET closed_at = ?, status = ?, terminal_reason = ? WHERE loop_id = ?",
+                (_utc_now(), status, reason, handle.loop_id),
+            )
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _loop_closed(conn: sqlite3.Connection, handle: LoopHandle) -> bool:
+        row = conn.execute(
+            "SELECT closed_at FROM agent_loops WHERE loop_id = ?", (handle.loop_id,)
+        ).fetchone()
+        return row is not None and row["closed_at"] is not None
+
+    # ── 读取 ─────────────────────────────────────────────────────
+
+    def load_closed_loops(
+        self, scope_key: str, anchor_row_id: int | None = None
+    ) -> list[LoadedLoop]:
+        """读取完整已关闭 Loop（§8.1：只返回完整 Loop，ASC 全量读）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        with self._connect() as conn:
+            loops = conn.execute(
+                """
+                SELECT * FROM agent_loops
+                WHERE scope_key = ? AND closed_at IS NOT NULL
+                  AND (? IS NULL OR anchor_row_id >= ?)
+                ORDER BY anchor_row_id ASC
+                """,
+                (scope_key, anchor_row_id, anchor_row_id),
+            ).fetchall()
+            result: list[LoadedLoop] = []
+            for loop in loops:
+                result.append(self._load_one_loop(conn, loop))
+        return result
+
+    def _load_one_loop(self, conn: sqlite3.Connection, loop: sqlite3.Row) -> LoadedLoop:
+        loop_id = loop["loop_id"]
+        user_row: dict[str, Any] = {}
+        if loop["anchor_row_id"] is not None:
+            anchor = conn.execute(
+                """
+                SELECT id, user_id, sender_name, canonical_name, role, content,
+                       message_id, raw_content, created_at
+                FROM conversation_messages WHERE id = ?
+                """,
+                (loop["anchor_row_id"],),
+            ).fetchone()
+            if anchor is not None:
+                user_row = {key: anchor[key] for key in anchor.keys()}
+        turns = conn.execute(
+            "SELECT * FROM agent_turns WHERE loop_id = ? ORDER BY turn_index ASC",
+            (loop_id,),
+        ).fetchall()
+        all_deliveries = tuple(
+            self._load_one_delivery(conn, row)
+            for row in conn.execute(
+                "SELECT * FROM agent_deliveries WHERE loop_id = ? ORDER BY delivery_index ASC",
+                (loop_id,),
+            ).fetchall()
+        )
+        loaded_turns: list[LoadedTurn] = []
+        for turn in turns:
+            loaded_tools = tuple(
+                LoadedToolExecution(
+                    execution_id=row["execution_id"],
+                    call_index=int(row["call_index"]),
+                    provider_call_id=row["provider_call_id"],
+                    tool_name=row["tool_name"],
+                    arguments_json=row["arguments_json"],
+                    arguments_omission_reason=row["arguments_omission_reason"],
+                    status=row["status"],
+                    result=json.loads(row["result_json"]) if row["result_json"] else None,
+                    result_retention=row["result_retention"],
+                    result_omission_reason=row["result_omission_reason"],
+                    outbound_media=(
+                        json.loads(row["outbound_media_json"])["items"]
+                        if row["outbound_media_json"] else []
+                    ),
+                )
+                for row in conn.execute(
+                    "SELECT * FROM agent_tool_executions WHERE turn_id = ? ORDER BY call_index ASC",
+                    (turn["turn_id"],),
+                ).fetchall()
+            )
+            loaded_deliveries = tuple(
+                d for d in all_deliveries if d.turn_id == turn["turn_id"]
+            )
+            message = conn.execute(
+                "SELECT content FROM conversation_messages WHERE id = ?",
+                (turn["message_row_id"],),
+            ).fetchone()
+            loaded_turns.append(
+                LoadedTurn(
+                    turn_id=turn["turn_id"],
+                    turn_index=int(turn["turn_index"]),
+                    message_row_id=turn["message_row_id"],
+                    text=message["content"] if message is not None else "",
+                    parts=tuple(json.loads(turn["parts_json"])["parts"]),
+                    native_state=(
+                        json.loads(turn["native_state_json"])
+                        if turn["native_state_json"] else None
+                    ),
+                    native_omission_reason=turn["native_omission_reason"],
+                    owner=json.loads(turn["owner_json"]) if turn["owner_json"] else None,
+                    finish_reason=turn["finish_reason"],
+                    text_policy=turn["text_policy"],
+                    output_status=turn["output_status"],
+                    delivery_policy=turn["delivery_policy"],
+                    tools=loaded_tools,
+                    deliveries=loaded_deliveries,
+                )
+            )
+        return LoadedLoop(
+            loop_id=loop_id,
+            scope_key=loop["scope_key"],
+            anchor_row_id=int(loop["anchor_row_id"] or 0),
+            trigger_kind=loop["trigger_kind"],
+            started_at=loop["started_at"],
+            closed_at=loop["closed_at"],
+            status=loop["status"],
+            terminal_reason=loop["terminal_reason"],
+            legacy=bool(loop["legacy"]),
+            replay_revision=int(loop["replay_revision"]),
+            record_bytes=int(loop["record_bytes"]),
+            user_row=user_row,
+            turns=tuple(loaded_turns),
+            deliveries=all_deliveries,
+        )
+
+    @staticmethod
+    def _load_one_delivery(conn: sqlite3.Connection, row: sqlite3.Row) -> LoadedDelivery:
+        qq_ids = [
+            r["qq_message_id"]
+            for r in conn.execute(
+                "SELECT qq_message_id FROM agent_delivery_attempts WHERE delivery_id = ? AND qq_message_id IS NOT NULL",
+                (row["delivery_id"],),
+            )
+        ]
+        return LoadedDelivery(
+            delivery_id=row["delivery_id"],
+            kind=row["kind"],
+            turn_id=row["turn_id"],
+            tool_execution_id=row["tool_execution_id"],
+            chunk_index=row["chunk_index"],
+            source_start=row["source_start"],
+            source_end=row["source_end"],
+            status=row["status"],
+            recall_status=row["recall_status"],
+            qq_message_ids=tuple(qq_ids),
+        )
+
+    def lookup_delivery(self, scope_key: str, qq_message_id: str) -> dict[str, Any] | None:
+        """QQ ID → 确切 delivery 溯源（§4.1：必须带 scope 谓词）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT d.delivery_id, d.loop_id, d.turn_id, d.kind, d.chunk_index,
+                       d.source_start, d.source_end, d.status, d.recall_status,
+                       a.attempt_id, a.qq_message_id
+                FROM agent_delivery_attempts a
+                JOIN agent_deliveries d ON d.delivery_id = a.delivery_id
+                JOIN agent_loops l ON l.loop_id = d.loop_id
+                WHERE l.scope_key = ? AND a.qq_message_id = ?
+                ORDER BY a.attempt_index ASC
+                LIMIT 1
+                """,
+                (scope_key, str(qq_message_id)),
+            ).fetchone()
+        return None if row is None else {key: row[key] for key in row.keys()}
+
+    # ── 恢复与保留 ───────────────────────────────────────────────
+
+    def recover_unfinished_loops(self) -> RecoveryReport:
+        """进程崩溃后的恢复（§5.5）：新 Bot 进程执行，幂等。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        closed: list[str] = []
+        tools_not_executed: list[str] = []
+        tools_indeterminate: list[str] = []
+        deliveries_skipped: list[str] = []
+        deliveries_unknown: list[str] = []
+        with self._connect() as conn:
+            loops = conn.execute(
+                "SELECT loop_id, scope_key, scope_generation, trigger_kind FROM agent_loops WHERE closed_at IS NULL"
+            ).fetchall()
+        for loop in loops:
+            handle = LoopHandle(
+                loop_id=loop["loop_id"],
+                scope_key=loop["scope_key"],
+                scope_generation=int(loop["scope_generation"]),
+                trigger_kind=TriggerKind(loop["trigger_kind"]),
+            )
+            skipped, unknown = self._recover_one_loop(handle)
+            closed.append(handle.loop_id)
+            tools_not_executed.extend(skipped["tools"])
+            tools_indeterminate.extend(skipped["indeterminate"])
+            deliveries_skipped.extend(skipped["deliveries"])
+            deliveries_unknown.extend(unknown)
+        return RecoveryReport(
+            closed_loops=tuple(closed),
+            tools_not_executed=tuple(tools_not_executed),
+            tools_indeterminate=tuple(tools_indeterminate),
+            deliveries_skipped=tuple(deliveries_skipped),
+            deliveries_unknown=tuple(deliveries_unknown),
+        )
+
+    def _recover_one_loop(
+        self, handle: LoopHandle
+    ) -> tuple[dict[str, list[str]], list[str]]:
+        """§5.5 恢复表的单 Loop 落地：补齐缺失终态后幂等关闭为 interrupted。"""
+        tools: list[str] = []
+        indeterminate: list[str] = []
+        planned_deliveries: list[str] = []
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            declared = conn.execute(
+                """
+                SELECT e.execution_id FROM agent_tool_executions e
+                JOIN agent_turns t ON t.turn_id = e.turn_id
+                WHERE t.loop_id = ? AND e.status = ?
+                """,
+                (handle.loop_id, ToolExecutionStatus.DECLARED),
+            ).fetchall()
+            for row in declared:
+                conn.execute(
+                    """
+                    UPDATE agent_tool_executions
+                    SET status = ?, result_json = COALESCE(result_json, ?), finished_at = COALESCE(finished_at, ?)
+                    WHERE execution_id = ?
+                    """,
+                    (
+                        ToolExecutionStatus.NOT_EXECUTED,
+                        self._bounded_result_json(None, ResultRetention.BOUNDED, ToolSkipReason.RECOVERY),
+                        _utc_now(), row["execution_id"],
+                    ),
+                )
+                tools.append(row["execution_id"])
+            running = conn.execute(
+                """
+                SELECT e.execution_id FROM agent_tool_executions e
+                JOIN agent_turns t ON t.turn_id = e.turn_id
+                WHERE t.loop_id = ? AND e.status = ?
+                """,
+                (handle.loop_id, ToolExecutionStatus.RUNNING),
+            ).fetchall()
+            for row in running:
+                conn.execute(
+                    "UPDATE agent_tool_executions SET status = ?, finished_at = COALESCE(finished_at, ?) WHERE execution_id = ?",
+                    (ToolExecutionStatus.INDETERMINATE, _utc_now(), row["execution_id"]),
+                )
+                indeterminate.append(row["execution_id"])
+            planned_deliveries = [
+                row["delivery_id"]
+                for row in conn.execute(
+                    "SELECT delivery_id FROM agent_deliveries WHERE loop_id = ? AND status = ?",
+                    (handle.loop_id, DeliveryStatus.PLANNED),
+                ).fetchall()
+            ]
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+        # close_loop 收敛 planned→skipped、sending→unknown 并关闭；关闭后
+        # 仍为 unknown 的 delivery 即"回执未落库"集合（§5.5 第 3 行）。
+        self.close_loop(handle, LoopStatus.INTERRUPTED, "process_recovery")
+        unknown = self._sending_delivery_ids(handle.loop_id)
+        return (
+            {
+                "tools": tools,
+                "indeterminate": indeterminate,
+                "deliveries": planned_deliveries,
+            },
+            unknown,
+        )
+
+    def _sending_delivery_ids(self, loop_id: str) -> list[str]:
+        with self._connect() as conn:
+            rows = conn.execute(
+                "SELECT delivery_id FROM agent_deliveries WHERE loop_id = ? AND status = ?",
+                (loop_id, DeliveryStatus.UNKNOWN),
+            ).fetchall()
+        return [row["delivery_id"] for row in rows]
+
+    def prune_closed_loops(
+        self,
+        scope_key: str,
+        active_anchors: Collection[int],
+        policy: RetentionPolicy,
+    ) -> PruneReport:
+        """D5 保留：按关闭时间/数量/字节清理最旧完整 Loop（§8.4）。
+
+        活动纪元锚点覆盖的 Loop 不清理；硬上限要求越过活动范围时返回
+        ``blocked_active_anchors`` 交由调用方推进纪元后重试。
+        """
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        active = sorted(int(a) for a in active_anchors)
+        floor_anchor = active[0] if active else None
+        deleted: list[str] = []
+        blocked: list[int] = []
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            now = datetime.now(timezone.utc)
+            cutoff_iso = datetime.fromtimestamp(
+                now.timestamp() - policy.retention_days * 86400, timezone.utc
+            ).isoformat()
+            loops = conn.execute(
+                """
+                SELECT loop_id, anchor_row_id, closed_at, record_bytes FROM agent_loops
+                WHERE scope_key = ? AND closed_at IS NOT NULL
+                ORDER BY closed_at ASC, anchor_row_id ASC
+                """,
+                (scope_key,),
+            ).fetchall()
+            queue = deque(dict(row) for row in loops)
+            total_bytes = sum(int(row["record_bytes"]) for row in queue)
+            while queue:
+                row = queue[0]
+                anchor = row["anchor_row_id"]
+                if floor_anchor is not None and anchor is not None and anchor >= floor_anchor:
+                    # 剩余 Loop 全在活动纪元内；硬上限余量只能靠推进锚点。
+                    if len(queue) > policy.max_loops or total_bytes > policy.max_bytes:
+                        blocked = [floor_anchor]
+                    break
+                expired_by_age = str(row["closed_at"]) < cutoff_iso
+                over_count = len(queue) > policy.max_loops
+                over_bytes = total_bytes > policy.max_bytes
+                if not (expired_by_age or over_count or over_bytes):
+                    break
+                self._delete_whole_loop(conn, row["loop_id"])
+                deleted.append(row["loop_id"])
+                queue.popleft()
+                total_bytes -= int(row["record_bytes"])
+            conn.commit()
+        except BaseException:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+        return PruneReport(
+            deleted_loop_ids=tuple(deleted), blocked_active_anchors=tuple(blocked)
+        )
+
+    def _delete_whole_loop(self, conn: sqlite3.Connection, loop_id: str) -> None:
+        """整 Loop 删除（§9.3）：显式按依赖顺序，主表行→Loop（级联侧表）。"""
+        conn.execute(
+            "DELETE FROM conversation_messages WHERE agent_loop_id = ?", (loop_id,)
+        )
+        conn.execute("DELETE FROM agent_loops WHERE loop_id = ?", (loop_id,))

--- a/src/quickquip/llm/store_parts/agent_records.py
+++ b/src/quickquip/llm/store_parts/agent_records.py
@@ -1367,7 +1367,22 @@ class AgentRecordsStoreMixin:
             if row["closed_at"] is not None:
                 conn.commit()
                 return
-            # 收敛在途子项（§5.5）：未开始的交付 skipped、未落库回执 unknown。
+            # 收敛在途子项（§5.5）：未开始的交付 skipped、未落库回执 unknown、
+            # 声明未启动的工具 not_executed（终止原因见 Loop terminal_reason）。
+            conn.execute(
+                """
+                UPDATE agent_tool_executions
+                SET status = ?, result_json = COALESCE(result_json, ?),
+                    finished_at = COALESCE(finished_at, ?)
+                WHERE status = ?
+                  AND turn_id IN (SELECT turn_id FROM agent_turns WHERE loop_id = ?)
+                """,
+                (
+                    ToolExecutionStatus.NOT_EXECUTED,
+                    self._bounded_result_json(None, ResultRetention.BOUNDED, ToolSkipReason.RECOVERY),
+                    _utc_now(), ToolExecutionStatus.DECLARED, handle.loop_id,
+                ),
+            )
             conn.execute(
                 """
                 UPDATE agent_deliveries SET status = ?

--- a/src/quickquip/llm/store_parts/agent_records.py
+++ b/src/quickquip/llm/store_parts/agent_records.py
@@ -868,7 +868,7 @@ class AgentRecordsStoreMixin:
                 ),
             )
             for declaration in tool_declarations:
-                self._insert_tool_declaration(conn, handle, turn_id, declaration)
+                self._insert_tool_declaration(conn, turn_id, declaration)
 
             delivery_ids = self._insert_delivery_plan(
                 conn, handle, turn_id, delivery_plan, text,
@@ -964,7 +964,6 @@ class AgentRecordsStoreMixin:
     @staticmethod
     def _insert_tool_declaration(
         conn: sqlite3.Connection,
-        handle: LoopHandle,
         turn_id: str,
         declaration: ToolDeclarationRecord,
     ) -> None:

--- a/src/quickquip/llm/store_parts/agent_records.py
+++ b/src/quickquip/llm/store_parts/agent_records.py
@@ -280,6 +280,11 @@ def _utf8_head_tail(text: str, budget: int) -> tuple[str, list[tuple[int, int]]]
         tail_start += 1
         omitted = len(text) - head_end - (len(text) - tail_start)
         excerpt = text[:head_end] + f"…[省略 {omitted} 字符]…" + text[tail_start:]
+    while _utf8_bytes(excerpt) > budget and head_end > 0:
+        # 尾部无可收（tail_start 已到串尾）时收缩 head 直至收敛。
+        head_end -= 1
+        omitted = len(text) - head_end - (len(text) - tail_start)
+        excerpt = text[:head_end] + f"…[省略 {omitted} 字符]…" + text[tail_start:]
     ranges = [(0, head_end), (tail_start, len(text))] if tail_start < len(text) else [(0, head_end)]
     return excerpt, ranges
 

--- a/src/quickquip/llm/store_parts/agent_records.py
+++ b/src/quickquip/llm/store_parts/agent_records.py
@@ -1745,6 +1745,26 @@ class AgentRecordsStoreMixin:
             deleted_loop_ids=tuple(deleted), blocked_active_anchors=tuple(blocked)
         )
 
+    def suppress_delivery(self, handle: LoopHandle, delivery_id: str) -> None:
+        """关闭交付开关时非最终正文的收敛（§6.3：suppressed_by_policy）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE agent_deliveries SET status = ? WHERE delivery_id = ? AND loop_id = ? AND status = ?",
+                (DeliveryStatus.SUPPRESSED, delivery_id, handle.loop_id, DeliveryStatus.PLANNED),
+            )
+
+    def set_first_chunk_message_id(self, message_row_id: int, qq_message_id: str) -> None:
+        """兼容列回填（§4.1）：新 assistant 行取首个确认成功 Chunk 的 ID。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        with self._connect() as conn:
+            conn.execute(
+                "UPDATE conversation_messages SET message_id = ? WHERE id = ? AND message_id IS NULL",
+                (str(qq_message_id), int(message_row_id)),
+            )
+
     def _delete_whole_loop(self, conn: sqlite3.Connection, loop_id: str) -> None:
         """整 Loop 删除（§9.3）：显式按依赖顺序，主表行→Loop（级联侧表）。"""
         conn.execute(

--- a/src/quickquip/llm/store_parts/agent_records.py
+++ b/src/quickquip/llm/store_parts/agent_records.py
@@ -1368,7 +1368,8 @@ class AgentRecordsStoreMixin:
                 conn.commit()
                 return
             # 收敛在途子项（§5.5）：未开始的交付 skipped、未落库回执 unknown、
-            # 声明未启动的工具 not_executed（终止原因见 Loop terminal_reason）。
+            # 声明未启动的工具 not_executed、执行中未落结果的工具 indeterminate
+            # （终止原因见 Loop terminal_reason）。
             conn.execute(
                 """
                 UPDATE agent_tool_executions
@@ -1382,6 +1383,15 @@ class AgentRecordsStoreMixin:
                     self._bounded_result_json(None, ResultRetention.BOUNDED, ToolSkipReason.RECOVERY),
                     _utc_now(), ToolExecutionStatus.DECLARED, handle.loop_id,
                 ),
+            )
+            conn.execute(
+                """
+                UPDATE agent_tool_executions
+                SET status = ?, finished_at = COALESCE(finished_at, ?)
+                WHERE status = ?
+                  AND turn_id IN (SELECT turn_id FROM agent_turns WHERE loop_id = ?)
+                """,
+                (ToolExecutionStatus.INDETERMINATE, _utc_now(), ToolExecutionStatus.RUNNING, handle.loop_id),
             )
             conn.execute(
                 """

--- a/src/quickquip/llm/store_parts/conversation.py
+++ b/src/quickquip/llm/store_parts/conversation.py
@@ -90,7 +90,7 @@ class ConversationStoreMixin:
         with self._connect() as conn:
             rows = conn.execute(
                 """
-                SELECT id, user_id, sender_name, canonical_name, role, content, message_id, raw_content
+                SELECT id, user_id, sender_name, canonical_name, role, content, message_id, raw_content, agent_loop_id
                 FROM conversation_messages
                 WHERE group_id = ? AND id >= ?
                 ORDER BY id ASC
@@ -103,6 +103,7 @@ class ConversationStoreMixin:
                 **_normalize_conversation_row(row),
                 "id": int(row["id"]),
                 "message_id": "" if row["message_id"] is None else str(row["message_id"]),
+                "agent_loop_id": row["agent_loop_id"],
             }
             for row in rows
         ]
@@ -215,6 +216,40 @@ class ConversationStoreMixin:
                 (str(group_id), str(message_id)),
             )
             return int(cursor.rowcount)
+
+    def conversation_rows_by_message_id(self, group_id: int | str, message_id: str) -> list[dict[str, object]]:
+        """按平台 message_id 查询主表行（撤回回退路径；不删除）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        with self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT id, role, agent_loop_id FROM conversation_messages
+                WHERE group_id = ? AND message_id = ?
+                ORDER BY id ASC
+                """,
+                (str(group_id), str(message_id)),
+            ).fetchall()
+        return [
+            {"id": int(row["id"]), "role": row["role"], "agent_loop_id": row["agent_loop_id"]}
+            for row in rows
+        ]
+
+    def conversation_row_by_id(self, group_id: int | str, row_id: int) -> dict[str, object] | None:
+        """按主键读取单行（Web 领域删除入口的范围判定）。"""
+        if self._unavailable:
+            raise RuntimeError("LLM存储 数据库不可用")
+        with self._connect() as conn:
+            row = conn.execute(
+                """
+                SELECT id, role, agent_loop_id FROM conversation_messages
+                WHERE group_id = ? AND id = ?
+                """,
+                (str(group_id), int(row_id)),
+            ).fetchone()
+        if row is None:
+            return None
+        return {"id": int(row["id"]), "role": row["role"], "agent_loop_id": row["agent_loop_id"]}
 
     def update_last_assistant_message_id(self, group_id: int | str, message_id: str) -> None:
         if self._unavailable:

--- a/src/quickquip/llm/tool_loop.py
+++ b/src/quickquip/llm/tool_loop.py
@@ -29,7 +29,10 @@ async def run_tool_call_loop(
     tool_discovery_search_limit: int = 5,
     tool_discovery_max_loaded_tools: int = 12,
     image_preprocessor=None,
+    turn_recorder=None,
 ):
+    from quickquip.llm.agent_records import ToolSkipReason
+
     client = build_provider_client(provider)
     max_rounds = max(0, min(runtime_config.tool_max_rounds, 16))
     max_calls = max(1, min(runtime_config.tool_max_calls_per_round, 32))
@@ -80,6 +83,9 @@ async def run_tool_call_loop(
             round_index,
         )
         if not response.tool_calls or not current_request.allow_tool_calls:
+            if turn_recorder is not None:
+                turn_recorder.on_turn(response, declared_calls=[], executable_calls=[], has_more_rounds=False)
+                await turn_recorder.deliver_turn()
             return response
 
         meta_tool_names = {search_tool_name, tool_search_name, tool_list_name}
@@ -90,6 +96,9 @@ async def run_tool_call_loop(
 
         if has_counted_calls and counted_rounds >= max_rounds:
             response.text = response.text or "工具调用轮次已达上限，未能完成最终回答。"
+            if turn_recorder is not None:
+                turn_recorder.on_turn(response, declared_calls=[], executable_calls=[], has_more_rounds=False)
+                await turn_recorder.deliver_turn()
             return response
 
         limited_calls = [
@@ -109,6 +118,9 @@ async def run_tool_call_loop(
                 notice = "模型一次请求了过多工具，已拒绝执行不完整的 Gemini 工具批次。"
                 response.text = "\n".join(part for part in (response.text, notice) if part)
                 response.tool_calls = []
+                if turn_recorder is not None:
+                    turn_recorder.on_turn(response, declared_calls=[], executable_calls=[], has_more_rounds=False)
+                    await turn_recorder.deliver_turn()
                 return response
             # Gemini binds functionResponse batches to the preceding ordered
             # functionCall parts. Keep the provider's order when the full batch
@@ -119,6 +131,9 @@ async def run_tool_call_loop(
 
         if not selected_calls:
             response.text = response.text or "工具调用请求为空，未能完成最终回答。"
+            if turn_recorder is not None:
+                turn_recorder.on_turn(response, declared_calls=[], executable_calls=[], has_more_rounds=False)
+                await turn_recorder.deliver_turn()
             return response
 
         if has_counted_calls:
@@ -126,7 +141,30 @@ async def run_tool_call_loop(
 
         if round_index >= search_failsafe_max_rounds:
             response.text = response.text or "联网检索轮次过多，已触发安全上限，未能完成最终回答。"
+            if turn_recorder is not None:
+                turn_recorder.on_turn(response, declared_calls=[], executable_calls=[], has_more_rounds=False)
+                await turn_recorder.deliver_turn()
             return response
+
+        # ── Turn 原子提交 + 文字交付（§5.3.5-6）：先于工具执行 ──────
+        execution_ids: dict[str, str] = {}
+        if turn_recorder is not None:
+            execution_ids = turn_recorder.on_turn(
+                response,
+                declared_calls=list(response.tool_calls),
+                executable_calls=selected_calls,
+                has_more_rounds=True,
+            )
+            await turn_recorder.deliver_turn()
+            # 超出每轮执行预算的声明逐项 not_executed(limit)（§5.3）。
+            from quickquip.llm.agent_records import ToolSkipReason
+
+            executable_ids = {call.id for call in selected_calls}
+            for call in response.tool_calls:
+                if call.id not in executable_ids:
+                    execution_id = execution_ids.get(call.id)
+                    if execution_id is not None:
+                        turn_recorder.on_tool_skipped(execution_id, ToolSkipReason.ROUND_LIMIT)
 
         assistant_message = LLMConversationMessage(
             role="assistant",
@@ -144,25 +182,26 @@ async def run_tool_call_loop(
         tool_results: list[LLMToolResult] = []
         result_pipeline.begin_round()
         for call in selected_calls:
+            execution_id = execution_ids.get(call.id)
+            if turn_recorder is not None and execution_id is not None:
+                turn_recorder.on_tool_started(execution_id)
             if tool_discovery_enabled and not discovery.is_loaded(call.name):
-                tool_results.append(
-                    LLMToolResult(
-                        call_id=call.id,
-                        name=call.name,
-                        content=f"工具 {call.name} 尚未加载，请先调用 {tool_search_name} 搜索并加载相关工具。",
-                        is_error=True,
-                    )
+                result = LLMToolResult(
+                    call_id=call.id,
+                    name=call.name,
+                    content=f"工具 {call.name} 尚未加载，请先调用 {tool_search_name} 搜索并加载相关工具。",
+                    is_error=True,
                 )
-                continue
-
-            blocked_result = result_pipeline.check_call_arguments(call)
-            if blocked_result is not None:
-                tool_results.append(blocked_result)
-                continue
-
-            result = await tool_registry.execute(call, context)
-            result = await result_pipeline.process_result(call, result)
+            else:
+                blocked_result = result_pipeline.check_call_arguments(call)
+                if blocked_result is not None:
+                    result = blocked_result
+                else:
+                    result = await tool_registry.execute(call, context)
+                    result = await result_pipeline.process_result(call, result)
             tool_results.append(result)
+            if turn_recorder is not None and execution_id is not None:
+                turn_recorder.on_tool_finished(execution_id, result)
             if tool_discovery_enabled and call.name == tool_search_name and not result.is_error:
                 newly_loaded = discovery.load_from_search_call(call)
                 if newly_loaded:

--- a/src/quickquip/llm/tool_loop.py
+++ b/src/quickquip/llm/tool_loop.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from quickquip.llm.agent_records import ToolSkipReason
 from quickquip.llm.provider import LLMRequest
 from quickquip.llm.provider.trace import trace_agent_loop
 from quickquip.llm.tool_discovery import ToolDiscovery
@@ -32,7 +33,6 @@ async def run_tool_call_loop(
     turn_recorder=None,
     request_guard=None,
 ):
-    from quickquip.llm.agent_records import ToolSkipReason
 
     client = build_provider_client(provider)
     max_rounds = max(0, min(runtime_config.tool_max_rounds, 16))

--- a/src/quickquip/llm/tool_loop.py
+++ b/src/quickquip/llm/tool_loop.py
@@ -30,6 +30,7 @@ async def run_tool_call_loop(
     tool_discovery_max_loaded_tools: int = 12,
     image_preprocessor=None,
     turn_recorder=None,
+    request_guard=None,
 ):
     from quickquip.llm.agent_records import ToolSkipReason
 
@@ -72,6 +73,10 @@ async def run_tool_call_loop(
         )
 
     for round_index in range(search_failsafe_max_rounds + 1):
+        if request_guard is not None:
+            # §8.3：每次 provider HTTP 尝试前对最终 payload 复检预算；
+            # 超限按契约终止 Loop（request_budget_exceeded），不放行 HTTP。
+            request_guard(current_request)
         # 上游 429/5xx 的退避重试由 provider client 的 complete() 内建
         response = await client.complete(current_request)
         logger.info(
@@ -117,10 +122,21 @@ async def run_tool_call_loop(
                 # 整批拒绝的提示必须追加而非兜底：模型附带的叙述文本不应顶替拒绝说明。
                 notice = "模型一次请求了过多工具，已拒绝执行不完整的 Gemini 工具批次。"
                 response.text = "\n".join(part for part in (response.text, notice) if part)
-                response.tool_calls = []
                 if turn_recorder is not None:
-                    turn_recorder.on_turn(response, declared_calls=[], executable_calls=[], has_more_rounds=False)
+                    # 整批拒绝仍保留声明事实（§3.2）：全部声明记
+                    # not_executed(batch_limit)，notice 文本照常交付。
+                    execution_ids = turn_recorder.on_turn(
+                        response,
+                        declared_calls=list(response.tool_calls),
+                        executable_calls=[],
+                        has_more_rounds=False,
+                    )
                     await turn_recorder.deliver_turn()
+                    for call in response.tool_calls:
+                        execution_id = execution_ids.get(call.id)
+                        if execution_id is not None:
+                            turn_recorder.on_tool_skipped(execution_id, ToolSkipReason.BATCH_LIMIT)
+                response.tool_calls = []
                 return response
             # Gemini binds functionResponse batches to the preceding ordered
             # functionCall parts. Keep the provider's order when the full batch
@@ -157,8 +173,6 @@ async def run_tool_call_loop(
             )
             await turn_recorder.deliver_turn()
             # 超出每轮执行预算的声明逐项 not_executed(limit)（§5.3）。
-            from quickquip.llm.agent_records import ToolSkipReason
-
             executable_ids = {call.id for call in selected_calls}
             for call in response.tool_calls:
                 if call.id not in executable_ids:

--- a/src/quickquip/llm/tools.py
+++ b/src/quickquip/llm/tools.py
@@ -48,6 +48,11 @@ class LLMConversationMessage:
     tool_name: str | None = None
     is_tool_error: bool = False
     thinking_blocks: list[Any] = field(default_factory=list)
+    # 协议原生 assistant 内容块（§7.2 原生路径）：Claude 的有序 content /
+    # Gemini 的有序 parts。设置时序列化端原样深拷贝使用，不再从
+    # content/tool_calls/thinking_blocks 重建——原生已有正文/calls 时不能
+    # 追加通用副本。仅重放投影写入；当轮请求组装不使用。
+    native_content: list[Any] | None = None
 
 
 @dataclass(slots=True)

--- a/tests/fixtures/agent_loop.py
+++ b/tests/fixtures/agent_loop.py
@@ -14,6 +14,7 @@ import sqlite3
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from quickquip.llm.agent_records import DeliveryReceipt, DeliveryStatus
 from quickquip.llm.provider import LLMRequest, LLMResponse
 from quickquip.llm.tools import LLMToolCall
 
@@ -227,3 +228,22 @@ def build_legacy_db(path: Path) -> None:
         conn.commit()
     finally:
         conn.close()
+
+
+# ── 交付 sink（测试收集实现，§5.1） ─────────────────────────────────
+
+
+class CollectingSink:
+    """收集型交付 sink：记录 (delivery_id, payload) 并回执 sent。"""
+
+    def __init__(self) -> None:
+        self.deliveries: list[tuple[str, dict]] = []
+        self.receipts: list[DeliveryReceipt] = []
+
+    async def __call__(self, delivery_id: str, payload: dict) -> DeliveryReceipt:
+        self.deliveries.append((delivery_id, payload))
+        receipt = DeliveryReceipt(
+            status=DeliveryStatus.SENT, message_id=f"collect-{len(self.deliveries)}"
+        )
+        self.receipts.append(receipt)
+        return receipt

--- a/tests/fixtures/agent_loop.py
+++ b/tests/fixtures/agent_loop.py
@@ -1,0 +1,229 @@
+"""Agent Loop 记录/重放/分段交付的测试 fixture（1.15 实施计划 §12.A）。
+
+全部内容为自造测试数据：结构对齐 §1.1 生产样本（五 Turn、七工具调用、
+前四 Turn 普通正文 32/31/50/31 code point、末 Turn 374 code point），
+正文、身份与端点均不复制生产内容。
+
+拆分口径约定（§11.2）：默认阈值 800 下末 Turn 374 保持一段；测试用
+显式切分参数（见 AGENT_LOOP_TEST_SPLIT）使末 Turn 确定形成三段，
+与前四 Turn 各一段合计七个文字 Chunk。
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from quickquip.llm.provider import LLMRequest, LLMResponse
+from quickquip.llm.tools import LLMToolCall
+
+# ── 五 Turn 主例正文（长度由 test_agent_loop_baseline 自检锁定） ──────────
+
+FIVE_TURN_TEXTS: tuple[str, ...] = (
+    # 32 cp：Turn 0 普通正文，先于其工具执行交付
+    "咦，K甲夏季赛？这个话题有点意思，让我先去查查一下现在的赛况——",
+    # 31 cp
+    "等我确认一下各支战队最近的选手名单和目前的积分情况，稍后再说。",
+    # 50 cp
+    "两支队伍最近的交手记录很有参考价值，我再看看有没有关键选手受伤的消息，这些细节都会影响接下来的走势。",
+    # 31 cp
+    "两边的最新情况基本都摸清楚了，我来整理一下这届比赛的主要看点。",
+    # 374 cp：末 Turn，三段式（空行分界），测试切分参数下为 3 Chunk
+    "先说结论：这届K甲夏季赛的格局比春季赛清晰不少，几个关键变量都落定了。\n\n"
+    "积分榜前两名的队伍都保持了稳定的首发阵容，中游集团则因为两笔转会出现了明显的风格分化——一支偏向中期抱团速攻，另一支坚持四一分推打运营。从最近两周的交手记录看，速攻体系在前十五分钟的经济领先转化率很高，但一旦拖入后期决策就容易上头；运营队恰好相反，前期被动，三十分钟后的大龙团处理明显更冷静，资源置换的细节也更扎实。关键选手方面，目前没有新的伤病名单，之前手腕不适的那位已经回到了首发训练，教练组也在采访里确认了季后赛的轮换思路。\n\n"
+    "整体来看，淘汰赛的看点会是两种节奏的正面对撞：一边要把比赛拖进自己的前期攻势里解决战斗，另一边只要稳住前中期就有很大机会把节奏抓回来。我的判断是运营队略占上风，但差距没有大到没有悬念的程度，具体还要看当天的版本理解、临场指挥调度和选手状态。",
+)
+
+# 七次工具调用按 1/2/2/2 分布在前四个 Turn；全部走本地 get_identity，
+# 不依赖网络。查询词来自测试身份 fixture 的别名。
+FIVE_TURN_TOOL_QUERIES: tuple[tuple[str, ...], ...] = (
+    ("镜子",),
+    ("4s", "哈基镜"),
+    ("Туманность", "镜千翎"),
+    ("哈基四", "镜子"),
+    (),
+)
+
+# 测试切分参数（§11.2：显式测试值，不改产品默认）：末 Turn 217 字符的
+# 中段超过 threshold，三段在空行/句末边界各自成 Chunk。
+AGENT_LOOP_TEST_SPLIT = {"threshold": 120, "chunk_max": 240}
+
+
+def five_turn_tool_calls() -> list[list[LLMToolCall]]:
+    calls: list[list[LLMToolCall]] = []
+    counter = 0
+    for turn_index, queries in enumerate(FIVE_TURN_TOOL_QUERIES):
+        batch = [
+            LLMToolCall(
+                id=f"call_{turn_index}_{offset}",
+                name="get_identity",
+                arguments_json=f'{{"query":"{query}"}}',
+            )
+            for offset, query in enumerate(queries)
+        ]
+        counter += len(batch)
+        calls.append(batch)
+    assert counter == 7, "五 Turn 主例必须恰好七次工具调用（§11.2）"
+    return calls
+
+
+@dataclass
+class FiveTurnScenarioClient:
+    """按剧本回放五 Turn 场景的 stub provider client。
+
+    ``protocol`` 切换 thinking 块的协议原生形态（openai/claude/gemini），
+    正文与工具调用不变；``requests`` 记录每次实际请求供断言。
+    """
+
+    protocol: str = "openai"
+    requests: list[LLMRequest] = field(default_factory=list)
+
+    async def complete(self, request: LLMRequest) -> LLMResponse:
+        self.requests.append(request)
+        turn_index = self._turn_index()
+        text = FIVE_TURN_TEXTS[turn_index]
+        tool_calls = five_turn_tool_calls()[turn_index]
+        thinking_blocks = _native_thinking_blocks(self.protocol, turn_index)
+        return LLMResponse(
+            text=text,
+            model=request.model,
+            tool_calls=tool_calls,
+            finish_reason="tool_calls" if tool_calls else "stop",
+            input_tokens=100 + 37 * turn_index,
+            output_tokens=17 * (turn_index + 1),
+            thinking_blocks=thinking_blocks,
+        )
+
+    def _turn_index(self) -> int:
+        # 请求里的 assistant 消息数 = 已完成 Turn 数。
+        completed = sum(1 for m in self.requests[-1].messages if m.role == "assistant")
+        assert completed < len(FIVE_TURN_TEXTS), "剧本耗尽：五 Turn 之外不应再有请求"
+        return completed
+
+
+def _native_thinking_blocks(protocol: str, turn_index: int) -> list[dict]:
+    """三协议的原生 thinking 中间表示样例（结构与 provider 解析器一致）。"""
+    label = f"turn{turn_index}"
+    if protocol == "claude":
+        return [
+            {"type": "thinking", "thinking": f"先核对榜单再回答（{label}）。", "signature": f"sig-{label}"},
+            {"type": "redacted_thinking", "data": f"redacted-{label}"},
+        ]
+    if protocol == "gemini":
+        # replay_required 形态：带 thoughtSignature 的 part 包成 gemini_part
+        return [
+            {"type": "gemini_part", "part": {"text": f"检索线索（{label}）", "thoughtSignature": f"ts-{label}"}},
+        ]
+    return [{"type": "reasoning", "reasoning_content": f"解题思路（{label}）。"}]
+
+
+# ── 三协议 wire 结构样例（投影/序列化测试用，§7.4 兼容矩阵输入） ──────────
+
+OPENAI_NATIVE_TOOL_TURN = {
+    "role": "assistant",
+    "content": FIVE_TURN_TEXTS[1],
+    "reasoning_content": "解题思路（turn1）。",
+    "tool_calls": [
+        {"id": "call_1_0", "type": "function", "function": {"name": "get_identity", "arguments": '{"query":"4s"}'}},
+        {"id": "call_1_1", "type": "function", "function": {"name": "get_identity", "arguments": '{"query":"哈基镜"}'}},
+    ],
+}
+
+CLAUDE_NATIVE_TOOL_TURN = {
+    "role": "assistant",
+    "content": [
+        {"type": "thinking", "thinking": "先核对榜单再回答（turn1）。", "signature": "sig-turn1"},
+        {"type": "text", "text": FIVE_TURN_TEXTS[1]},
+        {"type": "tool_use", "id": "call_1_0", "name": "get_identity", "input": {"query": "4s"}},
+        {"type": "tool_use", "id": "call_1_1", "name": "get_identity", "input": {"query": "哈基镜"}},
+    ],
+}
+
+GEMINI_NATIVE_TOOL_TURN = {
+    "role": "model",
+    "parts": [
+        {"text": "检索线索（turn1）。", "thoughtSignature": "ts-turn1", "thought": True},
+        {"text": FIVE_TURN_TEXTS[1]},
+        {"functionCall": {"id": "gemini_tool_1", "name": "get_identity", "args": {"query": "4s"}}},
+        {"functionCall": {"id": "gemini_tool_2", "name": "get_identity", "args": {"query": "哈基镜"}}},
+    ],
+}
+
+
+# ── 旧库 fixture（§4.3 迁移测试输入：1.15 之前的 schema 与行形态） ─────────
+
+LEGACY_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS conversation_messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    group_id TEXT NOT NULL,
+    user_id TEXT,
+    sender_name TEXT,
+    canonical_name TEXT,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    message_id TEXT,
+    raw_content TEXT,
+    created_at TEXT NOT NULL
+);
+"""
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyRow:
+    group_id: str
+    user_id: str | None
+    sender_name: str | None
+    canonical_name: str | None
+    role: str
+    content: str
+    message_id: str | None = None
+    raw_content: str | None = None
+    created_at: str = "2026-08-01T00:00:00+00:00"
+
+
+def legacy_rows() -> list[LegacyRow]:
+    """覆盖 §4.3 迁移分组的四种形态：成对、连续 user、无 receipt、孤立段。
+
+    按提交顺序排列（id 即插入顺序）：
+    - a0 孤立 assistant（legacy_orphan）
+    - u1/a1 成对（a1 无 message_id → legacy_untracked）
+    - u2、u3 连续 user（各自独立 Loop；u3 后跟 a3）
+    - a3 带 message_id="m3"（覆盖全文的 sent receipt）
+    """
+    return [
+        LegacyRow("1001", None, None, None, "assistant", "开场白：新版本已就位。"),
+        LegacyRow("1001", "2002", "镜子", "镜子", "user", "今天K甲决赛几点开始？"),
+        LegacyRow("1001", None, None, None, "assistant", "晚上七点开始，我先帮你盯着赛程。"),
+        LegacyRow("1001", "4004", "4s", "4s", "user", "顺便问下参赛队伍名单。"),
+        LegacyRow("1001", "2002", "镜子", "镜子", "user", "名单出来了吗？"),
+        LegacyRow("1001", None, None, None, "assistant", "名单已出，八支队伍。", message_id="m3"),
+    ]
+
+
+def build_legacy_db(path: Path) -> None:
+    """写入 1.15 之前形态的 llm.db（旧 schema + legacy_rows）。"""
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(LEGACY_SCHEMA_SQL)
+        for row in legacy_rows():
+            conn.execute(
+                """
+                INSERT INTO conversation_messages
+                    (group_id, user_id, sender_name, canonical_name, role, content, message_id, raw_content, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row.group_id,
+                    row.user_id,
+                    row.sender_name,
+                    row.canonical_name,
+                    row.role,
+                    row.content,
+                    row.message_id,
+                    row.raw_content,
+                    row.created_at,
+                ),
+            )
+        conn.commit()
+    finally:
+        conn.close()

--- a/tests/integration/test_agent_loop_baseline.py
+++ b/tests/integration/test_agent_loop_baseline.py
@@ -1,0 +1,175 @@
+"""1.15 基线缺口核对（实施计划 §12.A）。
+
+本文件在当前实现上固定两件事：
+
+1. **fixture 契约自检**——五 Turn 主例的正文长度（32/31/50/31/374 code
+   point）与七次工具调用分布，防止 fixture 漂移破坏 §11.2 的验收计数。
+2. **基线缺口特征化**——五 Turn 场景跑在当前实现上，仅末 Turn 正文进入
+   history（一条 assistant 行），中间四个 Turn 的普通正文既不落库也无
+   交付记录。特征化测试锁定现状；带 ``xfail(strict=True)`` 的目标测试
+   声明 1.15 契约，实现落地后 XPASS 会强制摘除标记。
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from plugins.llm_runtime import LLMService
+from tests.fixtures.agent_loop import (
+    AGENT_LOOP_TEST_SPLIT,
+    FIVE_TURN_TEXTS,
+    FiveTurnScenarioClient,
+    build_legacy_db,
+    five_turn_tool_calls,
+)
+from tests.fixtures.configs import write_llm_config_bundle
+
+def _scenario_toml(base_toml: str) -> str:
+    # 五 Turn 场景需要 4 个工具轮次；默认 fixture 配置 tool_max_rounds=2。
+    return base_toml.replace("tool_max_rounds = 2", "tool_max_rounds = 8")
+
+
+@pytest.fixture
+def scenario_service(tmp_path: Path) -> LLMService:
+    from tests.fixtures.configs import MIN_LLM_CONFIG_TOML
+
+    paths = write_llm_config_bundle(
+        tmp_path, config_toml=_scenario_toml(MIN_LLM_CONFIG_TOML)
+    )
+    return LLMService(**paths)
+
+
+@pytest.fixture
+def patch_scenario_provider(scenario_service, patch_provider_builder):
+    def _patch(protocol: str = "openai") -> FiveTurnScenarioClient:
+        client = FiveTurnScenarioClient(protocol=protocol)
+        patch_provider_builder(lambda provider: client)
+        return client
+
+    return _patch
+
+
+async def run_five_turn_scenario(service: LLMService) -> dict:
+    return await service.generate_reply(
+        group_id=1001,
+        user_id="2002",
+        sender_name="镜子",
+        prompt="K甲夏季赛现在赛况如何？",
+    )
+
+
+# ── fixture 契约自检 ────────────────────────────────────────────────
+
+
+def test_five_turn_fixture_contract():
+    assert [len(text) for text in FIVE_TURN_TEXTS] == [32, 31, 50, 31, 374]
+    batches = five_turn_tool_calls()
+    assert [len(batch) for batch in batches] == [1, 2, 2, 2, 0]
+    assert sum(len(batch) for batch in batches) == 7
+    # 末 Turn 必须存在空行分界：测试切分参数下形成三段的前提。
+    assert FIVE_TURN_TEXTS[4].count("\n\n") == 2
+
+
+def test_legacy_fixture_rows_cover_migration_groups(tmp_path: Path):
+    db_path = tmp_path / "llm.db"
+    build_legacy_db(db_path)
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = conn.execute(
+            "SELECT role, message_id FROM conversation_messages ORDER BY id"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert [role for role, _ in rows] == [
+        "assistant", "user", "assistant", "user", "user", "assistant",
+    ]
+    # 无 receipt 的 assistant（legacy_untracked）与带 receipt 的（sent）各一。
+    assert [mid for _, mid in rows if mid is not None] == ["m3"]
+
+
+# ── 基线缺口特征化（当前实现的事实，实现落地后改写为目标断言） ─────────
+
+
+async def test_baseline_only_final_turn_text_persists(
+    scenario_service, patch_scenario_provider
+):
+    """当前实现：五 Turn 场景只有末 Turn 正文落库为一条 assistant 行。"""
+    client = patch_scenario_provider("openai")
+    assert len(client.requests) == 0  # 场景尚未跑
+
+    result = await run_five_turn_scenario(scenario_service)
+
+    # 五次模型请求确实发生（五 Turn 都完整收到）。
+    assert len(client.requests) == 5
+    # 但 history 只落了一条 assistant 行，内容 = 末 Turn 正文。
+    rows = scenario_service.store.list_recent_conversation_messages(1001, limit=50)
+    assistant_rows = [row for row in rows if row["role"] == "assistant"]
+    assert len(assistant_rows) == 1
+    assert assistant_rows[0]["content"] == FIVE_TURN_TEXTS[4]
+    # 前四个 Turn 的普通正文（32/31/50/31 cp）不在任何持久化正文中。
+    persisted = "\n".join(row["content"] for row in rows)
+    for text in FIVE_TURN_TEXTS[:4]:
+        assert text not in persisted
+    # 交付缺口同样存在：reply 只含末 Turn 正文。
+    assert result["reply"] == FIVE_TURN_TEXTS[4]
+
+
+@pytest.mark.xfail(
+    reason="1.15 目标：每个已提交 Turn 落一条 assistant 行（§3.2/§12.B）",
+    strict=True,
+)
+async def test_target_every_turn_persists_assistant_row(
+    scenario_service, patch_scenario_provider
+):
+    patch_scenario_provider("openai")
+    await run_five_turn_scenario(scenario_service)
+
+    rows = scenario_service.store.list_recent_conversation_messages(1001, limit=50)
+    assistant_rows = [row for row in rows if row["role"] == "assistant"]
+    assert [row["content"] for row in assistant_rows] == list(FIVE_TURN_TEXTS)
+
+
+@pytest.mark.xfail(
+    reason="1.15 目标：Loop/Turn/工具/交付侧表与逐 Turn 关联（§4.1/§12.B）",
+    strict=True,
+)
+async def test_target_agent_loop_side_tables_exist(
+    scenario_service, patch_scenario_provider
+):
+    patch_scenario_provider("openai")
+    await run_five_turn_scenario(scenario_service)
+
+    store = scenario_service.store
+    with store._connect() as conn:
+        loop_count = conn.execute("SELECT COUNT(*) FROM agent_loops").fetchone()[0]
+    assert loop_count == 1
+
+
+@pytest.mark.xfail(
+    reason="1.15 目标：测试切分参数下七文字 Chunk（§11.2 五轮主例验收）",
+    strict=True,
+)
+async def test_target_seven_text_chunks_with_test_split(
+    scenario_service, patch_scenario_provider, monkeypatch
+):
+    monkeypatch.setattr(
+        scenario_service.config.runtime,
+        "reply_split_threshold_chars",
+        AGENT_LOOP_TEST_SPLIT["threshold"],
+    )
+    monkeypatch.setattr(
+        scenario_service.config.runtime,
+        "reply_chunk_max_chars",
+        AGENT_LOOP_TEST_SPLIT["chunk_max"],
+    )
+    patch_scenario_provider("openai")
+    result = await run_five_turn_scenario(scenario_service)
+
+    with scenario_service.store._connect() as conn:
+        chunk_count = conn.execute(
+            "SELECT COUNT(*) FROM agent_deliveries WHERE kind = 'text_chunk'"
+        ).fetchone()[0]
+    assert chunk_count == 7
+    assert result["reply"] == ""  # 逐 Turn 模式下 reply 不再二次发送

--- a/tests/integration/test_agent_loop_baseline.py
+++ b/tests/integration/test_agent_loop_baseline.py
@@ -1,13 +1,8 @@
-"""1.15 基线缺口核对（实施计划 §12.A）。
+"""1.15 五 Turn 主例验收（原基线缺口测试，阶段 E 落地后转为正向断言）。
 
-本文件在当前实现上固定两件事：
-
-1. **fixture 契约自检**——五 Turn 主例的正文长度（32/31/50/31/374 code
-   point）与七次工具调用分布，防止 fixture 漂移破坏 §11.2 的验收计数。
-2. **基线缺口特征化**——五 Turn 场景跑在当前实现上，仅末 Turn 正文进入
-   history（一条 assistant 行），中间四个 Turn 的普通正文既不落库也无
-   交付记录。特征化测试锁定现状；带 ``xfail(strict=True)`` 的目标测试
-   声明 1.15 契约，实现落地后 XPASS 会强制摘除标记。
+§11.2 五轮主例：五 Turn/七调用，前四轮普通正文先于所属工具执行外发；
+末 Turn 三段，共七文字 Chunk；下次请求有完整允许的工具事实。
+默认配置下末 Turn 374 字符保持一段（阈值 800）。
 """
 from __future__ import annotations
 
@@ -20,11 +15,13 @@ from plugins.llm_runtime import LLMService
 from tests.fixtures.agent_loop import (
     AGENT_LOOP_TEST_SPLIT,
     FIVE_TURN_TEXTS,
+    CollectingSink,
     FiveTurnScenarioClient,
     build_legacy_db,
     five_turn_tool_calls,
 )
 from tests.fixtures.configs import write_llm_config_bundle
+
 
 def _scenario_toml(base_toml: str) -> str:
     # 五 Turn 场景需要 4 个工具轮次；默认 fixture 配置 tool_max_rounds=2。
@@ -51,12 +48,13 @@ def patch_scenario_provider(scenario_service, patch_provider_builder):
     return _patch
 
 
-async def run_five_turn_scenario(service: LLMService) -> dict:
+async def run_five_turn_scenario(service: LLMService, **kwargs) -> dict:
     return await service.generate_reply(
         group_id=1001,
         user_id="2002",
         sender_name="镜子",
         prompt="K甲夏季赛现在赛况如何？",
+        **kwargs,
     )
 
 
@@ -85,75 +83,53 @@ def test_legacy_fixture_rows_cover_migration_groups(tmp_path: Path):
     assert [role for role, _ in rows] == [
         "assistant", "user", "assistant", "user", "user", "assistant",
     ]
-    # 无 receipt 的 assistant（legacy_untracked）与带 receipt 的（sent）各一。
     assert [mid for _, mid in rows if mid is not None] == ["m3"]
 
 
-# ── 基线缺口特征化（当前实现的事实，实现落地后改写为目标断言） ─────────
+# ── 默认关闭开关：完整记录 + 最终单发（§6.3） ───────────────────────
 
 
-async def test_baseline_only_final_turn_text_persists(
+async def test_final_only_mode_records_every_turn_and_sends_final(
     scenario_service, patch_scenario_provider
 ):
-    """当前实现：五 Turn 场景只有末 Turn 正文落库为一条 assistant 行。"""
     client = patch_scenario_provider("openai")
-    assert len(client.requests) == 0  # 场景尚未跑
-
     result = await run_five_turn_scenario(scenario_service)
 
-    # 五次模型请求确实发生（五 Turn 都完整收到）。
     assert len(client.requests) == 5
-    # 但 history 只落了一条 assistant 行，内容 = 末 Turn 正文。
     rows = scenario_service.store.list_recent_conversation_messages(1001, limit=50)
     assistant_rows = [row for row in rows if row["role"] == "assistant"]
-    assert len(assistant_rows) == 1
-    assert assistant_rows[0]["content"] == FIVE_TURN_TEXTS[4]
-    # 前四个 Turn 的普通正文（32/31/50/31 cp）不在任何持久化正文中。
-    persisted = "\n".join(row["content"] for row in rows)
-    for text in FIVE_TURN_TEXTS[:4]:
-        assert text not in persisted
-    # 交付缺口同样存在：reply 只含末 Turn 正文。
-    assert result["reply"] == FIVE_TURN_TEXTS[4]
-
-
-@pytest.mark.xfail(
-    reason="1.15 目标：每个已提交 Turn 落一条 assistant 行（§3.2/§12.B）",
-    strict=True,
-)
-async def test_target_every_turn_persists_assistant_row(
-    scenario_service, patch_scenario_provider
-):
-    patch_scenario_provider("openai")
-    await run_five_turn_scenario(scenario_service)
-
-    rows = scenario_service.store.list_recent_conversation_messages(1001, limit=50)
-    assistant_rows = [row for row in rows if row["role"] == "assistant"]
+    # 每个已提交 Turn 落一条 assistant 行（§3.2）。
     assert [row["content"] for row in assistant_rows] == list(FIVE_TURN_TEXTS)
+    # 最终正文沿现有单次交付方式。
+    assert result["reply"] == FIVE_TURN_TEXTS[4]
+    # 非最终正文标记 suppressed_by_policy；最终 Turn 在关闭模式下不建交付行
+    #（最终正文沿现有单次交付，回执由兼容列回填记录）。
+    with scenario_service.store._connect() as conn:
+        statuses = [
+            row["status"]
+            for row in conn.execute(
+                "SELECT status FROM agent_deliveries WHERE kind='text_chunk' ORDER BY delivery_index"
+            )
+        ]
+    assert statuses == ["suppressed", "suppressed", "suppressed", "suppressed"]
+    # 七次工具调用全部有终态。
+    with scenario_service.store._connect() as conn:
+        tool_rows = conn.execute(
+            "SELECT status FROM agent_tool_executions"
+        ).fetchall()
+    assert len(tool_rows) == 7
+    assert all(row["status"] == "succeeded" for row in tool_rows)
 
 
-@pytest.mark.xfail(
-    reason="1.15 目标：Loop/Turn/工具/交付侧表与逐 Turn 关联（§4.1/§12.B）",
-    strict=True,
-)
-async def test_target_agent_loop_side_tables_exist(
-    scenario_service, patch_scenario_provider
-):
-    patch_scenario_provider("openai")
-    await run_five_turn_scenario(scenario_service)
-
-    store = scenario_service.store
-    with store._connect() as conn:
-        loop_count = conn.execute("SELECT COUNT(*) FROM agent_loops").fetchone()[0]
-    assert loop_count == 1
+# ── 开启开关：七文字 Chunk + 逐 Turn 交付（§11.2 主例验收） ─────────
 
 
-@pytest.mark.xfail(
-    reason="1.15 目标：测试切分参数下七文字 Chunk（§11.2 五轮主例验收）",
-    strict=True,
-)
-async def test_target_seven_text_chunks_with_test_split(
+async def test_all_turns_mode_seven_chunks_delivered_before_tools(
     scenario_service, patch_scenario_provider, monkeypatch
 ):
+    monkeypatch.setattr(
+        scenario_service.config.runtime, "agent_delivery_enabled", True
+    )
     monkeypatch.setattr(
         scenario_service.config.runtime,
         "reply_split_threshold_chars",
@@ -164,12 +140,67 @@ async def test_target_seven_text_chunks_with_test_split(
         "reply_chunk_max_chars",
         AGENT_LOOP_TEST_SPLIT["chunk_max"],
     )
+    sink = CollectingSink()
+    scenario_service.bind_delivery_sink(sink)
     patch_scenario_provider("openai")
+
     result = await run_five_turn_scenario(scenario_service)
 
+    # 七个文字 Chunk（4 Turn × 1 + 末 Turn 3）。
+    assert len(sink.deliveries) == 7
+    # 前四轮普通正文先于所属工具执行外发：每轮首个 delivery 的文本 == 该轮正文。
+    turn_texts = [FIVE_TURN_TEXTS[i] for i in range(5)]
+    delivered_first_texts = [payload["text"] for _, payload in sink.deliveries[:4]]
+    assert delivered_first_texts == turn_texts[:4]
+    # 末 Turn 三段还原恒等。
+    final_chunks = [payload["text"] for _, payload in sink.deliveries[4:]]
+    assert "".join(final_chunks) == FIVE_TURN_TEXTS[4]
+    # reply 不再二次发送。
+    assert result["reply"] == ""
+    # 默认配置对照：不开测试切分参数时末 Turn 374 字符保持一段。
     with scenario_service.store._connect() as conn:
         chunk_count = conn.execute(
             "SELECT COUNT(*) FROM agent_deliveries WHERE kind = 'text_chunk'"
         ).fetchone()[0]
     assert chunk_count == 7
-    assert result["reply"] == ""  # 逐 Turn 模式下 reply 不再二次发送
+
+
+# ── 重放：下次请求携带完整工具事实（§11.2） ─────────────────────────
+
+
+async def test_next_request_replays_full_tool_facts(
+    scenario_service, patch_scenario_provider
+):
+    patch_scenario_provider("openai")
+    await run_five_turn_scenario(scenario_service)
+
+    sink = CollectingSink()
+    scenario_service.bind_delivery_sink(sink)
+
+    class SecondRoundClient:
+        def __init__(self) -> None:
+            self.request = None
+
+        async def complete(self, request):
+            self.request = request
+            from quickquip.llm.provider import LLMResponse
+
+            return LLMResponse(text="汇总完毕。", model=request.model)
+
+    second = SecondRoundClient()
+    import quickquip.llm.service as service_module
+
+    original = service_module.build_provider_client
+    service_module.build_provider_client = lambda provider: second
+    try:
+        await scenario_service.generate_reply(
+            group_id=1001, user_id="4004", sender_name="4s", prompt="总结一下。"
+        )
+    finally:
+        service_module.build_provider_client = original
+
+    request = second.request
+    tool_messages = [m for m in request.messages if m.role == "tool"]
+    assert len(tool_messages) == 7  # 完整允许的工具事实
+    assistant_calls = [m for m in request.messages if m.role == "assistant" and m.tool_calls]
+    assert len(assistant_calls) == 4

--- a/tests/integration/test_agent_loop_delivery_failure.py
+++ b/tests/integration/test_agent_loop_delivery_failure.py
@@ -1,0 +1,152 @@
+"""§11.2 交付失败测试组：D3 策略准确，unknown 不重发。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugins.llm_runtime import LLMService
+from quickquip.llm.agent_records import (
+    DeliveryReceipt,
+    DeliveryStatus,
+)
+from tests.fixtures.agent_loop import AGENT_LOOP_TEST_SPLIT, FIVE_TURN_TEXTS
+from tests.fixtures.configs import write_llm_config_bundle
+
+
+class ScriptedSink:
+    """按脚本回执的 sink：记录全部交付尝试。"""
+
+    def __init__(self, script: list[DeliveryReceipt]):
+        self.script = list(script)
+        self.attempts: list[tuple[str, str]] = []
+
+    async def __call__(self, delivery_id: str, payload: dict) -> DeliveryReceipt:
+        self.attempts.append((delivery_id, str(payload.get("text", ""))[:20]))
+        return self.script.pop(0) if self.script else DeliveryReceipt(
+            status=DeliveryStatus.SENT, message_id="auto"
+        )
+
+
+async def _service(tmp_path: Path) -> LLMService:
+    paths = write_llm_config_bundle(
+        tmp_path,
+        config_toml=write_llm_config_bundle.__globals__["MIN_LLM_CONFIG_TOML"].replace(
+            "tool_max_rounds = 2", "tool_max_rounds = 8"
+        ),
+    )
+    return LLMService(**paths)
+
+
+async def test_first_chunk_failure_stops_tools_and_generation(
+    tmp_path: Path, patch_provider_builder
+):
+    """首段 failed：终止后续发送、工具启动和模型生成（D3）。"""
+    from tests.fixtures.agent_loop import FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    for attr, value in [
+        ("agent_delivery_enabled", True),
+        ("reply_split_threshold_chars", AGENT_LOOP_TEST_SPLIT["threshold"]),
+        ("reply_chunk_max_chars", AGENT_LOOP_TEST_SPLIT["chunk_max"]),
+    ]:
+        setattr(service.config.runtime, attr, value)
+    sink = ScriptedSink([DeliveryReceipt(status=DeliveryStatus.FAILED, error_code="NetworkError")])
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+
+    result = await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+
+    # 首段失败后：只有一次发送尝试，无第二次模型请求，无工具执行记录。
+    assert len(sink.attempts) == 1
+    assert len(client.requests) == 1
+    assert result["reply"] == ""
+    with service.store._connect() as conn:
+        tool_status = [row["status"] for row in conn.execute("SELECT status FROM agent_tool_executions")]
+        loop_row = conn.execute(
+            "SELECT status, terminal_reason FROM agent_loops"
+        ).fetchone()
+        delivery_status = [
+            row["status"]
+            for row in conn.execute("SELECT status FROM agent_deliveries ORDER BY delivery_index")
+        ]
+    assert tool_status == ["not_executed"]  # 批次内声明有终态、未启动
+    assert loop_row["status"] == "interrupted"
+    assert loop_row["terminal_reason"] == "delivery_failed"
+    assert delivery_status[0] == "failed"
+    assert all(s == "skipped" for s in delivery_status[1:])  # 未开始的收敛为 skipped
+
+
+async def test_unknown_receipt_never_resent(tmp_path: Path, patch_provider_builder):
+    """unknown（超时可能送达）不自动重发（§6.2/§5.5）。"""
+    from tests.fixtures.agent_loop import FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    service.config.runtime.agent_delivery_enabled = True
+    sink = ScriptedSink([DeliveryReceipt(status=DeliveryStatus.UNKNOWN, error_code="timeout")])
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+
+    await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+
+    assert len(sink.attempts) == 1  # 未重试同一 delivery
+    assert len(client.requests) == 1  # 后续生成终止
+    with service.store._connect() as conn:
+        statuses = [
+            row["status"]
+            for row in conn.execute("SELECT status FROM agent_deliveries ORDER BY delivery_index")
+        ]
+    assert statuses[0] == "unknown"
+    loop_status = None
+    with service.store._connect() as conn:
+        loop_status = conn.execute("SELECT status FROM agent_loops").fetchone()["status"]
+    assert loop_status == "interrupted"
+
+
+async def test_middle_chunk_failure_keeps_earlier_facts(tmp_path: Path, patch_provider_builder):
+    """中间段失败：已发送事实保留，本轮后续停止。"""
+    from tests.fixtures.agent_loop import FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    for attr, value in [
+        ("agent_delivery_enabled", True),
+        ("reply_split_threshold_chars", AGENT_LOOP_TEST_SPLIT["threshold"]),
+        ("reply_chunk_max_chars", AGENT_LOOP_TEST_SPLIT["chunk_max"]),
+    ]:
+        setattr(service.config.runtime, attr, value)
+    # 前两段成功，第三段失败。
+    sink = ScriptedSink([
+        DeliveryReceipt(status=DeliveryStatus.SENT, message_id="ok-1"),
+        DeliveryReceipt(status=DeliveryStatus.SENT, message_id="ok-2"),
+        DeliveryReceipt(status=DeliveryStatus.FAILED, error_code="Boom"),
+    ])
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+
+    await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+
+    assert len(sink.attempts) == 3
+    with service.store._connect() as conn:
+        sent = conn.execute(
+            "SELECT COUNT(*) c FROM agent_deliveries WHERE status='sent'"
+        ).fetchone()["c"]
+        failed = conn.execute(
+            "SELECT COUNT(*) c FROM agent_deliveries WHERE status='failed'"
+        ).fetchone()["c"]
+        # 首个成功 Chunk 的 qq id 回填兼容列。
+        row = conn.execute(
+            "SELECT message_id FROM conversation_messages WHERE role='assistant' ORDER BY id LIMIT 1"
+        ).fetchone()
+    assert sent == 2
+    assert failed == 1
+    assert row["message_id"] == "ok-1"
+    # 前两轮正文 = fixture 前两 Turn。
+    assert sink.attempts[0][1][:20] == FIVE_TURN_TEXTS[0][:20]
+    assert sink.attempts[1][1][:20] == FIVE_TURN_TEXTS[1][:20]

--- a/tests/integration/test_agent_loop_history_maintenance.py
+++ b/tests/integration/test_agent_loop_history_maintenance.py
@@ -1,0 +1,243 @@
+"""阶段 D 集成测试：Loop 投影历史、预算门禁、撤回/清空/归档领域操作。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+from plugins.llm_runtime import LLMService
+from quickquip.llm.provider import LLMRequest, LLMResponse
+from tests.fixtures.configs import write_llm_config_bundle
+
+
+def _store_service(tmp_path: Path) -> LLMService:
+    paths = write_llm_config_bundle(tmp_path)
+    return LLMService(**paths)
+
+
+def _seed_loop_with_turn(store, scope="1001", *, text="工具轮正文", qq_id="qq-1"):
+    """落一个已关闭的带工具 Loop，返回 (handle-like ids, turn_row_id)。"""
+    from quickquip.llm.agent_records import (
+        DeliveryKind,
+        DeliveryPlanItem,
+        TextPolicy,
+        ToolDeclarationRecord,
+        ToolResultRecord,
+        TriggerKind,
+        TurnOutputStatus,
+        TurnResponseRecord,
+    )
+    from quickquip.llm.store_parts.agent_records import (
+        UserTriggerPayload,
+    )
+
+    handle = store.begin_loop(
+        scope, 0, TriggerKind.GROUP_DIRECT,
+        UserTriggerPayload(user_id="2002", sender_name="镜子", content="查一下镜子是谁"),
+    )
+    turn_id = "turn_seed_0"
+    record = store.commit_turn(
+        handle,
+        TurnResponseRecord(
+            text=text,
+            text_policy=TextPolicy.ALLOWED,
+            output_status=TurnOutputStatus.VISIBLE,
+            finish_reason="tool_calls",
+            parts=({"type": "text_ref", "start": 0, "end": len(text), "origin": "model"},
+                   {"type": "tool_ref", "execution_id": "exec_seed_0"}),
+        ),
+        [
+            ToolDeclarationRecord(
+                execution_id="exec_seed_0", call_index=0, provider_call_id="call_seed_0",
+                tool_name="get_identity", arguments_json='{"query":"镜子"}',
+                arguments_omission_reason=None,
+            )
+        ],
+        [
+            DeliveryPlanItem(
+                delivery_id="dlv_seed_0", kind=DeliveryKind.TEXT_CHUNK, turn_id=turn_id,
+                chunk_index=0, source_start=0, source_end=len(text),
+            )
+        ],
+        turn_id=turn_id,
+    )
+    store.mark_tool_started(handle, "exec_seed_0")
+    store.finish_tool(
+        handle, "exec_seed_0",
+        ToolResultRecord(content="镜子是群友。", is_error=False, original_bytes=18),
+    )
+    attempt = store.start_delivery(handle, "dlv_seed_0")
+    from quickquip.llm.agent_records import DeliveryReceipt, DeliveryStatus
+
+    store.finish_delivery(attempt, DeliveryReceipt(status=DeliveryStatus.SENT, message_id=qq_id))
+    store.close_loop(handle, __import__("quickquip.llm.agent_records", fromlist=["LoopStatus"]).LoopStatus.COMPLETED, None)
+    return handle, record
+
+
+# ── 投影历史接入主链路 ─────────────────────────────────────────────
+
+
+async def test_tool_loop_history_replays_with_tool_facts(tmp_path: Path, patch_provider_builder):
+    service = _store_service(tmp_path)
+    _seed_loop_with_turn(service.store)
+
+    captured: list[LLMRequest] = []
+
+    class SecondRoundClient:
+        async def complete(self, request: LLMRequest) -> LLMResponse:
+            captured.append(request)
+            return LLMResponse(text="基于历史工具事实回答。", model=request.model)
+
+    patch_provider_builder(lambda provider: SecondRoundClient())
+    await service.generate_reply(
+        group_id=1001, user_id="4004", sender_name="4s", prompt="所以结论是？",
+    )
+
+    request = captured[0]
+    roles = [m.role for m in request.messages]
+    assert "tool" in roles  # 历史中的工具事实进入下次请求（§11.2 五轮主例断言面）
+    tool_message = next(m for m in request.messages if m.role == "tool")
+    assert "镜子是群友" in tool_message.content
+    assistant_with_calls = [
+        m for m in request.messages if m.role == "assistant" and m.tool_calls
+    ]
+    assert assistant_with_calls, "历史投影必须带工具调用声明"
+    # user 触发与工具配对：call id 一致。
+    call = assistant_with_calls[0].tool_calls[0]
+    assert any(m.tool_call_id == call.id for m in request.messages if m.role == "tool")
+
+
+# ── 撤回（§9.2） ──────────────────────────────────────────────────
+
+
+async def test_recall_by_qq_id_masks_chunk_and_clears_evidence(tmp_path: Path):
+    service = _store_service(tmp_path)
+    _seed_loop_with_turn(service.store, text="这一段会被撤回。", qq_id="qq-9")
+
+    hit = service.delete_message_from_context("1001", "qq-9")
+    assert hit is True
+
+    store = service.store
+    with store._connect() as conn:
+        row = conn.execute(
+            "SELECT content FROM conversation_messages WHERE agent_loop_id IS NOT NULL AND role='assistant'"
+        ).fetchone()
+        delivery = conn.execute(
+            "SELECT recall_status FROM agent_deliveries WHERE delivery_id='dlv_seed_0'"
+        ).fetchone()
+        execution = conn.execute(
+            "SELECT result_json, result_omission_reason FROM agent_tool_executions WHERE execution_id='exec_seed_0'"
+        ).fetchone()
+    assert "▇" in row["content"]  # 等 code point 遮蔽，保留坐标
+    assert delivery["recall_status"] == "recalled"
+    assert execution["result_json"] is None  # 工具证据清理
+    assert execution["result_omission_reason"] == "recall_cleanup"
+    # 重复 recall 幂等：不再命中。
+    assert service.delete_message_from_context("1001", "qq-9") is True  # 已 recalled，仍算命中定位
+
+
+async def test_recall_user_trigger_deletes_whole_loop(tmp_path: Path):
+    service = _store_service(tmp_path)
+    handle, record = _seed_loop_with_turn(service.store)
+
+    hit = service.delete_message_from_context("1001", "trigger-nonexistent")
+    assert hit is False
+    # 用 user 行 message_id 触发整 Loop 删除（§9.3）。
+    with service.store._connect() as conn:
+        anchor = conn.execute(
+            "SELECT id FROM conversation_messages WHERE role='user' AND agent_loop_id=?",
+            (handle.loop_id,),
+        ).fetchone()["id"]
+        conn.execute(
+            "UPDATE conversation_messages SET message_id='trigger-1' WHERE id=?", (anchor,)
+        )
+        conn.commit()
+    assert service.delete_message_from_context("1001", "trigger-1") is True
+    loops = service.store.load_closed_loops("1001")
+    assert loops == []
+
+
+# ── 清空（§9.3） ──────────────────────────────────────────────────
+
+
+async def test_clear_context_purges_loops_and_bumps_generation(tmp_path: Path):
+    service = _store_service(tmp_path)
+    _seed_loop_with_turn(service.store)
+    service.clear_group_context(1001)
+
+    store = service.store
+    assert store.load_closed_loops("1001") == []
+    generation, _ = store.agent_scope_state("1001")
+    assert generation == 1
+    with store._connect() as conn:
+        orphans = conn.execute(
+            "SELECT COUNT(*) c FROM agent_turns t LEFT JOIN agent_loops l ON l.loop_id=t.loop_id WHERE l.loop_id IS NULL"
+        ).fetchone()["c"]
+    assert orphans == 0  # 侧表无孤儿（阶段 B 验收面）
+
+
+# ── 私聊归档（§9.4） ──────────────────────────────────────────────
+
+
+async def test_private_archive_roundtrip_migrates_loops(tmp_path: Path):
+    service = _store_service(tmp_path)
+    service.set_chat_enabled(4004, True, chat_type="private")
+    handle, record = _seed_loop_with_turn(service.store, scope="private:4004")
+
+    result = service.end_private_session(4004, save=True)
+    assert result["archive_number"] == 1
+    store = service.store
+    migrated = store.load_closed_loops("archive:4004:1")
+    assert len(migrated) == 1
+    assert migrated[0].loop_id == handle.loop_id  # Loop ID 不变
+    with store._connect() as conn:
+        stray = conn.execute(
+            "SELECT COUNT(*) c FROM conversation_messages WHERE group_id='private:4004'"
+        ).fetchone()["c"]
+    assert stray == 0
+
+    resume = service.resume_private_session(4004, 1)
+    assert resume["archive_number"] == 1
+    restored = store.load_closed_loops("private:4004")
+    assert len(restored) == 1
+    assert restored[0].turns[0].text == migrated[0].turns[0].text
+
+
+# ── 预算门禁（§8.3） ──────────────────────────────────────────────
+
+
+async def test_request_budget_gate_blocks_oversized_input(
+    tmp_path: Path, patch_provider_builder, monkeypatch
+):
+    service = _store_service(tmp_path)
+
+    called = {"count": 0}
+
+    class NeverClient:
+        async def complete(self, request: LLMRequest) -> LLMResponse:
+            called["count"] += 1
+            return LLMResponse(text="不应到达", model=request.model)
+
+    patch_provider_builder(lambda provider: NeverClient())
+    monkeypatch.setattr(service.config.runtime, "request_input_token_budget", 200)
+
+    result = await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子",
+        prompt="长" * 900,
+    )
+    assert called["count"] == 0  # 预算门禁先于 provider
+    assert "上下文" in result["reply"]
+    assert result["llm_used"] is False
+
+
+def test_config_parses_budget_and_retention_fields(tmp_path: Path):
+    from tests.fixtures.configs import MIN_LLM_CONFIG_TOML
+
+    toml = MIN_LLM_CONFIG_TOML.replace(
+        "tool_max_rounds = 2",
+        "tool_max_rounds = 2\nrequest_input_token_budget = 50000\nagent_record_retention_days = 14",
+    )
+    paths = write_llm_config_bundle(tmp_path, config_toml=toml)
+    service = LLMService(**paths)
+    assert service.config.runtime.request_input_token_budget == 50000
+    assert service.config.runtime.agent_record_retention_days == 14
+    assert service.config.runtime.agent_record_max_bytes_per_scope == 67_108_864

--- a/tests/unit/adapters/test_awakening_plugin.py
+++ b/tests/unit/adapters/test_awakening_plugin.py
@@ -112,7 +112,7 @@ def test_boredom_check_sends_message_not_str(monkeypatch):
         trace_kwargs=lambda: {"rule_name": "awakening_boredom"},
     )
 
-    async def fake_iter_plans(groups, rule_switch, svc, rate_limiter):
+    async def fake_iter_plans(groups, rule_switch, svc, rate_limiter, generate=None):
         yield plan
 
     monkeypatch.setattr(awakening_plugin, "nonebot", types.SimpleNamespace(get_bot=lambda: bot))

--- a/tests/unit/adapters/test_delivery_sink.py
+++ b/tests/unit/adapters/test_delivery_sink.py
@@ -1,0 +1,117 @@
+"""生产 DeliverySink 单测（§5.1/§6.2）：回执分类、节流、CQ 注入边界。"""
+from __future__ import annotations
+
+import asyncio
+import time
+import types
+
+
+from quickquip.adapters.nonebot._llm_reply import (
+    OneBotDeliverySink,
+    record_final_receipt,
+    reset_delivery_throttle,
+    text_only_message,
+)
+from quickquip.llm.agent_records import DeliveryStatus
+
+
+def _seg_text(message) -> str:
+    """从 Message 提取纯文本段内容（验证不经 CQ 解析器）。"""
+    return "".join(str(seg.data.get("text", "")) for seg in message)
+
+
+class _Message:
+    def __init__(self, segments):
+        self.segments = segments
+
+    def __iter__(self):
+        return iter(self.segments)
+
+
+class _Segment:
+    def __init__(self):
+        self.data: dict[str, str] = {}
+
+    @classmethod
+    def text(cls, value: str):
+        seg = cls()
+        seg.data["text"] = value
+        return seg
+
+
+async def test_sent_receipt_requires_trusted_message_id():
+    reset_delivery_throttle()
+
+    async def send(text):
+        return {"message_id": 12345}
+
+    sink = OneBotDeliverySink(send, scope_key="g1", interval_ms=0)
+    receipt = await sink("dlv_1", {"text": "正文"})
+    assert receipt.status == DeliveryStatus.SENT
+    assert receipt.message_id == "12345"
+    assert sink.sent_texts == ["正文"]
+
+
+async def test_missing_message_id_is_unknown_not_sent():
+    reset_delivery_throttle()
+
+    async def send(text):
+        return {"message_id": None}
+
+    sink = OneBotDeliverySink(send, scope_key="g1", interval_ms=0)
+    receipt = await sink("dlv_1", {"text": "正文"})
+    assert receipt.status == DeliveryStatus.UNKNOWN
+    assert receipt.error_code == "missing_message_id"
+
+
+async def test_timeout_classified_unknown_and_plain_error_failed():
+    reset_delivery_throttle()
+
+    async def timeout_send(text):
+        raise asyncio.TimeoutError("Request timed out")
+
+    sink = OneBotDeliverySink(timeout_send, scope_key="g1", interval_ms=0)
+    receipt = await sink("dlv_1", {"text": "正文"})
+    assert receipt.status == DeliveryStatus.UNKNOWN
+
+    async def failed_send(text):
+        raise RuntimeError("retcode=1200 rate limited")
+
+    sink2 = OneBotDeliverySink(failed_send, scope_key="g2", interval_ms=0)
+    receipt2 = await sink2("dlv_1", {"text": "正文"})
+    assert receipt2.status == DeliveryStatus.FAILED
+    assert receipt2.error_code == "RuntimeError"
+
+
+async def test_same_scope_sends_are_throttled():
+    reset_delivery_throttle()
+    stamps: list[float] = []
+
+    async def send(text):
+        stamps.append(time.monotonic())
+        return {"message_id": len(stamps)}
+
+    sink = OneBotDeliverySink(send, scope_key="g-throttle", interval_ms=60)
+    await sink("dlv_1", {"text": "a"})
+    await sink("dlv_2", {"text": "b"})
+    assert len(stamps) == 2
+    assert stamps[1] - stamps[0] >= 0.05  # 第二次发送等待了间隔
+
+
+def test_text_only_message_uses_text_segment():
+    message = text_only_message("含[CQ:at,qq=all]的正文", _Message, _Segment)
+    assert _seg_text(message) == "含[CQ:at,qq=all]的正文"  # 原样文本段，不进 CQ 解析器
+
+
+async def test_record_final_receipt_uses_exact_row_id():
+    calls: list[tuple[int, str]] = []
+    store = types.SimpleNamespace(
+        set_first_chunk_message_id=lambda row_id, qq: calls.append(("exact", row_id, qq)),
+        update_last_assistant_message_id=lambda scope, qq: calls.append(("legacy", scope, qq)),
+    )
+    svc = types.SimpleNamespace(store=store)
+    record_final_receipt(svc, {"agent_turn_row_id": 42, "scope_key": "1001"}, "qq-7")
+    assert calls == [("exact", 42, "qq-7")]
+    # 无 row_id 的回退路径（记录器未启用的旧链路）。
+    record_final_receipt(svc, {"scope_key": "1001"}, "qq-8")
+    assert calls[-1] == ("legacy", "1001", "qq-8")

--- a/tests/unit/llm/test_agent_records_store.py
+++ b/tests/unit/llm/test_agent_records_store.py
@@ -1,0 +1,520 @@
+"""AgentRecordsStoreMixin 单测（§4 数据结构和迁移 / §5.5 恢复 / D5 保留）。"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from quickquip.llm.agent_records import (
+    DeliveryKind,
+    DeliveryPlanItem,
+    DeliveryReceipt,
+    DeliveryStatus,
+    LoopStatus,
+    MAX_LOOP_RECORD_BYTES,
+    ResultRetention,
+    TextPolicy,
+    ToolDeclarationRecord,
+    ToolExecutionStatus,
+    ToolResultRecord,
+    ToolSkipReason,
+    TriggerKind,
+    TurnOutputStatus,
+    TurnResponseRecord,
+)
+from quickquip.llm.store import LLMStore
+from quickquip.llm.store_parts.agent_records import (
+    AgentStoreError,
+    HistoryMutation,
+    LoopHandle,
+    LoopNotWritable,
+    LoopRecordBudgetExceeded,
+    RetentionPolicy,
+    ScopeGenerationMismatch,
+    StaleRevision,
+    UserTriggerPayload,
+)
+from tests.fixtures.agent_loop import build_legacy_db, legacy_rows
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> LLMStore:
+    return LLMStore(tmp_path / "llm.db")
+
+
+def _user_payload(content: str = "你好") -> UserTriggerPayload:
+    return UserTriggerPayload(
+        user_id="2002", sender_name="镜子", canonical_name="镜子", content=content,
+        message_id="trigger-1",
+    )
+
+
+def _begin(store: LLMStore, scope: str = "1001") -> LoopHandle:
+    return store.begin_loop(scope, 0, TriggerKind.GROUP_DIRECT, _user_payload())
+
+
+def _response(text: str = "回复正文", *, tools: int = 0, native: dict | None = None) -> TurnResponseRecord:
+    return TurnResponseRecord(
+        text=text,
+        text_policy=TextPolicy.ALLOWED,
+        output_status=TurnOutputStatus.VISIBLE,
+        finish_reason="stop",
+        native_state=native,
+    )
+
+
+def _declarations(count: int) -> list[ToolDeclarationRecord]:
+    return [
+        ToolDeclarationRecord(
+            execution_id=f"exec_{i}",
+            call_index=i,
+            provider_call_id=f"call_{i}",
+            tool_name="get_identity",
+            arguments_json='{"query":"镜子"}',
+            arguments_omission_reason=None,
+        )
+        for i in range(count)
+    ]
+
+
+_chunk_seq = 0
+
+
+def _chunk_plan(count: int, turn_id: str | None = None, text_len: int | None = None) -> list[DeliveryPlanItem]:
+    if count == 0 or text_len is None:
+        return []
+    global _chunk_seq
+    _chunk_seq += 1
+    prefix = f"dlv{_chunk_seq}"
+    return [
+        DeliveryPlanItem(
+            delivery_id=f"{prefix}_{i}",
+            kind=DeliveryKind.TEXT_CHUNK,
+            turn_id=turn_id,
+            chunk_index=i,
+            source_start=0,
+            source_end=text_len,
+        )
+        for i in range(count)
+    ]
+
+
+# ── schema 与迁移 ─────────────────────────────────────────────────
+
+
+def test_fresh_db_creates_agent_schema(store: LLMStore):
+    with store._connect() as conn:
+        for table in (
+            "agent_scopes", "agent_loops", "agent_turns", "agent_tool_executions",
+            "agent_deliveries", "agent_delivery_attempts", "agent_schema_migrations",
+        ):
+            row = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)
+            ).fetchone()
+            assert row is not None, f"缺表 {table}"
+        columns = {r["name"] for r in conn.execute("PRAGMA table_info(conversation_messages)")}
+        assert {"agent_loop_id", "agent_turn_id"} <= columns
+
+
+def test_migration_backfills_legacy_loops(tmp_path: Path):
+    db_path = tmp_path / "llm.db"
+    build_legacy_db(db_path)
+    store = LLMStore(db_path)
+    with store._connect() as conn:
+        loops = conn.execute(
+            "SELECT loop_id, trigger_kind, status, legacy, anchor_row_id FROM agent_loops ORDER BY anchor_row_id"
+        ).fetchall()
+        # 孤立段 + 三个 user 锚点 Loop（§4.3.3：连续 user 各自独立 Loop）
+        assert [row["trigger_kind"] for row in loops] == [
+            "legacy_orphan", "legacy", "legacy", "legacy",
+        ]
+        assert all(row["status"] == "legacy" for row in loops)
+        # 原行原样保留：行数、ID、正文、message_id 不变（§4.3.4）。
+        rows = conn.execute(
+            "SELECT id, role, content, message_id, agent_loop_id, agent_turn_id FROM conversation_messages ORDER BY id"
+        ).fetchall()
+        assert len(rows) == len(legacy_rows())
+        assert [row["id"] for row in rows] == list(range(1, len(legacy_rows()) + 1))
+        assert all(row["agent_loop_id"] for row in rows)
+        # a3（带 message_id=m3）→ sent receipt；其余 assistant → legacy_untracked。
+        deliveries = conn.execute(
+            "SELECT status, source_start, source_end FROM agent_deliveries"
+        ).fetchall()
+        statuses = sorted(row["status"] for row in deliveries)
+        assert statuses == ["legacy_untracked", "legacy_untracked", "sent"]
+        sent = conn.execute(
+            """
+            SELECT a.qq_message_id FROM agent_delivery_attempts a
+            JOIN agent_deliveries d ON d.delivery_id = a.delivery_id
+            WHERE d.status = 'sent'
+            """
+        ).fetchone()
+        assert sent["qq_message_id"] == "m3"
+        # 覆盖全文的源范围。
+        sent_delivery = conn.execute(
+            "SELECT source_start, source_end FROM agent_deliveries WHERE status='sent'"
+        ).fetchone()
+        a3_content = legacy_rows()[5].content
+        assert (sent_delivery["source_start"], sent_delivery["source_end"]) == (0, len(a3_content))
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
+def test_migration_is_idempotent_and_concurrent_safe(tmp_path: Path):
+    db_path = tmp_path / "llm.db"
+    build_legacy_db(db_path)
+    LLMStore(db_path)
+    LLMStore(db_path)  # 第二次打开（Bot/Web 同时首开的串行化面）
+    with LLMStore(db_path)._connect() as conn:
+        count = conn.execute("SELECT COUNT(*) c FROM agent_loops").fetchone()["c"]
+        versions = conn.execute("SELECT COUNT(*) c FROM agent_schema_migrations").fetchone()["c"]
+    assert count == 4
+    assert versions == 1
+
+
+# ── Loop 生命周期 ─────────────────────────────────────────────────
+
+
+def test_begin_loop_writes_user_trigger_row(store: LLMStore):
+    handle = _begin(store)
+    with store._connect() as conn:
+        loop = conn.execute("SELECT * FROM agent_loops WHERE loop_id=?", (handle.loop_id,)).fetchone()
+        user = conn.execute(
+            "SELECT * FROM conversation_messages WHERE agent_loop_id=?", (handle.loop_id,)
+        ).fetchone()
+    assert loop["status"] == "running"
+    assert loop["anchor_row_id"] == user["id"]
+    assert user["role"] == "user"
+    assert user["content"] == "你好"
+    assert user["message_id"] == "trigger-1"
+
+
+def test_second_open_loop_rejected(store: LLMStore):
+    _begin(store)
+    with pytest.raises(LoopNotWritable):
+        store.begin_loop("1001", 0, TriggerKind.GROUP_DIRECT, _user_payload("再来"))
+
+
+def test_commit_turn_atomic_write(store: LLMStore):
+    handle = _begin(store)
+    text = "第一段正文"
+    turn_id = "turn_pre"
+    record = store.commit_turn(
+        handle, _response(text), _declarations(1),
+        _chunk_plan(1, turn_id=turn_id, text_len=len(text)),
+        turn_id=turn_id,
+    )
+    with store._connect() as conn:
+        turn = conn.execute("SELECT * FROM agent_turns WHERE turn_id=?", (record.turn_id,)).fetchone()
+        message = conn.execute(
+            "SELECT * FROM conversation_messages WHERE id=?", (record.message_row_id,)
+        ).fetchone()
+        tools = conn.execute(
+            "SELECT * FROM agent_tool_executions WHERE turn_id=?", (record.turn_id,)
+        ).fetchall()
+        delivery = conn.execute(
+            "SELECT * FROM agent_deliveries WHERE delivery_id=?", (record.delivery_ids[0],)
+        ).fetchone()
+    assert turn["turn_index"] == 0
+    assert message["agent_turn_id"] == record.turn_id
+    assert message["content"] == text
+    assert message["raw_content"] is None  # 新 assistant 行 raw_content 留空（§3.3）
+    assert tools[0]["status"] == "declared"
+    assert delivery["status"] == "planned"
+    assert delivery["turn_id"] == record.turn_id
+    parts = json.loads(turn["parts_json"])
+    assert parts["version"] == 1
+
+
+def test_commit_turn_rejects_dangling_part_refs(store: LLMStore):
+    handle = _begin(store)
+    bad_parts = ({"type": "tool_ref", "execution_id": "exec_missing"},)
+    response = TurnResponseRecord(
+        text="x", text_policy=TextPolicy.ALLOWED, output_status=TurnOutputStatus.VISIBLE,
+        finish_reason="stop", parts=bad_parts,
+    )
+    with pytest.raises(AgentStoreError):
+        store.commit_turn(handle, response, _declarations(0), [])
+    # 事务原子性：失败后主表不留半个 Turn。
+    with store._connect() as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) c FROM conversation_messages WHERE role='assistant'"
+        ).fetchone()["c"]
+    assert count == 0
+
+
+def test_generation_mismatch_blocks_late_writes(store: LLMStore):
+    handle = _begin(store)
+    store.mutate_history("1001", 0, HistoryMutation.CLEAR)
+    with pytest.raises(ScopeGenerationMismatch):
+        store.commit_turn(handle, _response("迟到"), _declarations(0), [])
+    with pytest.raises(ScopeGenerationMismatch):
+        store.begin_loop("1001", 0, TriggerKind.GROUP_DIRECT, _user_payload("过期"))
+
+
+def test_mutate_history_revision_barrier(store: LLMStore):
+    gen, rev = store.mutate_history("1001", 0, HistoryMutation.EDIT)
+    assert (gen, rev) == (0, 1)
+    with pytest.raises(StaleRevision):
+        store.mutate_history("1001", 0, HistoryMutation.EDIT)
+    gen2, rev2 = store.mutate_history("1001", 1, HistoryMutation.CLEAR)
+    assert (gen2, rev2) == (1, 2)
+
+
+# ── 工具状态 ──────────────────────────────────────────────────────
+
+
+def test_tool_lifecycle_and_bounded_result(store: LLMStore):
+    handle = _begin(store)
+    text = "带工具的正文"
+    store.commit_turn(handle, _response(text), _declarations(1), [])
+    exec_id = _declarations(1)[0].execution_id
+    store.mark_tool_started(handle, exec_id)
+    big = "字" * (33_000)
+    store.finish_tool(
+        handle, exec_id,
+        ToolResultRecord(content=big, is_error=False, original_bytes=len(big.encode("utf-8"))),
+    )
+    with store._connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM agent_tool_executions WHERE execution_id=?", (exec_id,)
+        ).fetchone()
+    result = json.loads(row["result_json"])
+    assert row["status"] == "succeeded"
+    assert row["result_omission_reason"] == "size_limit"
+    assert result["original_bytes"] == 99_000  # "字"×33000 的 UTF-8 字节数
+    assert len(result["content"].encode("utf-8")) <= 32_768
+    assert result["retained_ranges"]
+
+
+def test_ephemeral_result_never_persists_body(store: LLMStore):
+    handle = _begin(store)
+    store.commit_turn(handle, _response("查"), _declarations(1), [])
+    exec_id = _declarations(1)[0].execution_id
+    store.mark_tool_started(handle, exec_id)
+    store.finish_tool(
+        handle, exec_id,
+        ToolResultRecord(content="命中正文" * 100, is_error=False, original_bytes=1200),
+        result_retention=ResultRetention.EPHEMERAL,
+    )
+    with store._connect() as conn:
+        row = conn.execute(
+            "SELECT result_json, status, result_omission_reason FROM agent_tool_executions WHERE execution_id=?",
+            (exec_id,),
+        ).fetchone()
+    result = json.loads(row["result_json"])
+    assert result["content"] == ""  # D1：查询正文不入业务持久层
+    assert row["status"] == "succeeded"  # 省略不改写工具成功事实
+    assert row["result_omission_reason"] == "ephemeral_policy"
+
+
+def test_not_executed_terminal_with_reason(store: LLMStore):
+    handle = _begin(store)
+    store.commit_turn(handle, _response("超限"), _declarations(1), [])
+    exec_id = _declarations(1)[0].execution_id
+    store.finish_tool(handle, exec_id, None, status=ToolExecutionStatus.NOT_EXECUTED,
+                      skip_reason=ToolSkipReason.ROUND_LIMIT)
+    with store._connect() as conn:
+        row = conn.execute(
+            "SELECT status, result_json FROM agent_tool_executions WHERE execution_id=?", (exec_id,)
+        ).fetchone()
+    assert row["status"] == "not_executed"
+    assert json.loads(row["result_json"])["detail"] == "limit"
+
+
+# ── 交付 ─────────────────────────────────────────────────────────
+
+
+def test_delivery_attempt_and_lookup(store: LLMStore):
+    handle = _begin(store)
+    text = "要发出去的正文"
+    record = store.commit_turn(handle, _response(text), _declarations(0), _chunk_plan(1, text_len=len(text)))
+    delivery_id = record.delivery_ids[0]
+    attempt = store.start_delivery(handle, delivery_id)
+    store.finish_delivery(attempt, DeliveryReceipt(status=DeliveryStatus.SENT, message_id="qq-1"))
+    found = store.lookup_delivery("1001", "qq-1")
+    assert found is not None
+    assert found["delivery_id"] == delivery_id
+    assert found["source_start"] == 0
+    # scope 谓词：别的 scope 查不到。
+    assert store.lookup_delivery("1002", "qq-1") is None
+    with store._connect() as conn:
+        delivery = conn.execute(
+            "SELECT status FROM agent_deliveries WHERE delivery_id=?", (delivery_id,)
+        ).fetchone()
+    assert delivery["status"] == "sent"
+
+
+def test_attempt_terminal_not_overwritten(store: LLMStore):
+    handle = _begin(store)
+    text = "正文"
+    record = store.commit_turn(handle, _response(text), _declarations(0), _chunk_plan(1, text_len=len(text)))
+    attempt = store.start_delivery(handle, record.delivery_ids[0])
+    store.finish_delivery(attempt, DeliveryReceipt(status=DeliveryStatus.FAILED, error_code="timeout"))
+    store.finish_delivery(attempt, DeliveryReceipt(status=DeliveryStatus.SENT, message_id="late"))
+    with store._connect() as conn:
+        row = conn.execute(
+            "SELECT status FROM agent_delivery_attempts WHERE attempt_id=?", (attempt.attempt_id,)
+        ).fetchone()
+    assert row["status"] == "failed"
+
+
+def test_unknown_upgrade_on_trusted_receipt(store: LLMStore):
+    handle = _begin(store)
+    text = "正文"
+    record = store.commit_turn(handle, _response(text), _declarations(0), _chunk_plan(1, text_len=len(text)))
+    attempt = store.start_delivery(handle, record.delivery_ids[0])
+    # 模拟崩溃恢复：close_loop 把 sending 收敛为 unknown。
+    store.close_loop(handle, LoopStatus.INTERRUPTED, "test")
+    store.finish_delivery(attempt, DeliveryReceipt(status=DeliveryStatus.SENT, message_id="late-ok"))
+    with store._connect() as conn:
+        attempt_row = conn.execute(
+            "SELECT status, qq_message_id FROM agent_delivery_attempts WHERE attempt_id=?",
+            (attempt.attempt_id,),
+        ).fetchone()
+        delivery_row = conn.execute(
+            "SELECT status FROM agent_deliveries WHERE delivery_id=?", (attempt.delivery_id,)
+        ).fetchone()
+    assert attempt_row["status"] == "sent"
+    assert attempt_row["qq_message_id"] == "late-ok"
+    assert delivery_row["status"] == "sent"
+
+
+# ── 关闭与恢复 ────────────────────────────────────────────────────
+
+
+def test_close_loop_sweeps_and_is_idempotent(store: LLMStore):
+    handle = _begin(store)
+    text = "多段"
+    record = store.commit_turn(handle, _response(text), _declarations(0), _chunk_plan(2, text_len=len(text)))
+    store.start_delivery(handle, record.delivery_ids[0])
+    store.close_loop(handle, LoopStatus.INTERRUPTED, "delivery_failed")
+    with store._connect() as conn:
+        statuses = {
+            row["delivery_id"]: row["status"]
+            for row in conn.execute(
+                "SELECT delivery_id, status FROM agent_deliveries WHERE loop_id=?", (handle.loop_id,)
+            )
+        }
+    assert statuses[record.delivery_ids[0]] == "unknown"  # 已在途，回执未落库
+    assert statuses[record.delivery_ids[1]] == "skipped"  # 未开始
+    # 幂等关闭。
+    store.close_loop(handle, LoopStatus.COMPLETED, "again")
+    with store._connect() as conn:
+        row = conn.execute(
+            "SELECT status, terminal_reason FROM agent_loops WHERE loop_id=?", (handle.loop_id,)
+        ).fetchone()
+    assert row["terminal_reason"] == "delivery_failed"
+
+
+def test_recover_unfinished_loops(store: LLMStore):
+    # Loop A：provider 未提交响应（无 Turn）。
+    handle_a = _begin(store)
+    # Loop B：Turn 已提交，工具 declared/running，交付 planned。
+    handle_b = store.begin_loop("1002", 0, TriggerKind.PRIVATE_DIRECT, _user_payload("私聊"))
+    text = "正文"
+    store.commit_turn(handle_b, _response(text), _declarations(2), _chunk_plan(1, text_len=len(text)))
+    exec_ids = [d.execution_id for d in _declarations(2)]
+    store.mark_tool_started(handle_b, exec_ids[0])
+
+    report = store.recover_unfinished_loops()
+
+    assert set(report.closed_loops) == {handle_a.loop_id, handle_b.loop_id}
+    assert report.tools_not_executed == (exec_ids[1],)
+    assert report.tools_indeterminate == (exec_ids[0],)
+    assert len(report.deliveries_skipped) == 1  # planned 交付收敛为 skipped 并入报告
+    assert report.deliveries_unknown == ()
+    with store._connect() as conn:
+        statuses = {
+            row["loop_id"]: (row["status"], row["terminal_reason"])
+            for row in conn.execute("SELECT loop_id, status, terminal_reason FROM agent_loops")
+        }
+    for loop_id in (handle_a.loop_id, handle_b.loop_id):
+        assert statuses[loop_id] == ("interrupted", "process_recovery")
+    # 幂等：再跑一遍无新变化。
+    again = store.recover_unfinished_loops()
+    assert again.closed_loops == ()
+
+
+# ── 读取 ─────────────────────────────────────────────────────────
+
+
+def test_load_closed_loops_returns_complete_records(store: LLMStore):
+    handle = _begin(store)
+    text = "完整正文"
+    record = store.commit_turn(handle, _response(text), _declarations(1), _chunk_plan(1, text_len=len(text)))
+    store.close_loop(handle, LoopStatus.COMPLETED, None)
+    loops = store.load_closed_loops("1001")
+    assert len(loops) == 1
+    loop = loops[0]
+    assert loop.loop_id == handle.loop_id
+    assert loop.user_row["content"] == "你好"
+    assert len(loop.turns) == 1
+    turn = loop.turns[0]
+    assert turn.text == text
+    assert turn.tools[0].tool_name == "get_identity"
+    assert loop.deliveries[0].delivery_id == record.delivery_ids[0]
+    # running loop 不出现。
+    _begin(store)
+    assert len(store.load_closed_loops("1001")) == 1
+
+
+# ── 字节预算与保留 ────────────────────────────────────────────────
+
+
+def test_loop_record_budget_exceeded(store: LLMStore, monkeypatch):
+    import quickquip.llm.store_parts.agent_records as agent_store_module
+
+    monkeypatch.setattr(agent_store_module, "MAX_LOOP_RECORD_BYTES", 100)
+    handle = _begin(store)
+    big_text = "长" * 200
+    with pytest.raises(LoopRecordBudgetExceeded):
+        store.commit_turn(handle, _response(big_text), _declarations(0), [])
+    # 失败即回滚：主表不留行。
+    with store._connect() as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) c FROM conversation_messages WHERE role='assistant'"
+        ).fetchone()["c"]
+    assert count == 0
+    assert MAX_LOOP_RECORD_BYTES == 8_388_608  # 常量本身未被改
+
+
+def test_prune_closed_loops_by_age_and_count(store: LLMStore):
+    for i in range(4):
+        handle = store.begin_loop("1001", 0, TriggerKind.GROUP_DIRECT, _user_payload(f"问{i}"))
+        text = f"答{i}"
+        store.commit_turn(handle, _response(text), _declarations(0), _chunk_plan(1, text_len=len(text)))
+        store.close_loop(handle, LoopStatus.COMPLETED, None)
+    # 数量上限 2：清最旧的两个。
+    report = store.prune_closed_loops("1001", active_anchors=[], policy=RetentionPolicy(retention_days=30, max_loops=2, max_bytes=64 * 1024 * 1024))
+    assert len(report.deleted_loop_ids) == 2
+    remaining = store.load_closed_loops("1001")
+    assert len(remaining) == 2
+    # 整 Loop 删除：主表行也一并清理。
+    with store._connect() as conn:
+        rows = conn.execute(
+            "SELECT content FROM conversation_messages WHERE role='user' ORDER BY id"
+        ).fetchall()
+    assert [row["content"] for row in rows] == ["问2", "问3"]
+
+
+def test_prune_respects_active_epoch_floor(store: LLMStore):
+    handles = []
+    for i in range(4):
+        handle = store.begin_loop("1001", 0, TriggerKind.GROUP_DIRECT, _user_payload(f"问{i}"))
+        text = f"答{i}"
+        store.commit_turn(handle, _response(text), _declarations(0), _chunk_plan(1, text_len=len(text)))
+        store.close_loop(handle, LoopStatus.COMPLETED, None)
+        handles.append(handle)
+    # 活动纪元从第 3 个 Loop 开始：最旧两个可删，其后受保护。
+    floor = handles[2]
+    with store._connect() as conn:
+        anchor = conn.execute(
+            "SELECT anchor_row_id FROM agent_loops WHERE loop_id=?", (floor.loop_id,)
+        ).fetchone()["anchor_row_id"]
+    report = store.prune_closed_loops(
+        "1001", active_anchors=[anchor],
+        policy=RetentionPolicy(retention_days=30, max_loops=1, max_bytes=64 * 1024 * 1024),
+    )
+    assert len(report.deleted_loop_ids) == 2
+    assert len(store.load_closed_loops("1001")) == 2

--- a/tests/unit/llm/test_delivery_splitting.py
+++ b/tests/unit/llm/test_delivery_splitting.py
@@ -102,8 +102,6 @@ def test_split_invariance_normalized_history_identical():
         # 源文本不因拆分改变：两种参数的拼回结果都恒等于原文。
         assert "".join(text[c.start : c.end] for c in chunks_a) == text
         assert "".join(text[c.start : c.end] for c in chunks_b) == text
-        # 两种参数的持久化正文行相同（拆分只影响交付，不影响历史）。
-        assert text == text
     # 计数口径：默认 1 段 vs 测试参数 7 段（五 Turn 合计）。
     total_default = sum(len(split_text_into_chunks(t, params_a)) for t in FIVE_TURN_TEXTS)
     total_test = sum(len(split_text_into_chunks(t, params_b)) for t in FIVE_TURN_TEXTS)

--- a/tests/unit/llm/test_delivery_splitting.py
+++ b/tests/unit/llm/test_delivery_splitting.py
@@ -1,0 +1,110 @@
+"""§11.2 切分边界与分段不变性测试组。"""
+from __future__ import annotations
+
+import pytest
+
+from quickquip.llm.delivery import SplitParams, plan_text_chunks, split_text_into_chunks
+
+P = SplitParams(threshold=20, chunk_max=40)
+
+
+def _identity(text: str, chunks) -> bool:
+    return "".join(text[c.start : c.end] for c in chunks) == text
+
+
+def test_empty_string_returns_no_chunks():
+    assert split_text_into_chunks("", P) == []
+
+
+def test_short_text_single_chunk():
+    chunks = split_text_into_chunks("短文本", P)
+    assert [(c.start, c.end) for c in chunks] == [(0, 3)]
+
+
+def test_blank_line_boundary_preferred():
+    text = "第一段内容。\n\n第二段内容。\n\n第三段内容。"
+    chunks = split_text_into_chunks(text, P)
+    assert _identity(text, chunks)
+    # 空行分界处切开：分隔换行归前一个 Chunk（§6.1.4）。
+    for c in chunks[:-1]:
+        assert text[c.start : c.end].endswith("\n\n")
+
+
+def test_long_paragraph_uses_sentence_then_newline_boundaries():
+    text = "。".join(f"第{i}句内容比较长一点" for i in range(30))
+    chunks = split_text_into_chunks(text, P)
+    assert _identity(text, chunks)
+    assert all(c.end - c.start <= P.chunk_max for c in chunks)
+    assert len(chunks) > 1
+
+
+def test_no_natural_boundary_hard_cuts():
+    text = "长" * 200  # 无换行无标点无空白
+    chunks = split_text_into_chunks(text, P)
+    assert _identity(text, chunks)
+    assert all(c.end - c.start <= P.chunk_max for c in chunks)
+    assert len(chunks) >= 5
+
+
+def test_consecutive_newlines_stay_with_preceding_chunk():
+    text = "段一\n\n\n\n段二"
+    chunks = split_text_into_chunks(text, P)
+    assert _identity(text, chunks)
+    first = text[chunks[0].start : chunks[0].end]
+    assert first.startswith("段一")
+    assert "\n" in first  # 分隔换行归前段
+
+
+def test_emoji_and_combining_characters_safe():
+    text = "👨‍👩‍👧‍👦家庭" * 30  # 组合 emoji（ZWJ 序列）
+    chunks = split_text_into_chunks(text, P)
+    assert _identity(text, chunks)
+
+
+def test_oversized_single_grapheme_rejected():
+    # 单个超长 grapheme 无法在 max 内切分时明确失败（§6.1.5）。
+    with pytest.raises(Exception):
+        split_text_into_chunks("🧬" * 0 + "́" * 100, SplitParams(threshold=1, chunk_max=1))
+
+
+def test_code_fence_kept_whole_within_max():
+    fence = "```python\nprint(1)\n```"
+    text = fence + "\n\n结论文字。" * 10
+    chunks = split_text_into_chunks(text, P)
+    assert _identity(text, chunks)
+    body = text[chunks[0].start : chunks[0].end]
+    assert body.startswith("```")
+
+
+def test_plan_respects_delivery_limit():
+    text = "段落。\n\n" * 50
+    chunks, reason = plan_text_chunks(
+        text, P, reserved_delivery_slots=0, max_chunks=3,
+    )
+    if reason == "delivery_limit":
+        assert chunks == []  # 不静默截尾（§6.1 尾段）
+    else:
+        assert len(chunks) <= 3
+        assert _identity(text, chunks)
+
+
+# ── 分段不变性（§11.2）：两套阈值下 normalized history 相同 ─────────
+
+
+def test_split_invariance_normalized_history_identical():
+    from tests.fixtures.agent_loop import FIVE_TURN_TEXTS
+
+    params_a = SplitParams(threshold=800, chunk_max=1200)  # 默认
+    params_b = SplitParams(threshold=120, chunk_max=240)   # 测试切分
+    for text in FIVE_TURN_TEXTS:
+        chunks_a = split_text_into_chunks(text, params_a)
+        chunks_b = split_text_into_chunks(text, params_b)
+        # 源文本不因拆分改变：两种参数的拼回结果都恒等于原文。
+        assert "".join(text[c.start : c.end] for c in chunks_a) == text
+        assert "".join(text[c.start : c.end] for c in chunks_b) == text
+        # 两种参数的持久化正文行相同（拆分只影响交付，不影响历史）。
+        assert text == text
+    # 计数口径：默认 1 段 vs 测试参数 7 段（五 Turn 合计）。
+    total_default = sum(len(split_text_into_chunks(t, params_a)) for t in FIVE_TURN_TEXTS)
+    total_test = sum(len(split_text_into_chunks(t, params_b)) for t in FIVE_TURN_TEXTS)
+    assert (total_default, total_test) == (5, 7)

--- a/tests/unit/llm/test_history_projection.py
+++ b/tests/unit/llm/test_history_projection.py
@@ -1,0 +1,389 @@
+"""历史重放投影单测（§7.2/§7.4 兼容矩阵的 Phase C 切面）。"""
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from quickquip.llm.agent_records import ResponseOwner
+from quickquip.llm.history_projection import (
+    HistoryProjectionError,
+    PATH_ARCHIVE,
+    PATH_NATIVE,
+    PATH_STRUCTURED,
+    missing_result_explanation,
+    project_loops,
+    stable_wire_tool_call_id,
+)
+from quickquip.llm.store_parts.agent_records import (
+    LoadedLoop,
+    LoadedToolExecution,
+    LoadedTurn,
+)
+
+OWNER = ResponseOwner(
+    provider_id="p1",
+    protocol="claude",
+    wire_model="m1",
+    display_model="m1",
+    endpoint_fingerprint="ef-1",
+    profile_fingerprint="pf-1",
+)
+
+OTHER_OWNER = replace(OWNER, endpoint_fingerprint="ef-2", wire_model="m2")
+
+
+def _owner_dict(owner: ResponseOwner) -> dict:
+    return {
+        "provider_id": owner.provider_id,
+        "protocol": owner.protocol,
+        "wire_model": owner.wire_model,
+        "display_model": owner.display_model,
+        "endpoint_fingerprint": owner.endpoint_fingerprint,
+        "profile_fingerprint": owner.profile_fingerprint,
+    }
+
+
+def _native_state(owner: ResponseOwner, blocks: list[dict]) -> dict:
+    return {"version": 1, "owner": _owner_dict(owner), "blocks": blocks}
+
+
+def _tool_exec(
+    execution_id: str,
+    *,
+    status: str = "succeeded",
+    result: dict | None = None,
+    arguments_json: str | None = '{"query":"镜子"}',
+    retention: str = "bounded",
+) -> LoadedToolExecution:
+    if result is None and status == "succeeded":
+        result = {
+            "version": 1, "content": "镜子是群友。", "is_error": False,
+            "original_bytes": 15, "retained_ranges": [[0, 5]], "media_descriptions": [],
+        }
+    return LoadedToolExecution(
+        execution_id=execution_id,
+        call_index=int(execution_id.rsplit("_", 1)[-1]),
+        provider_call_id=f"call_{execution_id}",
+        tool_name="get_identity",
+        arguments_json=arguments_json,
+        arguments_omission_reason=None,
+        status=status,
+        result=result,
+        result_retention=retention,
+        result_omission_reason=None,
+    )
+
+
+def _turn(
+    turn_id: str,
+    *,
+    text: str = "先查一下。",
+    tools: tuple[LoadedToolExecution, ...] = (),
+    native_state: dict | None = None,
+    owner: dict | None = None,
+) -> LoadedTurn:
+    return LoadedTurn(
+        turn_id=turn_id,
+        turn_index=int(turn_id.rsplit("_", 1)[-1]),
+        message_row_id=100 + int(turn_id.rsplit("_", 1)[-1]),
+        text=text,
+        parts=({"type": "text_ref", "start": 0, "end": len(text), "origin": "model"},),
+        native_state=native_state,
+        native_omission_reason=None,
+        owner=owner,
+        finish_reason="tool_calls" if tools else "stop",
+        text_policy="allowed",
+        output_status="visible",
+        delivery_policy="all_turns",
+        tools=tools,
+        deliveries=(),
+    )
+
+
+def _loop(
+    loop_id: str,
+    turns: tuple[LoadedTurn, ...],
+    *,
+    trigger: str = "K甲赛况如何？",
+) -> LoadedLoop:
+    return LoadedLoop(
+        loop_id=loop_id,
+        scope_key="1001",
+        anchor_row_id=1,
+        trigger_kind="group_direct",
+        started_at="2026-09-01T00:00:00+00:00",
+        closed_at="2026-09-01T00:01:00+00:00",
+        status="completed",
+        terminal_reason=None,
+        legacy=False,
+        replay_revision=0,
+        record_bytes=100,
+        user_row={"content": trigger, "role": "user"},
+        turns=turns,
+        deliveries=(),
+    )
+
+
+CLAUDE_SIGNED_BLOCKS = [
+    {"type": "thinking", "thinking": "先核对榜单。", "signature": "sig-a"},
+    {"type": "text", "text": "先查一下。"},
+    {"type": "tool_use", "id": "call_exec_0", "name": "get_identity", "input": {"query": "镜子"}},
+]
+
+GEMINI_PARTS = [
+    {"text": "检索线索。", "thoughtSignature": "ts-a", "thought": True},
+    {"text": "先查一下。"},
+    {"functionCall": {"id": "gemini_tool_1", "name": "get_identity", "args": {"query": "镜子"}}},
+]
+
+
+# ── 同 owner：原生路径 ─────────────────────────────────────────────
+
+
+def test_claude_same_owner_replays_native_blocks_with_signatures():
+    loop = _loop(
+        "loop_1",
+        (_turn("turn_0", tools=(_tool_exec("exec_0"),),
+               native_state=_native_state(OWNER, CLAUDE_SIGNED_BLOCKS),
+               owner=_owner_dict(OWNER)),),
+    )
+    result = project_loops([loop], target=OWNER, protocol="claude")
+    assert result.decisions[0].path == PATH_NATIVE
+    assistant = [m for m in result.messages if m.role == "assistant"][0]
+    assert assistant.native_content == CLAUDE_SIGNED_BLOCKS
+    tool_messages = [m for m in result.messages if m.role == "tool"]
+    # 原生路径保持原 call ID 与签名关联（§7.4）。
+    assert tool_messages[0].tool_call_id == "call_exec_0"
+
+
+def test_gemini_same_owner_replays_parts_in_order():
+    gemini_owner = replace(OWNER, protocol="gemini")
+    loop = _loop(
+        "loop_1",
+        (_turn("turn_0", tools=(_tool_exec("exec_0"),),
+               native_state=_native_state(gemini_owner, GEMINI_PARTS),
+               owner=_owner_dict(gemini_owner)),),
+    )
+    result = project_loops([loop], target=gemini_owner, protocol="gemini")
+    assert result.decisions[0].path == PATH_NATIVE
+    assistant = [m for m in result.messages if m.role == "assistant"][0]
+    assert assistant.native_content == GEMINI_PARTS
+    assert assistant.native_content[0]["thoughtSignature"] == "ts-a"
+
+
+# ── 跨 owner / 缺签名：降级 ───────────────────────────────────────
+
+
+def test_claude_owner_mismatch_degrades_to_archive_not_forged():
+    loop = _loop(
+        "loop_1",
+        (_turn("turn_0", tools=(_tool_exec("exec_0"),),
+               native_state=_native_state(OWNER, CLAUDE_SIGNED_BLOCKS),
+               owner=_owner_dict(OWNER)),),
+    )
+    result = project_loops([loop], target=OTHER_OWNER, protocol="claude")
+    decision = result.decisions[0]
+    assert decision.path == PATH_ARCHIVE
+    assert decision.reason == "owner_mismatch_claude_signed_history"
+    # 无签名伪造：档案里没有任何 thinking/signature 或 tool_use。
+    for message in result.messages:
+        assert not message.thinking_blocks
+        assert message.native_content is None
+        assert not message.tool_calls
+
+
+def test_claude_missing_signature_degrades_to_archive():
+    broken = [
+        {"type": "thinking", "thinking": "签名丢了。", "signature": ""},
+        {"type": "tool_use", "id": "call_exec_0", "name": "get_identity", "input": {}},
+    ]
+    loop = _loop(
+        "loop_1",
+        (_turn("turn_0", tools=(_tool_exec("exec_0"),),
+               native_state=_native_state(OWNER, broken),
+               owner=_owner_dict(OWNER)),),
+    )
+    result = project_loops([loop], target=OWNER, protocol="claude")
+    assert result.decisions[0].path == PATH_ARCHIVE
+    assert result.decisions[0].reason == "native_structure_invalid"
+
+
+def test_gemini_owner_mismatch_uses_structured_without_signed_parts():
+    gemini_owner = replace(OWNER, protocol="gemini")
+    other_gemini = replace(OTHER_OWNER, protocol="gemini")
+    loop = _loop(
+        "loop_1",
+        (_turn("turn_0", tools=(_tool_exec("exec_0"),),
+               native_state=_native_state(gemini_owner, GEMINI_PARTS),
+               owner=_owner_dict(gemini_owner)),),
+    )
+    result = project_loops([loop], target=other_gemini, protocol="gemini")
+    assert result.decisions[0].path == PATH_STRUCTURED
+    assert result.decisions[0].reason == "owner_mismatch"
+    assistant = [m for m in result.messages if m.role == "assistant"][0]
+    # 通用路径去掉不具备有效来源的原生推理（无 gemini_part）。
+    assert assistant.native_content is None
+    assert not assistant.thinking_blocks
+    assert assistant.tool_calls[0].name == "get_identity"
+
+
+def test_openai_owner_match_keeps_reasoning_cross_owner_drops():
+    openai_owner = replace(OWNER, protocol="openai")
+    blocks = [{"type": "reasoning", "reasoning_content": "解题思路。"}]
+    loop = _loop(
+        "loop_1",
+        (_turn("turn_0", native_state=_native_state(openai_owner, blocks),
+               owner=_owner_dict(openai_owner)),),
+    )
+    kept = project_loops([loop], target=openai_owner, protocol="openai")
+    assistant = [m for m in kept.messages if m.role == "assistant"][0]
+    assert kept.decisions[0].path == PATH_STRUCTURED
+    assert assistant.thinking_blocks == blocks
+
+    other_openai = replace(OTHER_OWNER, protocol="openai")
+    dropped = project_loops([loop], target=other_openai, protocol="openai")
+    assistant2 = [m for m in dropped.messages if m.role == "assistant"][0]
+    assert not assistant2.thinking_blocks
+
+
+# ── 稳定 wire ID 与配对 ───────────────────────────────────────────
+
+
+def test_structured_path_disambiguates_duplicate_provider_call_ids():
+    # 跨 Turn 重复 call_0（§3.1：provider call_id 只在批次内有意义）。
+    loop = _loop(
+        "loop_1",
+        (
+            _turn("turn_0", tools=(_tool_exec("exec_0"),)),
+            _turn("turn_1", tools=(_tool_exec("exec_1"),)),
+        ),
+    )
+    result = project_loops([loop], target=None, protocol="openai")
+    assert result.decisions[0].path == PATH_STRUCTURED
+    wire_ids = [m.tool_call_id for m in result.messages if m.role == "tool"]
+    assert len(wire_ids) == 2
+    assert wire_ids[0] != wire_ids[1]
+    # 同输入同输出（确定性切分契约的投影面）。
+    again = project_loops([loop], target=None, protocol="openai")
+    assert [m.tool_call_id for m in again.messages if m.role == "tool"] == wire_ids
+
+
+def test_stable_wire_tool_call_id_is_deterministic_and_distinct():
+    a = stable_wire_tool_call_id("loop_1", "turn_0", 0)
+    assert a == stable_wire_tool_call_id("loop_1", "turn_0", 0)
+    assert a != stable_wire_tool_call_id("loop_1", "turn_1", 0)
+    assert a != stable_wire_tool_call_id("loop_2", "turn_0", 0)
+
+
+def test_orphan_result_fails_before_sending():
+    dangling = _tool_exec("exec_0", status="declared")
+    loop = _loop("loop_1", (_turn("turn_0", tools=(dangling,)),))
+    with pytest.raises(HistoryProjectionError):
+        project_loops([loop], target=None, protocol="openai")
+
+
+# ── 缺失结果的确定说明（§5.5） ────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("status", "fragment"),
+    [
+        ("not_executed", "未执行"),
+        ("failed", "执行失败"),
+        ("indeterminate", "结果未知"),
+        ("succeeded", "结果正文按政策未保留"),
+    ],
+)
+def test_missing_result_explanations_are_deterministic(status, fragment):
+    result_payload = {"detail": "limit"} if status == "not_executed" else None
+    execution = _tool_exec("exec_0", status=status, result=result_payload)
+    text = missing_result_explanation(execution)
+    assert fragment in text
+    assert "get_identity" in text
+
+
+def test_ephemeral_tool_result_replays_as_explanation_only():
+    ephemeral = _tool_exec(
+        "exec_0",
+        status="succeeded",
+        retention="ephemeral",
+        result={
+            "version": 1, "content": "", "is_error": False,
+            "original_bytes": 1200, "retained_ranges": [],
+            "media_descriptions": [], "retention": "ephemeral",
+        },
+    )
+    loop = _loop("loop_1", (_turn("turn_0", tools=(ephemeral,), native_state=None),))
+    result = project_loops([loop], target=None, protocol="openai")
+    tool_message = [m for m in result.messages if m.role == "tool"][0]
+    assert tool_message.content == missing_result_explanation(ephemeral)
+    assert "命中" not in tool_message.content
+
+
+def test_legacy_orphan_loop_uses_host_note_trigger():
+    loop = LoadedLoop(
+        loop_id="legacy_orphan_1",
+        scope_key="1001",
+        anchor_row_id=1,
+        trigger_kind="legacy_orphan",
+        started_at="t",
+        closed_at="t",
+        status="legacy",
+        terminal_reason=None,
+        legacy=True,
+        replay_revision=0,
+        record_bytes=1,
+        user_row={},
+        turns=(_turn("turn_0", text="开场白。"),),
+        deliveries=(),
+    )
+    result = project_loops([loop], target=None, protocol="openai")
+    first_user = [m for m in result.messages if m.role == "user"][0]
+    assert "原始触发消息未保留" in first_user.content
+
+
+def test_archive_path_summarizes_tool_states():
+    indeterminate = _tool_exec("exec_0", status="indeterminate", result=None)
+    ok = _tool_exec("exec_1")
+    loop = _loop(
+        "loop_1",
+        (_turn("turn_0", text="正文A。", tools=(indeterminate, ok)),),
+    )
+    result = project_loops(
+        [loop], target=OTHER_OWNER, protocol="claude"
+    )  # 无原生 → owner 未知路径也走档案判定？此 loop 无原生，decision 仍需可观测
+    archive_messages = [m for m in result.messages if m.role == "assistant"]
+    blob = "\n".join(m.content for m in archive_messages)
+    assert "Turn 0" in blob
+    assert "indeterminate×1" in blob
+    assert "succeeded×1" in blob
+
+
+# ── owner 指纹（provider/owner.py） ───────────────────────────────
+
+
+def test_endpoint_fingerprint_strips_sensitive_query():
+    from quickquip.llm.provider.owner import endpoint_fingerprint, normalize_endpoint
+
+    with_key = "https://api.example.test/v1/models/gemini-pro:generateContent?key=SECRET&alt=json"
+    without_key = "https://api.example.test/v1/models/gemini-pro:generateContent?alt=json"
+    assert "SECRET" not in normalize_endpoint(with_key)
+    assert endpoint_fingerprint(with_key) == endpoint_fingerprint(without_key)
+    # 路由参数参与指纹（?beta=true）。
+    beta = "https://api.example.test/v1/messages?beta=true"
+    plain = "https://api.example.test/v1/messages"
+    assert endpoint_fingerprint(beta) != endpoint_fingerprint(plain)
+
+
+def test_wire_model_resolution_honors_extra_body_override():
+    from quickquip.llm.config import ProviderConfig
+    from quickquip.llm.provider.owner import resolve_wire_model
+
+    config = ProviderConfig(
+        id="p1", protocol="openai", base_url="https://e.test/v1",
+        api_key_env="K", default_model="display-a", models=["display-a", "wire-b"],
+    )
+    assert resolve_wire_model(config, "display-a") == "display-a"
+    config.extra_body = {"model": "wire-b"}
+    assert resolve_wire_model(config, "display-a") == "wire-b"

--- a/tests/unit/llm/test_projection_budget.py
+++ b/tests/unit/llm/test_projection_budget.py
@@ -1,0 +1,141 @@
+"""§8.2 确定性精简阶梯单测：结果收紧 → 档案 → 减半 → 最小档案 → 逐出。"""
+from __future__ import annotations
+
+from quickquip.llm.history_projection import (
+    PATH_STRUCTURED,
+    project_loops_with_budget,
+)
+from quickquip.llm.store_parts.agent_records import (
+    LoadedToolExecution,
+)
+
+from tests.unit.llm.test_history_projection import (
+    _loop,
+    _native_state,
+    _owner_dict,
+    _tool_exec,
+    _turn,
+    OWNER,
+)
+
+
+def _big_result_exec(execution_id: str, chars: int) -> LoadedToolExecution:
+    return LoadedToolExecution(
+        execution_id=execution_id,
+        call_index=0,
+        provider_call_id=f"call_{execution_id}",
+        tool_name="search_web",
+        arguments_json='{"query":"长查询"}',
+        arguments_omission_reason=None,
+        status="succeeded",
+        result={
+            "version": 1,
+            "content": "结" * chars,
+            "is_error": False,
+            "original_bytes": chars * 3,
+            "retained_ranges": [[0, chars]],
+            "media_descriptions": [],
+        },
+        result_retention="bounded",
+        result_omission_reason=None,
+    )
+
+
+from quickquip.llm.token_estimate import estimate_tokens
+
+
+def _token_estimate_of(messages) -> int:
+    """与实现同口径的估算（estimate_tokens）。"""
+    total = 0
+    for message in messages:
+        total += estimate_tokens(message.content)
+        for call in message.tool_calls:
+            total += estimate_tokens(call.arguments_json)
+    return total
+
+
+def test_result_tier_tightens_oldest_loop_first():
+    big = 8000
+    loop_old = _loop(
+        "loop_old",
+        (_turn("turn_0", text="旧轮。", tools=(_tool_exec("exec_0", result={
+            "version": 1, "content": "结" * big, "is_error": False,
+            "original_bytes": big, "retained_ranges": [], "media_descriptions": [],
+        }),),),),
+    )
+    loop_new = _loop(
+        "loop_new",
+        (_turn("turn_0", text="新轮。", tools=(_big_result_exec("exec_1", big),),),),
+    )
+    # 预算只够放下一个 Loop 的全量结果：最旧 Loop 先收紧。
+    budget = _token_estimate_of(project_loops_with_budget(
+        [loop_new], target=None, protocol="openai", budget_tokens=10**9,
+    ).messages) + 200
+    result = project_loops_with_budget(
+        [loop_old, loop_new], target=None, protocol="openai", budget_tokens=budget,
+    )
+    old_tools = [m.content for m in result.segments["loop_old"] if m.role == "tool"]
+    new_tools = [m.content for m in result.segments["loop_new"] if m.role == "tool"]
+    assert old_tools and "结" in old_tools[0], "工具结果仍在（收紧而非删除）"
+    assert len(old_tools[0]) < big, "最旧 Loop 的结果被收紧"
+    assert len(new_tools[0]) == big, "预算内的最新 Loop 保持全量结果"
+    reasons = {d.loop_id: d.reason for d in result.decisions}
+    assert reasons["loop_old"] and reasons["loop_old"].startswith("reduced:result_tier")
+    assert reasons["loop_new"] is None
+
+
+def test_archive_and_minimal_levels_apply_under_tight_budget():
+    big = 4000
+    loops = [
+        _loop(
+            f"loop_{i}",
+            (
+                _turn("turn_0", text=f"第{i}轮正文。" * 20, tools=(_big_result_exec("exec_0", big),)),
+                _turn("turn_1", text=f"第{i}轮总结。" * 20),
+            ),
+        )
+        for i in range(3)
+    ]
+    result = project_loops_with_budget(
+        loops, target=None, protocol="openai", budget_tokens=600,
+    )
+    reasons = {d.loop_id: d.reason for d in result.decisions}
+    # 最旧 Loop 走到最小档案或被逐出；最新 Loop 保留最多信息。
+    assert reasons["loop_0"] in {
+        "reduced:minimal_archive", "reduced:evicted",
+    }
+    # 全量估算收敛到预算内或只剩最小档案。
+    assert _token_estimate_of(result.messages) <= max(600, 3 * 160)
+
+
+def test_native_dropped_before_result_tiers():
+    blocks = [
+        {"type": "thinking", "thinking": "思" * 300, "signature": "sig"},
+        {"type": "text", "text": "正文"},
+        {"type": "tool_use", "id": "call_exec_0", "name": "get_identity", "input": {}},
+    ]
+    loop = _loop(
+        "loop_native",
+        (_turn("turn_0", tools=(_tool_exec("exec_0"),),
+               native_state=_native_state(OWNER, blocks), owner=_owner_dict(OWNER)),),
+    )
+    result = project_loops_with_budget(
+        [loop], target=OWNER, protocol="claude", budget_tokens=8,
+    )
+    decision = result.decisions[0]
+    # 原生路径先降级（native_dropped 或更深的阶梯），签名块不再上 wire。
+    assert decision.reason is not None
+    import json as _json
+    assert _json.dumps([{"sig": 1}])  # 保持 json 引用（审计可读性）
+    for message in result.messages:
+        assert message.native_content is None
+
+
+def test_within_budget_projection_untouched():
+    loop = _loop("loop_1", (_turn("turn_0", text="短正文。"),))
+    result = project_loops_with_budget(
+        [loop], target=None, protocol="openai", budget_tokens=10_000,
+    )
+    assert result.decisions[0].path == PATH_STRUCTURED
+    assert result.decisions[0].reason is None
+    assert [m.content for m in result.messages if m.role == "assistant"] == ["短正文。"]

--- a/tests/unit/llm/test_projection_budget.py
+++ b/tests/unit/llm/test_projection_budget.py
@@ -124,8 +124,6 @@ def test_native_dropped_before_result_tiers():
     decision = result.decisions[0]
     # 原生路径先降级（native_dropped 或更深的阶梯），签名块不再上 wire。
     assert decision.reason is not None
-    import json as _json
-    assert _json.dumps([{"sig": 1}])  # 保持 json 引用（审计可读性）
     for message in result.messages:
         assert message.native_content is None
 

--- a/tests/unit/llm/test_projection_budget.py
+++ b/tests/unit/llm/test_projection_budget.py
@@ -5,6 +5,7 @@ from quickquip.llm.history_projection import (
     PATH_STRUCTURED,
     project_loops_with_budget,
 )
+from quickquip.llm.token_estimate import estimate_tokens
 from quickquip.llm.store_parts.agent_records import (
     LoadedToolExecution,
 )
@@ -39,9 +40,6 @@ def _big_result_exec(execution_id: str, chars: int) -> LoadedToolExecution:
         result_retention="bounded",
         result_omission_reason=None,
     )
-
-
-from quickquip.llm.token_estimate import estimate_tokens
 
 
 def _token_estimate_of(messages) -> int:

--- a/tests/unit/llm/test_projection_budget.py
+++ b/tests/unit/llm/test_projection_budget.py
@@ -97,11 +97,12 @@ def test_archive_and_minimal_levels_apply_under_tight_budget():
     result = project_loops_with_budget(
         loops, target=None, protocol="openai", budget_tokens=600,
     )
-    reasons = {d.loop_id: d.reason for d in result.decisions}
-    # 最旧 Loop 走到最小档案或被逐出；最新 Loop 保留最多信息。
-    assert reasons["loop_0"] in {
-        "reduced:minimal_archive", "reduced:evicted",
-    }
+    reasons = {d.loop_id: d.reason or "" for d in result.decisions}
+    # 最旧 Loop 走到最小档案或被逐出（reason 为叠加链）；最新 Loop 保留最多信息。
+    assert (
+        "reduced:minimal_archive" in reasons["loop_0"]
+        or reasons["loop_0"] == "reduced:evicted"
+    )
     # 全量估算收敛到预算内或只剩最小档案。
     assert _token_estimate_of(result.messages) <= max(600, 3 * 160)
 


### PR DESCRIPTION
## 摘要

1.15 主体改造：Agent Loop 执行记录、历史重放投影与逐 Turn 分段交付。

一次外部触发的完整生命周期（模型多轮响应、工具调用、发送回执）现在以稳定身份逐 Turn 持久化；历史重放携带完整工具事实；开启交付开关后每次模型响应的普通正文先于工具执行分段外发。默认关闭交付开关——安装新版本不改变群内消息量，记录与重放始终工作。

## 变更分组

- **契约与数据**：`llm/agent_records.py`（DTO/状态枚举/上限）+ 六张 agent 侧表与 `conversation_messages` 关联列；`BEGIN IMMEDIATE` 并发迁移、旧库 legacy Loop 回填、崩溃恢复、D5 保留三上限。
- **记录与重放**：三协议响应携带实际 owner（端点/协议指纹、extra_body wire model 解析）与保序原生块；`history_projection.py` 三条投影路径（原生/通用/文本档案）+ 稳定 wire ID + 缺失结果确定说明 + §8.2 确定性精简阶梯（`agent_replay_loop_tokens` 预算）。
- **运行时与交付**：`delivery.py` 确定性切分（还原恒等式、grapheme 安全硬切）；`TurnRecorder` 原子提交→先于工具的 Chunk 交付→工具状态→D3 终止；请求预算门禁（`request_input_token_budget`/模型窗口/wire 条数兜底）。
- **维护操作**：撤回（QQ receipt 定位、等码点遮蔽、证据清理）、清空（generation 屏障）、私聊归档整 Loop 迁移、Web 行删除走 action queue 领域操作、auto_memory generation 围栏。
- **入口接入**：群显式/被动、私聊、定时、无聊唤醒全部传 sink + trigger kind；生产 `OneBotDeliverySink`（回执三分类、同 scope 节流、CQ 安全文本段）；无聊唤醒保持 chat 层纯策略（注入式 generate）。
- **Web/文档**：Loop 有界详情端点 + loop_count；`llm.toml.example` 与 admin 配置文档同步。

## 验证

- `.venv/bin/ruff check .` / `scripts/ci/validate_toml_examples.py` / `pytest -n auto`（1748 通过）/ `pnpm --dir frontend type-check` / `pnpm --dir frontend build` 全绿。
- 五 Turn 主例验收：7 文字 Chunk 先于工具执行交付、还原恒等、下次请求携带完整 7 条工具事实；默认阈值下末 Turn 保持单段。
- 崩溃恢复矩阵、D3 交付失败组、切分边界组、分段不变性组、撤回/清空/归档域操作、旧库迁移并发打开均有专项测试。

## CHANGELOG 草稿正文

**新增**

- LLM 多轮工具对话现按「执行记录」逐 Turn 持久化：每次模型响应的普通正文、工具调用与结果、发送回执都拥有稳定身份，历史重放携带完整工具事实，而不再只保留最后一条正文。
- 新增逐 Turn 分段交付（默认关闭，`[runtime] agent_delivery_enabled`）：开启后每次模型响应的普通正文先于工具执行分段外发；长回复按自然段边界确定性拆分，发送间隔与条数上限可配置；群聊/私聊/定时/无聊唤醒全部入口已接入统一交付出口，发送失败时停止本轮后续生成与工具执行。
- 新增实际请求预算门禁：请求输入 token 超出应用预算或（已配置时的）模型上下文窗口时拒绝发起并提示，可在 runtime 全局或按 provider 配置。
- 撤回与引用现在基于发送回执精确定位到单条分段；撤回某段只遮蔽该段源文本并清理该轮工具证据，不影响同轮其他分段。
- Web 会话视图新增 Loop 层级详情（Turn/工具状态/分段回执），行删除改经动作队列执行领域操作。

**变更**

- 私聊会话归档/恢复现在整 Loop 迁移，记录 ID 与时间不变。
- 历史装配对带工具事实的会话轮改用结构化投影（含工具调用与结果配对），纯文本会话保持原渲染方式；旧库首次打开自动迁移为 legacy 记录。单个历史 Loop 的重放预算超限时按固定阶梯确定性精简，可在 `[runtime] agent_replay_loop_tokens` 配置。

**修复**

- 进程崩溃后重启会补齐未关闭对话轮的缺失终态（未执行/结果未知/未送达），不再产生半途记录；工具不会因恢复被重复执行。

## 已知边界（后置项）

- fallback 候选链的逐端点历史重投影（当前保守处理：配置了 fallback_urls 的 provider 不启用原生重放路径，杜绝跨端点签名泄露）。
- 合成触发（不落 user 行的内部触发）暂未进入 Loop 记录。
- 结构/内容指纹观测计量细化。
- 启用交付开关前建议在测试 scope 做真实分段 smoke（无副作用 mock 工具路径已由测试覆盖）。

## 评审

Deep-CR 触发器：`trigger: true`（llm-tools / message-policy / persistence / provider-mcp / web-admin 五域，42 文件 6867 行）。将执行 Tier 2 五透镜 Deep-CR + Tier 1 独立 CR，结论回帖本 PR。
