### PR TITLE
fix(agent-loop): preserve delivery and limit facts

### DIFF
--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -1473,6 +1473,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 normalized_forward_image_urls=normalized_forward_image_urls,
                 # 同 _persist_turn_and_build_reply 的落库口径：他人近期图注不落触发者名下。
                 image_descriptions=[d for d in image_descriptions if not d.context_label.startswith(RECENT_IMAGE_CONTEXT_PREFIX)] or None,
+                delivery_sink=delivery_sink,
             )
             with (
                 usage_scope("chat", group_id=scope_key, persona_id=settings.persona_id or None),
@@ -1588,7 +1589,10 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             recorder_rows_written=recorder is not None,
         )
         if recorder is not None:
-            recorder.close(LoopStatus.COMPLETED, None)
+            terminal_status = (
+                LoopStatus.INTERRUPTED if recorder.terminal_reason else LoopStatus.COMPLETED
+            )
+            recorder.close(terminal_status, recorder.terminal_reason)
             self.maintain_agent_retention(scope_key)
             if recorder.final_turn_record is not None:
                 result_payload = dict(result_payload)

--- a/src/quickquip/llm/service_parts/agent_runtime.py
+++ b/src/quickquip/llm/service_parts/agent_runtime.py
@@ -117,6 +117,14 @@ class TurnRecorder:
     def final_turn_record(self) -> TurnRecord | None:
         return self._final_turn_record
 
+    @property
+    def terminal_reason(self) -> str | None:
+        return self._terminal_reason
+
+    def mark_interrupted(self, reason: str) -> None:
+        """记录未完成 Loop 的领域终止原因，由 service 在收尾时关闭。"""
+        self._terminal_reason = reason
+
     def _clean_text(self, raw: str) -> str:
         text = strip_leading_reasoning_content(raw or "")
         text = re.sub(r"\n{3,}", "\n\n", text).strip()

--- a/src/quickquip/llm/tool_loop.py
+++ b/src/quickquip/llm/tool_loop.py
@@ -102,7 +102,17 @@ async def run_tool_call_loop(
         if has_counted_calls and counted_rounds >= max_rounds:
             response.text = response.text or "工具调用轮次已达上限，未能完成最终回答。"
             if turn_recorder is not None:
-                turn_recorder.on_turn(response, declared_calls=[], executable_calls=[], has_more_rounds=False)
+                execution_ids = turn_recorder.on_turn(
+                    response,
+                    declared_calls=list(response.tool_calls),
+                    executable_calls=[],
+                    has_more_rounds=False,
+                )
+                turn_recorder.mark_interrupted("tool_round_limit")
+                for call in response.tool_calls:
+                    execution_id = execution_ids.get(call.id)
+                    if execution_id is not None:
+                        turn_recorder.on_tool_skipped(execution_id, ToolSkipReason.ROUND_LIMIT)
                 await turn_recorder.deliver_turn()
             return response
 
@@ -158,7 +168,17 @@ async def run_tool_call_loop(
         if round_index >= search_failsafe_max_rounds:
             response.text = response.text or "联网检索轮次过多，已触发安全上限，未能完成最终回答。"
             if turn_recorder is not None:
-                turn_recorder.on_turn(response, declared_calls=[], executable_calls=[], has_more_rounds=False)
+                execution_ids = turn_recorder.on_turn(
+                    response,
+                    declared_calls=list(response.tool_calls),
+                    executable_calls=[],
+                    has_more_rounds=False,
+                )
+                turn_recorder.mark_interrupted("search_failsafe_limit")
+                for call in response.tool_calls:
+                    execution_id = execution_ids.get(call.id)
+                    if execution_id is not None:
+                        turn_recorder.on_tool_skipped(execution_id, ToolSkipReason.ROUND_LIMIT)
                 await turn_recorder.deliver_turn()
             return response
 

--- a/tests/integration/test_agent_loop_baseline.py
+++ b/tests/integration/test_agent_loop_baseline.py
@@ -141,10 +141,9 @@ async def test_all_turns_mode_seven_chunks_delivered_before_tools(
         AGENT_LOOP_TEST_SPLIT["chunk_max"],
     )
     sink = CollectingSink()
-    scenario_service.bind_delivery_sink(sink)
     patch_scenario_provider("openai")
 
-    result = await run_five_turn_scenario(scenario_service)
+    result = await run_five_turn_scenario(scenario_service, delivery_sink=sink)
 
     # 七个文字 Chunk（4 Turn × 1 + 末 Turn 3）。
     assert len(sink.deliveries) == 7
@@ -163,6 +162,34 @@ async def test_all_turns_mode_seven_chunks_delivered_before_tools(
             "SELECT COUNT(*) FROM agent_deliveries WHERE kind = 'text_chunk'"
         ).fetchone()[0]
     assert chunk_count == 7
+
+
+async def test_round_limit_records_declared_calls_as_not_executed(
+    scenario_service, patch_scenario_provider, monkeypatch
+):
+    monkeypatch.setattr(scenario_service.config.runtime, "tool_max_rounds", 1)
+    patch_scenario_provider("openai")
+
+    await run_five_turn_scenario(scenario_service)
+
+    with scenario_service.store._connect() as conn:
+        tool_rows = conn.execute(
+            "SELECT tool_name, status, result_json FROM agent_tool_executions ORDER BY rowid"
+        ).fetchall()
+
+    # Turn 0 executes its one call; Turn 1 is declared but rejected by the
+    # loop limit and must retain both calls as not_executed facts.
+    assert len(tool_rows) == 3
+    assert [row["status"] for row in tool_rows] == [
+        "succeeded", "not_executed", "not_executed"
+    ]
+    assert all("limit" in row["result_json"] for row in tool_rows[1:])
+    with scenario_service.store._connect() as conn:
+        loop_row = conn.execute(
+            "SELECT status, terminal_reason FROM agent_loops"
+        ).fetchone()
+    assert loop_row["status"] == "interrupted"
+    assert loop_row["terminal_reason"] == "tool_round_limit"
 
 
 # ── 重放：下次请求携带完整工具事实（§11.2） ─────────────────────────


### PR DESCRIPTION
## 变更

- 传递请求级 `DeliverySink` 到 `TurnRecorder`，修复开启逐 Turn 交付后生产入口落入缺少 sink 异常路径。
- 工具循环达到 `tool_max_rounds` 或搜索 failsafe 上限时，完整保存模型声明的工具调用并标记 `not_executed(limit)`。
- 将安全上限终止的 Loop 关闭为 `interrupted`，保留准确的终止原因。
- 增加生产形态的交付传递与轮次上限回归测试。

## 评审

- 独立 CR SubAgent：通过，无新的 P1/P0。
- 按授权不等待 Bot Review；当前变更已完成本地独立审查。

## 验证

- `.venv/bin/python -m pytest -q`：1749 passed, 2 deselected
- Ruff：通过
- `pnpm --dir frontend type-check`：通过
- 示例配置校验：12 files OK
- ID literals 检查：通过
- `git diff --check`：通过
