### PR TITLE
feat: agent-loop 原生预算重标定 — 计量修复 + 窗口推导

### DIFF
--- a/config/llm.toml.example
+++ b/config/llm.toml.example
@@ -34,8 +34,16 @@ tool_max_calls_per_round = 16
 # recent_context_floor_seconds = 300
 
 # 实际请求输入预算（应用侧估算口径，非模型平台上限）：每次 provider 请求前
-# 对最终 payload 估算，超限拒绝发起并提示清空上下文。provider 可单独覆盖。
+# 对最终 payload 估算。按「provider 显式覆盖 > 模型窗口推导（窗口−输出预留）>
+# 本缺省」解析；超限先把纪元窗口缩到热水位重建请求重试一次，仍超限才拒绝。
+# provider 可单独覆盖。
 # request_input_token_budget = 96000
+
+# 历史 Loop 重放投影预算的推导下限：实际预算按「请求输入预算 − 纪元可见窗
+# 上限 − system/工具预留 − 当前 Loop 比例预留」推导，配置了模型容量
+# （model_context_windows 或内置窗口表命中）的 provider 自动放大到窗口量级；
+# capacity unknown 时即本值。provider 可硬覆盖。
+# agent_replay_loop_tokens = 4096
 
 # Agent 执行记录保留（按 scope，先触顶者触发整 Loop 清理）
 # agent_record_retention_days = 30
@@ -45,7 +53,6 @@ tool_max_calls_per_round = 16
 # 逐 Turn 交付（默认关闭：安装新版本不改变群内消息量；记录与重放始终工作）
 # 开启后每次模型响应的普通正文先于工具执行分段外发；阈值/上限为 Unicode
 # code point 口径，独立于 OneBot 协议报文长度限制。
-# agent_replay_loop_tokens = 4096
 # agent_delivery_enabled = false
 # reply_split_threshold_chars = 800
 # reply_chunk_max_chars = 1200
@@ -339,6 +346,9 @@ style_profile = "claude_family"
 # auth_method = "bearer"      # 认证方式："api_key"=x-api-key 头（默认），"bearer"=Authorization: Bearer
 # prompt_caching = true       # 启用 Anthropic Prompt Caching（需中转站支持 CLI 格式）
 # headers = { x-app = "cli" } # 自定义 HTTP 头；不设置 x-app 时自动补为 "cli"
+# model_context_windows = { "claude-sonnet-4-6" = 200000 }  # wire 模型 → 上下文窗口；未配置的模型按内置家族表解析，中继自定义模型名建议显式声明
+# agent_replay_loop_tokens = 131072  # 重放投影预算硬覆盖（优先于按窗口推导）
+# request_input_token_budget = 96000 # 请求输入预算硬覆盖（优先于按窗口推导）
 timeout_seconds = 45
 temperature = 0.8
 max_output_tokens = 2048

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -134,11 +134,11 @@ GHCR 分发镜像和 `prod.example/Dockerfile` 均基于 Playwright Python 镜�
 | `epoch_cap_tokens` | 窗口硬上限：超过即触发触顶重置（H_hot / cap） | `64000` |
 | `recent_context_token_budget` | 【现场】补丁每轮 token 预算：近期消息缓冲服役给 LLM 的上限（从最新往回截） | `800` |
 | `recent_context_floor_seconds` | 【现场】滑动保底窗秒数：窗内消息即使已服役过也会重附（增量语义之外的保底） | `300` |
-| `request_input_token_budget` | 实际请求输入预算（应用侧估算口径，非模型平台上限）：超限拒绝发起请求；可在 `[[providers]]` 段按 provider 覆盖 | `96000` |
+| `request_input_token_budget` | 实际请求输入预算（应用侧估算口径，非模型平台上限）：按「provider 显式覆盖 > 模型窗口推导（窗口−输出预留）> 本缺省」解析，超限时先把纪元窗口缩到热水位重建请求重试一次，仍超限才拒绝发起；可在 `[[providers]]` 段按 provider 覆盖 | `96000` |
 | `agent_record_retention_days` | 已关闭对话轮（Loop）保留天数，按关闭时间计 | `30` |
 | `agent_record_max_loops_per_scope` | 每会话已关闭 Loop 数量上限，先触顶者触发清理最旧完整 Loop | `1000` |
 | `agent_record_max_bytes_per_scope` | 每会话 Loop 业务记录字节上限（UTF-8 计量） | `67108864` |
-| `agent_replay_loop_tokens` | 单个历史 Loop 的重放投影预算（token 估算，512-65536）；超限按固定阶梯确定性精简 | `4096` |
+| `agent_replay_loop_tokens` | 历史 Loop 重放投影预算的推导下限（token 估算，512-4194304）：实际预算按「请求输入预算 − 纪元可见窗上限 − system/工具预留 − 当前 Loop 比例预留」推导（配置了模型容量的 provider 自动放大到窗口量级），超限按固定阶梯确定性精简（先剥原生 thinking，再丢原生副本，再收工具结果）；可在 `[[providers]]` 段按 provider 硬覆盖 | `4096` |
 | `agent_delivery_enabled` | 逐 Turn 交付开关：开启后每次模型响应的普通正文先于工具执行分段外发；关闭时仅最终正文单发，记录不受影响 | `false` |
 | `reply_split_threshold_chars` | 回复超过该长度（Unicode code point）才进行自然分段 | `800` |
 | `reply_chunk_max_chars` | 单段源文本上限，独立于 OneBot 协议报文长度 | `1200` |
@@ -243,6 +243,8 @@ GHCR 分发镜像和 `prod.example/Dockerfile` 均基于 Playwright Python 镜�
 | `builtin_search` | 声明 provider 原生搜索工具（仅 `gemini` 协议生效）：请求携带 `google_search` 服务端检索声明，回复末尾自动附上 grounding 来源；开启后该 provider 的会话移除 `search_web` 工具，提示词引导同步切换。其他协议下该键不生效（配置加载时记录 warning）。检索在 provider 侧执行并计费，本地轮次上限与 token 看板不覆盖 grounding 调用本身。注意：`google_search` 与 function calling 在同一请求中组合仅 Gemini 3 系列模型支持；2.x 模型需关闭该 provider 的 `builtin_search` 或全局 `tool_calling_enabled`，否则聊天请求会被 API 拒绝 | `false` |
 
 > **会话纪元覆盖**：`[runtime]` 的 6 个 `epoch_*` 键可在本表同名覆盖（如 `epoch_cold_idle_seconds = 21600` 放宽 DeepSeek 的冷场判定），未覆盖的键继承全局缺省；详见 `[runtime]` 段说明。
+
+> **预算与模型容量覆盖**：`request_input_token_budget`（显式请求输入预算，优先于窗口推导）与 `agent_replay_loop_tokens`（重放投影预算硬覆盖，优先于推导）可按 provider 覆盖。`model_context_windows` 以 inline table 声明 wire 模型名 → 上下文窗口 token 数（如 `{ "claude-sonnet-4-6" = 200000 }`）；未显式配置的模型按内置策展表按家族前缀解析（claude 200k、gemini-2.5/3 1M、gpt-5 400k 等），均未命中按 capacity unknown 处理（只保证应用侧估算预算）。中继自定义模型名建议显式配置。
 
 > **协议适配说明**：`claude` 协议的请求默认带上完整的 Claude Code 客户端指纹头（`anthropic-version`、`anthropic-beta`、`x-app: cli`、全套 `x-stainless-*` 运行时遥测头、`anthropic-dangerous-direct-browser-access` 等），User-Agent 与 URL（`/messages?beta=true`）均对齐真实 claude-cli 客户端。`x-stainless-os` 按宿主 OS 动态探测。所有指纹头均可通过 `headers` 配置大小写无关地覆盖，`user_agent` 配置项优先级最高。
 

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -134,7 +134,7 @@ GHCR 分发镜像和 `prod.example/Dockerfile` 均基于 Playwright Python 镜�
 | `epoch_cap_tokens` | 窗口硬上限：超过即触发触顶重置（H_hot / cap） | `64000` |
 | `recent_context_token_budget` | 【现场】补丁每轮 token 预算：近期消息缓冲服役给 LLM 的上限（从最新往回截） | `800` |
 | `recent_context_floor_seconds` | 【现场】滑动保底窗秒数：窗内消息即使已服役过也会重附（增量语义之外的保底） | `300` |
-| `request_input_token_budget` | 实际请求输入预算（应用侧估算口径，非模型平台上限）：按「provider 显式覆盖 > 模型窗口推导（窗口−输出预留）> 本缺省」解析，超限时先把纪元窗口缩到热水位重建请求重试一次，仍超限才拒绝发起；可在 `[[providers]]` 段按 provider 覆盖 | `96000` |
+| `request_input_token_budget` | 实际请求输入预算（应用侧估算口径，非模型平台上限）：按「provider 显式覆盖 > 模型窗口推导（窗口−输出预留）> 本缺省」解析，超限时主链先把纪元窗口缩到热水位重建请求重试一次，仍超限才拒绝发起；工具调用循环内的逐轮门禁超限立即中止该循环（无降级重试）；可在 `[[providers]]` 段按 provider 覆盖（非正数视为未配置） | `96000` |
 | `agent_record_retention_days` | 已关闭对话轮（Loop）保留天数，按关闭时间计 | `30` |
 | `agent_record_max_loops_per_scope` | 每会话已关闭 Loop 数量上限，先触顶者触发清理最旧完整 Loop | `1000` |
 | `agent_record_max_bytes_per_scope` | 每会话 Loop 业务记录字节上限（UTF-8 计量） | `67108864` |
@@ -244,7 +244,7 @@ GHCR 分发镜像和 `prod.example/Dockerfile` 均基于 Playwright Python 镜�
 
 > **会话纪元覆盖**：`[runtime]` 的 6 个 `epoch_*` 键可在本表同名覆盖（如 `epoch_cold_idle_seconds = 21600` 放宽 DeepSeek 的冷场判定），未覆盖的键继承全局缺省；详见 `[runtime]` 段说明。
 
-> **预算与模型容量覆盖**：`request_input_token_budget`（显式请求输入预算，优先于窗口推导）与 `agent_replay_loop_tokens`（重放投影预算硬覆盖，优先于推导）可按 provider 覆盖。`model_context_windows` 以 inline table 声明 wire 模型名 → 上下文窗口 token 数（如 `{ "claude-sonnet-4-6" = 200000 }`）；未显式配置的模型按内置策展表按家族前缀解析（claude 200k、gemini-2.5/3 1M、gpt-5 400k 等），均未命中按 capacity unknown 处理（只保证应用侧估算预算）。中继自定义模型名建议显式配置。
+> **预算与模型容量覆盖**：`request_input_token_budget`（显式请求输入预算，优先于窗口推导）与 `agent_replay_loop_tokens`（重放投影预算硬覆盖，优先于推导）可按 provider 覆盖。`model_context_windows` 以 inline table 声明 wire 模型名 → 上下文窗口 token 数（如 `{ "claude-sonnet-4-6" = 200000 }`）；未显式配置的模型按内置策展表按家族前缀解析（claude 200k、gemini-2.5/3 1M、gpt-5 400k 等），均未命中按 capacity unknown 处理（只保证应用侧估算预算）。中继自定义模型名建议显式配置。**升级提示**：自本版本起，模型名命中内置窗口表的既有部署无需任何配置改动即可获得按窗口推导的更大请求/重放预算（例如 gemini-2.5 系列的重放预算从 4096 量级放大到数十万 token）；希望维持旧收紧行为的部署应显式配置 `agent_replay_loop_tokens` / `request_input_token_budget`。
 
 > **协议适配说明**：`claude` 协议的请求默认带上完整的 Claude Code 客户端指纹头（`anthropic-version`、`anthropic-beta`、`x-app: cli`、全套 `x-stainless-*` 运行时遥测头、`anthropic-dangerous-direct-browser-access` 等），User-Agent 与 URL（`/messages?beta=true`）均对齐真实 claude-cli 客户端。`x-stainless-os` 按宿主 OS 动态探测。所有指纹头均可通过 `headers` 配置大小写无关地覆盖，`user_agent` 配置项优先级最高。
 

--- a/docs/dev/llm-module.md
+++ b/docs/dev/llm-module.md
@@ -201,7 +201,7 @@ LLM 默认只在以下场景触发：
 LLM 自身的问答往返会写入 SQLite，用于多轮延续。自 1.14 起读取窗口由**会话纪元**（session epoch）机制管理，取代旧的「行数滚动窗」：
 
 - 每个键（`群 × provider × model`）维护一个只追加的读取锚点：每次触发读取 `id >= 锚点` 的全部历史，窗口随对话增长、不逐轮位移——这是自动前缀缓存跨轮命中的结构性前提
-- 锚点只在两种时机前移：**冷场**（距该键上次 LLM 请求超过 T 秒且窗口超过 H_cold，缩回 L_cold）或**触顶**（窗口超过 cap，缩回 L_hot）；默认 T=300s、L_cold=4k、H_cold=5k、L_hot=32k、cap=64k（token 估算），全部可在 `llm.toml` 的 `[runtime]` / `[[providers]]` 用 `epoch_*` 键调整（见 `docs/admin/configuration.md`）
+- 锚点只在三种时机前移：**冷场**（距该键上次 LLM 请求超过 T 秒且窗口超过 H_cold，缩回 L_cold）、**触顶**（窗口超过 cap，缩回 L_hot）或**容量降级**（请求预算超限时由服务层调用 `force_advance_to_hot` 缩回 L_hot 并重建请求重试一次，付费 miss 换优雅降级）；默认 T=300s、L_cold=4k、H_cold=5k、L_hot=32k、cap=64k（token 估算），全部可在 `llm.toml` 的 `[runtime]` / `[[providers]]` 用 `epoch_*` 键调整（见 `docs/admin/configuration.md`）
 - 窗口单位是 token 估算（`token_estimate.py`），不再是行数；另有 1024 行的行数硬兜底（防海量超短行撑爆 provider 的 messages 数组）
 - 锚点只落在 user/assistant 对边界，且保留最少 4 行（防单条超长转发把窗口吃空）
 - 存储裁剪以该群所有纪元键的最老锚点为准；锚点缺失（进程重启后）时只按 2048 行硬上限兜底（`MAX_STORED_CONVERSATION_MESSAGES`，群聊/私聊同值），不按窗口重估删行

--- a/src/quickquip/adapters/nonebot/_llm_reply.py
+++ b/src/quickquip/adapters/nonebot/_llm_reply.py
@@ -99,11 +99,14 @@ class OneBotDeliverySink:
             if "timeout" in lowered or "timed out" in lowered:
                 return DeliveryReceipt(status=DeliveryStatus.UNKNOWN, error_code=type(exc).__name__)
             return DeliveryReceipt(status=DeliveryStatus.FAILED, error_code=type(exc).__name__)
-        self.sent_texts.append(text)
         message_id = ""
         if isinstance(resp, dict):
             message_id = str(resp.get("message_id", "") or "").strip()
         if message_id:
+            # Only a trusted message id confirms a visible delivery.  An
+            # otherwise successful transport response without one is unknown
+            # and must not feed cooldowns, previews, or delivery statistics.
+            self.sent_texts.append(text)
             return DeliveryReceipt(status=DeliveryStatus.SENT, message_id=message_id)
         return DeliveryReceipt(status=DeliveryStatus.UNKNOWN, error_code="missing_message_id")
 

--- a/src/quickquip/llm/config.py
+++ b/src/quickquip/llm/config.py
@@ -85,7 +85,9 @@ class RuntimeConfig:
     # 逐 Turn 交付上线开关（§6.3）：默认关闭——安装新版本不立刻增加群内
     # 消息数；记录与投影始终工作。
     agent_delivery_enabled: bool = False
-    # 每个历史 Loop 的投影预算（§2：512..65536；可被更小的显式上下文预算收紧）。
+    # 历史重放投影预算（§8.2）：推导下限（512..4MiB）。实际预算由
+    # request_budget.derive_replay_budget 从请求输入预算（仲裁者）推导；
+    # provider 覆盖键为硬值，capacity unknown 时本值即实际值。
     agent_replay_loop_tokens: int = 4096
     reply_split_threshold_chars: int = 800
     reply_chunk_max_chars: int = 1200
@@ -203,8 +205,11 @@ class ProviderConfig:
     epoch_cap_tokens: int | None = None
     # 应用侧输入预算（§8.3）：provider 覆盖 None = 继承 runtime 缺省。
     request_input_token_budget: int | None = None
-    # wire model -> token 容量；只能来自维护者配置或可信已核实资料，
-    # 不从模型名称猜测。未配置的模型按 capacity unknown 处理。
+    # 历史重放投影预算的 provider 级硬覆盖（§8.2）；None = 推导
+    # （仲裁者减固定开销，runtime.agent_replay_loop_tokens 为下限）。
+    agent_replay_loop_tokens: int | None = None
+    # wire model -> token 容量；显式配置永远优先，未命中时按
+    # context_windows 内置策展表解析，均未命中按 capacity unknown 处理。
     model_context_windows: dict[str, int] = field(default_factory=dict)
 
 
@@ -561,6 +566,9 @@ def _parse_single_provider(
         epoch_hot_target_tokens=_as_optional_int(entry.get("epoch_hot_target_tokens")),
         epoch_cap_tokens=_as_optional_int(entry.get("epoch_cap_tokens")),
         request_input_token_budget=_as_optional_int(entry.get("request_input_token_budget")),
+        agent_replay_loop_tokens=_clamped_optional_int(
+            entry.get("agent_replay_loop_tokens"), floor=512, ceiling=4_194_304
+        ),
         model_context_windows={
             str(name): max(1024, int(size))
             for name, size in as_dict(entry.get("model_context_windows")).items()
@@ -586,6 +594,21 @@ def _as_optional_int(raw: Any) -> int | None:
     except ValueError:
         logger.warning("epoch_* 覆盖值 %r 无法解析为整数，回退继承 [runtime]", raw)
         return None
+
+
+def _clamped_optional_int(
+    raw: Any, *, floor: int, ceiling: int
+) -> int | None:
+    """provider 级可选整数键 + 范围钳制：缺省/越界告警并回退 None。"""
+    value = _as_optional_int(raw)
+    if value is None:
+        return None
+    clamped = min(ceiling, max(floor, value))
+    if clamped != value:
+        logger.warning(
+            "provider 覆盖值 %d 超出 [%d, %d]，已钳制为 %d", value, floor, ceiling, clamped
+        )
+    return clamped
 
 
 _MCP_NEGOTIATION_MODES = {"legacy", "auto", "modern"}
@@ -836,7 +859,7 @@ def load_llm_config(path: str | Path) -> LLMConfig:
                 runtime_raw.get("agent_delivery_enabled"), default=False
             ),
             agent_replay_loop_tokens=min(
-                65_536, max(512, int(runtime_raw.get("agent_replay_loop_tokens", 4096)))
+                4_194_304, max(512, int(runtime_raw.get("agent_replay_loop_tokens", 4096)))
             ),
             reply_split_threshold_chars=max(
                 1, int(runtime_raw.get("reply_split_threshold_chars", 800))

--- a/src/quickquip/llm/config.py
+++ b/src/quickquip/llm/config.py
@@ -19,6 +19,11 @@ DEFAULT_RETRY_MAX_ATTEMPTS = 3
 DEFAULT_RETRY_BASE_DELAY = 1.0
 DEFAULT_RETRY_JITTER = 0.5
 
+# agent_replay_loop_tokens 的解析钳制界（runtime 与 provider 覆盖共用；
+# request_budget 的推导下限/上限同源引用）。
+AGENT_REPLAY_LOOP_TOKENS_FLOOR = 512
+AGENT_REPLAY_LOOP_TOKENS_CEILING = 4_194_304
+
 
 @dataclass(slots=True)
 class TriggerConfig:
@@ -74,9 +79,9 @@ class RuntimeConfig:
     # ── 【现场】补丁（近期消息缓冲的 LLM 服役口径；仅全局，无 provider 覆盖） ──
     recent_context_token_budget: int = 800
     recent_context_floor_seconds: int = 300
-    # 应用侧输入预算（§8.3）：所有 provider 的缺省，可被 provider 覆盖。
-    # 不能从 epoch cap 推导实际模型上下文大小；未配置模型容量时文档与
-    # 日志按 capacity unknown 处理。
+    # 应用侧输入预算（§8.3）：显式与内置窗口表均未解析到模型容量
+    # （capacity unknown）时的缺省与兜底；可被 provider 覆盖（非正数视为
+    # 未配置），容量已知时按窗口推导优先。
     request_input_token_budget: int = 96_000
     # D5 关闭 Loop 保留三上限（§2）：先触顶者触发整 Loop 清理。
     agent_record_retention_days: int = 30
@@ -565,9 +570,13 @@ def _parse_single_provider(
         epoch_cold_trigger_tokens=_as_optional_int(entry.get("epoch_cold_trigger_tokens")),
         epoch_hot_target_tokens=_as_optional_int(entry.get("epoch_hot_target_tokens")),
         epoch_cap_tokens=_as_optional_int(entry.get("epoch_cap_tokens")),
-        request_input_token_budget=_as_optional_int(entry.get("request_input_token_budget")),
+        request_input_token_budget=_nonpositive_as_none(
+            entry.get("request_input_token_budget")
+        ),
         agent_replay_loop_tokens=_clamped_optional_int(
-            entry.get("agent_replay_loop_tokens"), floor=512, ceiling=4_194_304
+            entry.get("agent_replay_loop_tokens"),
+            floor=AGENT_REPLAY_LOOP_TOKENS_FLOOR,
+            ceiling=AGENT_REPLAY_LOOP_TOKENS_CEILING,
         ),
         model_context_windows={
             str(name): max(1024, int(size))
@@ -599,7 +608,7 @@ def _as_optional_int(raw: Any) -> int | None:
 def _clamped_optional_int(
     raw: Any, *, floor: int, ceiling: int
 ) -> int | None:
-    """provider 级可选整数键 + 范围钳制：缺省/越界告警并回退 None。"""
+    """provider 级可选整数键 + 范围钳制：缺省/不可解析回退 None，越界钳制到边界并告警。"""
     value = _as_optional_int(raw)
     if value is None:
         return None
@@ -609,6 +618,15 @@ def _clamped_optional_int(
             "provider 覆盖值 %d 超出 [%d, %d]，已钳制为 %d", value, floor, ceiling, clamped
         )
     return clamped
+
+
+def _nonpositive_as_none(raw: Any) -> int | None:
+    """非正数视为未配置（继承推导/缺省）：0/负值不是合法预算，告警不致命。"""
+    value = _as_optional_int(raw)
+    if value is not None and value <= 0:
+        logger.warning("provider 覆盖值 %d 非正数，按未配置处理（继承推导/缺省）", value)
+        return None
+    return value
 
 
 _MCP_NEGOTIATION_MODES = {"legacy", "auto", "modern"}
@@ -859,7 +877,11 @@ def load_llm_config(path: str | Path) -> LLMConfig:
                 runtime_raw.get("agent_delivery_enabled"), default=False
             ),
             agent_replay_loop_tokens=min(
-                4_194_304, max(512, int(runtime_raw.get("agent_replay_loop_tokens", 4096)))
+                AGENT_REPLAY_LOOP_TOKENS_CEILING,
+                max(
+                    AGENT_REPLAY_LOOP_TOKENS_FLOOR,
+                    int(runtime_raw.get("agent_replay_loop_tokens", 4096)),
+                ),
             ),
             reply_split_threshold_chars=max(
                 1, int(runtime_raw.get("reply_split_threshold_chars", 800))

--- a/src/quickquip/llm/context_windows.py
+++ b/src/quickquip/llm/context_windows.py
@@ -8,7 +8,10 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-# 前缀规则（小写匹配，长前缀优先）。
+# 前缀规则（小写匹配，长前缀优先）。存疑条目取低值并注明依据：
+# qwen3 原生 checkpoint 32k（YaRN 上限 131k），2507 刷新版原生 256k；
+# GLM-4.5/4.5-Air 为 128K（200K 属 4.6）；Kimi K2 基座 128K（256K 仅
+# k2-thinking）。中继/长窗部署请显式配置 model_context_windows 纠正。
 _BUILTIN_PREFIX_RULES: tuple[tuple[str, int], ...] = (
     ("claude-", 200_000),
     ("gemini-3", 1_000_000),
@@ -23,10 +26,13 @@ _BUILTIN_PREFIX_RULES: tuple[tuple[str, int], ...] = (
     ("o3", 200_000),
     ("o4", 200_000),
     ("deepseek", 128_000),
-    ("qwen3", 262_144),
+    ("qwen3-2507", 262_144),
+    ("qwen3", 32_768),
     ("qwen2.5", 131_072),
-    ("kimi", 256_000),
-    ("glm-4.5", 200_000),
+    ("kimi-k2-thinking", 256_000),
+    ("kimi", 128_000),
+    ("glm-4.6", 200_000),
+    ("glm-4.5", 128_000),
     ("glm-4", 128_000),
     ("grok-4", 256_000),
     ("grok-3", 131_072),

--- a/src/quickquip/llm/context_windows.py
+++ b/src/quickquip/llm/context_windows.py
@@ -40,6 +40,7 @@ _BUILTIN_PREFIX_RULES: tuple[tuple[str, int], ...] = (
     ("mistral-large", 128_000),
 )
 
+# 由 _BUILTIN_PREFIX_RULES 按前缀长度倒序派生的解析顺序（派生数据，非独立源）。
 _PREFIX_ORDER = sorted(_BUILTIN_PREFIX_RULES, key=lambda rule: -len(rule[0]))
 
 

--- a/src/quickquip/llm/context_windows.py
+++ b/src/quickquip/llm/context_windows.py
@@ -1,0 +1,58 @@
+"""模型上下文窗口解析：provider 显式配置 > 内置策展表 > capacity unknown。
+
+内置表按模型家族前缀保守策展（存疑条目取低值：低估收紧预算属安全侧，
+高估可能放行超限 payload）。中继自定义模型名、表外模型一律 unknown，
+由维护者显式配置 ``model_context_windows`` 补齐；显式键永远优先。
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+# 前缀规则（小写匹配，长前缀优先）。
+_BUILTIN_PREFIX_RULES: tuple[tuple[str, int], ...] = (
+    ("claude-", 200_000),
+    ("gemini-3", 1_000_000),
+    ("gemini-2.5", 1_000_000),
+    ("gemini-2.0", 1_000_000),
+    ("gemini-1.5-pro", 2_000_000),
+    ("gemini-1.5", 1_000_000),
+    ("gpt-5", 400_000),
+    ("gpt-4.1", 1_000_000),
+    ("gpt-4o", 128_000),
+    ("gpt-4-turbo", 128_000),
+    ("o3", 200_000),
+    ("o4", 200_000),
+    ("deepseek", 128_000),
+    ("qwen3", 262_144),
+    ("qwen2.5", 131_072),
+    ("kimi", 256_000),
+    ("glm-4.5", 200_000),
+    ("glm-4", 128_000),
+    ("grok-4", 256_000),
+    ("grok-3", 131_072),
+    ("minimax-m2", 204_800),
+    ("mistral-large", 128_000),
+)
+
+_PREFIX_ORDER = sorted(_BUILTIN_PREFIX_RULES, key=lambda rule: -len(rule[0]))
+
+
+def lookup_builtin_context_window(model: str) -> int | None:
+    """按家族前缀查内置窗口；无匹配返回 None（capacity unknown）。"""
+    name = model.strip().lower()
+    if not name:
+        return None
+    for prefix, window in _PREFIX_ORDER:
+        if name.startswith(prefix):
+            return window
+    return None
+
+
+def resolve_context_window(
+    explicit_windows: Mapping[str, int], model: str
+) -> int | None:
+    """窗口解析的单一入口：显式配置精确匹配 > 内置前缀 > None。"""
+    explicit = explicit_windows.get(model)
+    if explicit is not None and int(explicit) > 0:
+        return int(explicit)
+    return lookup_builtin_context_window(model)

--- a/src/quickquip/llm/epoch.py
+++ b/src/quickquip/llm/epoch.py
@@ -203,21 +203,27 @@ class EpochManager:
     ) -> EpochResetEvent | None:
         """容量 reset 路径（§8.3）：请求预算超限时的付费降级。
 
-        不看 idle 与 cap 触发条件，直接把锚点缩到热水位（L_hot）；无状态
-        （本进程未见过该键）或已无更小锚点时返回 None，由调用方走终止路径。
+        不看 idle 与 cap 触发条件，直接把锚点缩到热水位（L_hot）；与
+        ``maybe_advance`` 同款行数兜底先行（窗口行数超限时先按行数推进，
+        绝不让范围读截掉最新端）。无状态（本进程未见过该键）或已无更小
+        锚点时返回 None，由调用方走终止路径；仅行数兜底推进时返回该事件。
         """
         state = self._states.get(key)
         if state is None:
             return None
+        event: EpochResetEvent | None = None
+        row_anchor = store.find_anchor_row_id_by_rows(key.scope_key, DEFAULT_EPOCH_MAX_ROWS)
+        if row_anchor is not None and row_anchor > state.anchor_id:
+            event = self._advance(state, store, key, row_anchor, reason="rows")
         rows = store.list_conversation_messages_since(
             key.scope_key, state.anchor_id, limit=DEFAULT_EPOCH_MAX_ROWS
         )
         candidate = self._pick_anchor_by_tokens(rows, params.hot_target_tokens)
-        if candidate <= state.anchor_id:
-            return None
-        return self._advance(
-            state, store, key, candidate, reason="hot", epoch_tokens=estimate_rows_budget(rows)
-        )
+        if candidate > state.anchor_id:
+            return self._advance(
+                state, store, key, candidate, reason="hot", epoch_tokens=estimate_rows_budget(rows)
+            )
+        return event
 
     # ── 内部 ─────────────────────────────────────────────────────
 

--- a/src/quickquip/llm/epoch.py
+++ b/src/quickquip/llm/epoch.py
@@ -194,6 +194,31 @@ class EpochManager:
         state.last_activity_at = self._clock()
         return event
 
+    def force_advance_to_hot(
+        self,
+        key: EpochKey,
+        *,
+        store: LLMStore,
+        params: EpochParams,
+    ) -> EpochResetEvent | None:
+        """容量 reset 路径（§8.3）：请求预算超限时的付费降级。
+
+        不看 idle 与 cap 触发条件，直接把锚点缩到热水位（L_hot）；无状态
+        （本进程未见过该键）或已无更小锚点时返回 None，由调用方走终止路径。
+        """
+        state = self._states.get(key)
+        if state is None:
+            return None
+        rows = store.list_conversation_messages_since(
+            key.scope_key, state.anchor_id, limit=DEFAULT_EPOCH_MAX_ROWS
+        )
+        candidate = self._pick_anchor_by_tokens(rows, params.hot_target_tokens)
+        if candidate <= state.anchor_id:
+            return None
+        return self._advance(
+            state, store, key, candidate, reason="hot", epoch_tokens=estimate_rows_budget(rows)
+        )
+
     # ── 内部 ─────────────────────────────────────────────────────
 
     def _lazy_init(self, key: EpochKey, store: LLMStore, params: EpochParams) -> EpochState:

--- a/src/quickquip/llm/history_projection.py
+++ b/src/quickquip/llm/history_projection.py
@@ -368,13 +368,18 @@ _RESULT_TIERS = (4096, 1024, 256, 0)
 
 
 def _estimate_messages_tokens(messages: list[LLMConversationMessage]) -> int:
-    from quickquip.llm.token_estimate import estimate_tokens
+    from quickquip.llm.token_estimate import (
+        estimate_native_blocks_tokens,
+        estimate_tokens,
+    )
 
     total = 0
     for message in messages:
         total += estimate_tokens(message.content)
         for call in message.tool_calls:
             total += estimate_tokens(call.arguments_json)
+        total += estimate_native_blocks_tokens(message.thinking_blocks)
+        total += estimate_native_blocks_tokens(message.native_content)
     return total
 
 
@@ -453,6 +458,46 @@ def _project_loop_minimal(loop: LoadedLoop) -> list[LLMConversationMessage]:
     ]
 
 
+def _strip_native_thinking(
+    messages: list[LLMConversationMessage], protocol: str
+) -> list[LLMConversationMessage]:
+    """阶梯首档：原生块剥 thinking/thought 部分，保 tool_use/functionCall 配对。
+
+    签名回传要求只约束活跃工具循环内的最近 assistant 轮；已关闭 Loop 的
+    历史轮剥 thinking 属协议合法的保真降级。块剥空（纯 thinking 轮）退
+    通用正文表达，该轮无工具声明，配对不受影响。
+    """
+    stripped: list[LLMConversationMessage] = []
+    changed = False
+    for message in messages:
+        blocks = message.native_content
+        if blocks is None:
+            stripped.append(message)
+            continue
+        if protocol == "claude":
+            kept = [
+                block for block in blocks
+                if block.get("type") not in {"thinking", "redacted_thinking"}
+            ]
+        else:
+            kept = [block for block in blocks if not block.get("thought")]
+        if len(kept) == len(blocks):
+            stripped.append(message)
+            continue
+        changed = True
+        if kept:
+            stripped.append(
+                LLMConversationMessage(
+                    role=message.role, content=message.content, native_content=kept
+                )
+            )
+        else:
+            stripped.append(
+                LLMConversationMessage(role=message.role, content=message.content)
+            )
+    return stripped if changed else messages
+
+
 def project_loops_with_budget(
     loops: Sequence[LoadedLoop],
     *,
@@ -462,9 +507,10 @@ def project_loops_with_budget(
 ) -> ProjectionResult:
     """带 §8.2 精简阶梯的投影：超预算时按固定顺序精简最旧 Loop。
 
-    阶梯：工具结果按 4096/1024/256/0 收紧 → 纯文本档案 → 档案字符额度
-    减半 → 最小档案 → 逐出最旧完整 Loop。所有精简只影响模型投影，完整
-    记录留在执行表；禁止空循环重试。
+    阶梯：原生块剥 thinking → 丢弃可选 native（通用/档案形态）→ 工具结果
+    按 4096/1024/256/0 收紧 → 纯文本档案 → 档案字符额度减半 → 最小档案 →
+    逐出最旧完整 Loop。所有精简只影响模型投影，完整记录留在执行表；
+    禁止空循环重试。
     """
     result = project_loops(loops, target=target, protocol=protocol)
     if _estimate_messages_tokens(result.messages) <= budget_tokens or not loops:
@@ -494,6 +540,14 @@ def project_loops_with_budget(
         if _total() <= budget_tokens:
             break
         loop = loops_by_id[loop_id]
+        # 阶梯 0：原生块剥 thinking（保结构/配对），仍超限才整档丢弃。
+        if decisions[loop_id].path == PATH_NATIVE:
+            stripped = _strip_native_thinking(segments[loop_id], protocol)
+            if stripped is not segments[loop_id]:
+                segments[loop_id] = stripped
+                _mark(loop_id, "native_thinking_stripped")
+                if _total() <= budget_tokens:
+                    continue
         # 阶梯 1：丢弃可选 native（重投影为无 target 的通用/档案形态）。
         if decisions[loop_id].path == PATH_NATIVE:
             demoted = project_loops([loop], target=None, protocol=protocol)

--- a/src/quickquip/llm/history_projection.py
+++ b/src/quickquip/llm/history_projection.py
@@ -37,6 +37,8 @@ PATH_ARCHIVE = "archive"
 
 _ARCHIVE_TAG = "[历史档案]"
 _ORPHAN_TRIGGER_NOTE = "[系统说明] 该段历史的原始触发消息未保留。"
+# 剥空轮（纯 thinking、零正文零工具）的占位正文：空 text 块会被 Claude 拒 400。
+_STRIPPED_TURN_PLACEHOLDER = "…[历史推理内容已按预算精简]…"
 
 
 class HistoryProjectionError(RuntimeError):
@@ -375,9 +377,12 @@ def _estimate_messages_tokens(messages: list[LLMConversationMessage]) -> int:
 
     total = 0
     for message in messages:
-        total += estimate_tokens(message.content)
-        for call in message.tool_calls:
-            total += estimate_tokens(call.arguments_json)
+        # 原生路径消息的正文/工具声明已内含于 native 块（serializer 原样
+        # 发送、忽略通用字段），单计 content 会双倍计量同一 wire 内容。
+        if message.native_content is None:
+            total += estimate_tokens(message.content)
+            for call in message.tool_calls:
+                total += estimate_tokens(call.arguments_json)
         total += estimate_native_blocks_tokens(message.thinking_blocks)
         total += estimate_native_blocks_tokens(message.native_content)
     return total
@@ -465,7 +470,8 @@ def _strip_native_thinking(
 
     签名回传要求只约束活跃工具循环内的最近 assistant 轮；已关闭 Loop 的
     历史轮剥 thinking 属协议合法的保真降级。块剥空（纯 thinking 轮）退
-    通用正文表达，该轮无工具声明，配对不受影响。
+    通用正文表达并补占位（空 text 块会被 Claude 拒 400），该轮无工具
+    声明，配对不受影响。
     """
     stripped: list[LLMConversationMessage] = []
     changed = False
@@ -493,7 +499,10 @@ def _strip_native_thinking(
             )
         else:
             stripped.append(
-                LLMConversationMessage(role=message.role, content=message.content)
+                LLMConversationMessage(
+                    role=message.role,
+                    content=message.content or _STRIPPED_TURN_PLACEHOLDER,
+                )
             )
     return stripped if changed else messages
 

--- a/src/quickquip/llm/request_budget.py
+++ b/src/quickquip/llm/request_budget.py
@@ -16,7 +16,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from quickquip.llm.config import LLMConfig, ProviderConfig
+from quickquip.llm.config import (
+    AGENT_REPLAY_LOOP_TOKENS_CEILING,
+    AGENT_REPLAY_LOOP_TOKENS_FLOOR,
+    LLMConfig,
+    ProviderConfig,
+)
 from quickquip.llm.context_windows import resolve_context_window
 from quickquip.llm.provider import LLMRequest
 from quickquip.llm.token_estimate import (
@@ -37,8 +42,9 @@ _MIN_INPUT_BUDGET_TOKENS = 4096
 _SYSTEM_TOOLS_ALLOWANCE_TOKENS = 16_000
 # 重放推导中当前进行中 Loop（thinking/正文/工具结果）的比例预留。
 _LOOP_HEADROOM_FRACTION = 0.15
-# 重放预算绝对下界（与配置钳制下界一致）。
-_MIN_REPLAY_BUDGET_TOKENS = 512
+# 重放预算绝对下界（与 config 的钳制界单源）。
+_MIN_REPLAY_BUDGET_TOKENS = AGENT_REPLAY_LOOP_TOKENS_FLOOR
+_MAX_REPLAY_BUDGET_TOKENS = AGENT_REPLAY_LOOP_TOKENS_CEILING
 
 
 class RequestBudgetExceeded(RuntimeError):
@@ -98,7 +104,11 @@ def derive_replay_budget(
     capacity unknown 时即实际值）。
     """
     if provider.agent_replay_loop_tokens is not None:
-        return provider.agent_replay_loop_tokens
+        # 解析期已钳制；直连构造的配置对象在此兜底同界。
+        return min(
+            _MAX_REPLAY_BUDGET_TOKENS,
+            max(_MIN_REPLAY_BUDGET_TOKENS, provider.agent_replay_loop_tokens),
+        )
     arbiter = resolve_input_budget(
         config, provider, model, max_output_tokens=max_output_tokens
     )
@@ -123,11 +133,15 @@ def estimate_request_tokens(request: LLMRequest) -> int:
         total += estimate_tokens(spec.name) + estimate_tokens(spec.description)
         total += estimate_tokens(str(spec.input_schema))
     for message in request.messages:
-        total += estimate_tokens(message.content)
-        for call in message.tool_calls:
-            total += estimate_tokens(call.arguments_json)
-        total += estimate_native_blocks_tokens(message.thinking_blocks)
-        total += estimate_native_blocks_tokens(message.native_content)
+        # 原生路径消息的正文/工具声明已内含于 native 块（serializer 原样
+        # 发送、忽略通用字段），单计通用字段会双倍计量同一 wire 内容。
+        if message.native_content is not None:
+            total += estimate_native_blocks_tokens(message.native_content)
+        else:
+            total += estimate_tokens(message.content)
+            for call in message.tool_calls:
+                total += estimate_tokens(call.arguments_json)
+            total += estimate_native_blocks_tokens(message.thinking_blocks)
         # 媒体按已知协议成本粗估：每图固定档位（保守）。
         total += NATIVE_MEDIA_FLAT_TOKENS * len(message.image_urls)
     return total

--- a/src/quickquip/llm/request_budget.py
+++ b/src/quickquip/llm/request_budget.py
@@ -5,21 +5,40 @@
 成本估算。预算不足的处置（容量 reset / 终止）由调用方按契约执行，本
 模块只做检查与分类。
 
-``capacity unknown``：未配置模型容量时只保证应用估算预算，不得宣称
-不会触发上游 context-limit。
+预算解析优先级：provider 显式 ``request_input_token_budget`` > 模型窗口
+推导（窗口 − 输出预留）> ``runtime.request_input_token_budget`` 缺省。
+重放投影预算由 ``derive_replay_budget`` 从同一仲裁者推导。
+
+``capacity unknown``：未解析到模型容量（显式配置与内置策展表均未命中）
+时只保证应用估算预算，不得宣称不会触发上游 context-limit。
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
 
 from quickquip.llm.config import LLMConfig, ProviderConfig
+from quickquip.llm.context_windows import resolve_context_window
 from quickquip.llm.provider import LLMRequest
-from quickquip.llm.token_estimate import estimate_tokens
+from quickquip.llm.token_estimate import (
+    NATIVE_MEDIA_FLAT_TOKENS,
+    estimate_native_blocks_tokens,
+    estimate_tokens,
+)
 
-# 预留估算余量（§8.3：至少 1,024 token）。
+# 预留估算余量下界（§8.3：至少 1,024 token）。
 _RESERVE_TOKENS = 1024
+# 估算误差随 payload 放大：按估算值比例追加余量。
+_ESTIMATE_MARGIN_RATIO = 0.10
 # wire 消息/part 数的应用兜底（不替代供应商真实限制）。
 MAX_WIRE_ITEMS = 1024
+# 窗口推导输入预算的下界（防极小窗口 + 大输出预留产生无意义预算）。
+_MIN_INPUT_BUDGET_TOKENS = 4096
+# 重放推导中 system/工具 schema 的固定开销预留（token 估算）。
+_SYSTEM_TOOLS_ALLOWANCE_TOKENS = 16_000
+# 重放推导中当前进行中 Loop（thinking/正文/工具结果）的比例预留。
+_LOOP_HEADROOM_FRACTION = 0.15
+# 重放预算绝对下界（与配置钳制下界一致）。
+_MIN_REPLAY_BUDGET_TOKENS = 512
 
 
 class RequestBudgetExceeded(RuntimeError):
@@ -48,6 +67,55 @@ class RequestBudgetCheck:
         return within_budget and within_window and self.wire_items <= MAX_WIRE_ITEMS
 
 
+def resolve_input_budget(
+    config: LLMConfig,
+    provider: ProviderConfig,
+    model: str,
+    *,
+    max_output_tokens: int | None = None,
+) -> int:
+    """请求输入预算（仲裁者）解析：显式覆盖 > 窗口推导 > runtime 缺省。"""
+    if provider.request_input_token_budget is not None:
+        return provider.request_input_token_budget
+    window = resolve_context_window(provider.model_context_windows, model)
+    if window is not None:
+        output_reserve = (max_output_tokens or provider.max_output_tokens) + _RESERVE_TOKENS
+        return max(_MIN_INPUT_BUDGET_TOKENS, window - output_reserve)
+    return config.runtime.request_input_token_budget
+
+
+def derive_replay_budget(
+    config: LLMConfig,
+    provider: ProviderConfig,
+    model: str,
+    *,
+    max_output_tokens: int | None = None,
+) -> int:
+    """重放投影预算推导：provider 覆盖 > 仲裁者减固定开销（runtime 值为下限）。
+
+    仲裁者减去纪元可见窗上限、system/工具预留与当前 Loop 比例预留；
+    ``runtime.agent_replay_loop_tokens`` 作为推导下限保留（调高即放宽，
+    capacity unknown 时即实际值）。
+    """
+    if provider.agent_replay_loop_tokens is not None:
+        return provider.agent_replay_loop_tokens
+    arbiter = resolve_input_budget(
+        config, provider, model, max_output_tokens=max_output_tokens
+    )
+    epoch_cap = config.resolve_epoch_params(provider).cap_tokens
+    derived = (
+        arbiter
+        - epoch_cap
+        - _SYSTEM_TOOLS_ALLOWANCE_TOKENS
+        - int(arbiter * _LOOP_HEADROOM_FRACTION)
+    )
+    return max(
+        _MIN_REPLAY_BUDGET_TOKENS,
+        config.runtime.agent_replay_loop_tokens,
+        derived,
+    )
+
+
 def estimate_request_tokens(request: LLMRequest) -> int:
     """最终实际 payload 的输入估算：system/tools/messages 全量计入。"""
     total = estimate_tokens(request.system_prompt)
@@ -58,10 +126,10 @@ def estimate_request_tokens(request: LLMRequest) -> int:
         total += estimate_tokens(message.content)
         for call in message.tool_calls:
             total += estimate_tokens(call.arguments_json)
-        for block in message.thinking_blocks or []:
-            total += estimate_tokens(str(block))
+        total += estimate_native_blocks_tokens(message.thinking_blocks)
+        total += estimate_native_blocks_tokens(message.native_content)
         # 媒体按已知协议成本粗估：每图固定档位（保守）。
-        total += 1200 * len(message.image_urls)
+        total += NATIVE_MEDIA_FLAT_TOKENS * len(message.image_urls)
     return total
 
 
@@ -72,6 +140,8 @@ def count_wire_items(request: LLMRequest) -> int:
         count += 1
         count += len(message.tool_calls)
         count += len(message.image_urls)
+        count += len(message.thinking_blocks or [])
+        count += len(message.native_content or [])
     count += len(request.tools)
     return count
 
@@ -83,12 +153,18 @@ def check_request_budget(
     *,
     max_output_tokens: int | None = None,
 ) -> RequestBudgetCheck:
-    budget_limit = provider.request_input_token_budget or config.runtime.request_input_token_budget
+    budget_limit = resolve_input_budget(
+        config, provider, request.model, max_output_tokens=max_output_tokens
+    )
     wire_model = request.model
-    context_window = provider.model_context_windows.get(wire_model)
+    context_window = resolve_context_window(provider.model_context_windows, wire_model)
     output_reserve = (max_output_tokens or provider.max_output_tokens) + _RESERVE_TOKENS
     estimated = estimate_request_tokens(request)
-    effective_window = None if context_window is None else max(0, context_window - output_reserve)
+    if context_window is None:
+        effective_window = None
+    else:
+        margin = max(_RESERVE_TOKENS, int(estimated * _ESTIMATE_MARGIN_RATIO))
+        effective_window = max(0, context_window - output_reserve - margin)
     return RequestBudgetCheck(
         estimated_input_tokens=estimated,
         budget_limit=budget_limit,

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -39,7 +39,11 @@ from quickquip.llm.config import (
 )
 from quickquip.llm.rendering import append_web_search_source_block
 from quickquip.llm.history_projection import HistoryProjectionError, project_loops_with_budget
-from quickquip.llm.request_budget import RequestBudgetExceeded, enforce_request_budget
+from quickquip.llm.request_budget import (
+    RequestBudgetExceeded,
+    derive_replay_budget,
+    enforce_request_budget,
+)
 from quickquip.llm.agent_records import LoopStatus, TriggerKind
 from quickquip.llm.service_parts.agent_runtime import DeliveryAborted, TurnRecorder
 from quickquip.llm.store_parts.agent_records import AgentStoreError
@@ -1051,7 +1055,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         try:
             result = project_loops_with_budget(
                 loaded, target=target, protocol=provider.protocol,
-                budget_tokens=self.config.runtime.agent_replay_loop_tokens,
+                budget_tokens=derive_replay_budget(self.config, provider, model),
             )
         except HistoryProjectionError:
             # 结构损坏不砖化会话（Deep-CR 兜底）：该请求退回行渲染，损坏
@@ -1288,6 +1292,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             provider_id=provider.id,
             model=settings.model or provider.default_model,
         )
+        epoch_params = self.config.resolve_epoch_params(provider)
         history, participants, scene_patch, projected_segments = self._load_scrubbed_history_and_participants(
             chat_id=chat_id,
             chat_type=chat_type,
@@ -1301,7 +1306,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             quoted_sender_name=quoted_sender_name,
             quoted_user_id=quoted_user_id,
             epoch_key=epoch_key,
-            epoch_params=self.config.resolve_epoch_params(provider),
+            epoch_params=epoch_params,
             provider=provider,
         )
 
@@ -1428,21 +1433,102 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             tool_choice="auto",
             builtin_search=builtin_search_active,
         )
-        try:
-            enforce_request_budget(self.config, provider, request)
-        except RequestBudgetExceeded as exc:
-            logger.warning(
-                "request budget exceeded scope=%s provider=%s model=%s: %s",
-                scope_key, provider.id, request.model, exc,
-            )
-            return {
-                "reply": "这次对话的上下文已经太长，无法安全发起模型请求，请用清空上下文命令重置后再试。",
-                "rate_limit_key": LLM_RULE_NAME,
-                "rule_name": LLM_RULE_NAME,
-                "llm_used": False,
-                "provider_id": provider.id,
-                "model": request.model,
-            }
+        # §8.3 先降级再拒绝：超限时锚点强制缩到热水位（付费 miss 一次），
+        # 重载可见历史与 Loop 投影后重建请求重试一次；仍超限才终止本轮。
+        budget_retry_used = False
+        while True:
+            try:
+                enforce_request_budget(self.config, provider, request)
+                break
+            except RequestBudgetExceeded as exc:
+                logger.warning(
+                    "request budget exceeded scope=%s provider=%s model=%s: %s",
+                    scope_key, provider.id, request.model, exc,
+                )
+                if budget_retry_used:
+                    return {
+                        "reply": "这次对话的上下文已经太长，无法安全发起模型请求，请用清空上下文命令重置后再试。",
+                        "rate_limit_key": LLM_RULE_NAME,
+                        "rule_name": LLM_RULE_NAME,
+                        "llm_used": False,
+                        "provider_id": provider.id,
+                        "model": request.model,
+                    }
+                budget_retry_used = True
+                degraded = self._epochs.force_advance_to_hot(
+                    epoch_key, store=self.store, params=epoch_params
+                )
+                if degraded is None:
+                    return {
+                        "reply": "这次对话的上下文已经太长，无法安全发起模型请求，请用清空上下文命令重置后再试。",
+                        "rate_limit_key": LLM_RULE_NAME,
+                        "rule_name": LLM_RULE_NAME,
+                        "llm_used": False,
+                        "provider_id": provider.id,
+                        "model": request.model,
+                    }
+                logger.info(
+                    "epoch hot degrade for budget scope=%s anchor=%d->%d",
+                    scope_key, degraded.old_anchor_id, degraded.new_anchor_id,
+                )
+                history, participants, scene_patch, projected_segments = (
+                    self._load_scrubbed_history_and_participants(
+                        chat_id=chat_id,
+                        chat_type=chat_type,
+                        scope_key=scope_key,
+                        settings=settings,
+                        sensitive=sensitive,
+                        user_id=user_id,
+                        sender_name=sender_name,
+                        recent_messages=recent_messages,
+                        message_id=message_id,
+                        quoted_sender_name=quoted_sender_name,
+                        quoted_user_id=quoted_user_id,
+                        epoch_key=epoch_key,
+                        epoch_params=epoch_params,
+                        provider=provider,
+                    )
+                )
+                turn_envelope = self._build_turn_envelope(
+                    chat_id,
+                    chat_type,
+                    analysis_prompt or trimmed_prompt,
+                    memories,
+                    participants=participants,
+                )
+                messages = self._build_messages(
+                    prompt=trimmed_prompt,
+                    image_urls=effective_image_urls,
+                    history=history,
+                    recent_messages=scene_patch,
+                    recent_images_messages=recent_images_source,
+                    chat_type=chat_type,
+                    group_id=str(chat_id),
+                    current_sender_name=sender_name,
+                    current_user_id=str(user_id),
+                    quoted_text=quoted_prompt,
+                    quoted_sender_name=quoted_sender_name,
+                    quoted_user_id=quoted_user_id,
+                    quoted_image_urls=request_quoted_image_urls,
+                    quoted_is_bot_self=quoted_is_bot_self,
+                    forward_text=normalized_forward_text,
+                    forward_image_urls=request_forward_image_urls,
+                    image_descriptions=image_descriptions or None,
+                    include_recent_images=include_recent_images and not is_non_vision,
+                    turn_envelope=turn_envelope,
+                    projected_history_segments=projected_segments,
+                )
+                request = LLMRequest(
+                    model=settings.model or provider.default_model,
+                    system_prompt=system_prompt,
+                    messages=messages,
+                    temperature=provider.temperature,
+                    max_output_tokens=provider.max_output_tokens,
+                    tools=tool_specs,
+                    allow_tool_calls=bool(tool_specs),
+                    tool_choice="auto",
+                    builtin_search=builtin_search_active,
+                )
         tool_context = ToolExecutionContext(
             group_id=chat_id,
             user_id=user_id,

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -1393,48 +1393,92 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             provider_id=provider.id,
             builtin_search_active=builtin_search_active,
         )
-        turn_envelope = self._build_turn_envelope(
-            chat_id,
-            chat_type,
-            analysis_prompt or trimmed_prompt,
-            memories,
-            participants=participants,
-        )
-        messages = self._build_messages(
-            prompt=trimmed_prompt,
-            image_urls=effective_image_urls,
-            history=history,
-            recent_messages=scene_patch,
-            recent_images_messages=recent_images_source,
-            chat_type=chat_type,
-            group_id=str(chat_id),
-            current_sender_name=sender_name,
-            current_user_id=str(user_id),
-            quoted_text=quoted_prompt,
-            quoted_sender_name=quoted_sender_name,
-            quoted_user_id=quoted_user_id,
-            quoted_image_urls=request_quoted_image_urls,
-            quoted_is_bot_self=quoted_is_bot_self,
-            forward_text=normalized_forward_text,
-            forward_image_urls=request_forward_image_urls,
-            image_descriptions=image_descriptions or None,
-            include_recent_images=include_recent_images and not is_non_vision,
-            turn_envelope=turn_envelope,
-            projected_history_segments=projected_segments,
-        )
-        request = LLMRequest(
-            model=settings.model or provider.default_model,
-            system_prompt=system_prompt,
-            messages=messages,
-            temperature=provider.temperature,
-            max_output_tokens=provider.max_output_tokens,
-            tools=tool_specs,
-            allow_tool_calls=bool(tool_specs),
-            tool_choice="auto",
-            builtin_search=builtin_search_active,
-        )
+        # 装配闭包经 nonlocal 重绑定；下游账本 meter 消费降级后的最终值。
+        turn_envelope: str = ""
+        messages: list[LLMConversationMessage] = []
+
+        def _assemble_request(*, reuse_patch: bool = False) -> LLMRequest:
+            """请求装配（首轮与预算降级重试共用同一边界）。
+
+            reuse_patch=True 时注入首轮【现场】补丁：补丁游标读即服役，
+            降级后重取只会拿到 floor 滑窗，首轮（未派发）已含的更旧补丁
+            会静默丢失；首轮补丁按降级前（更大）的 history 去重，对缩后
+            history 的子集复用同样不产生重复。
+            """
+            nonlocal history, participants, scene_patch, projected_segments
+            nonlocal turn_envelope, messages
+            history, participants, scene_patch, projected_segments = (
+                self._load_scrubbed_history_and_participants(
+                    chat_id=chat_id,
+                    chat_type=chat_type,
+                    scope_key=scope_key,
+                    settings=settings,
+                    sensitive=sensitive,
+                    user_id=user_id,
+                    sender_name=sender_name,
+                    recent_messages=scene_patch if reuse_patch else recent_messages,
+                    message_id=message_id,
+                    quoted_sender_name=quoted_sender_name,
+                    quoted_user_id=quoted_user_id,
+                    epoch_key=epoch_key,
+                    epoch_params=epoch_params,
+                    provider=provider,
+                )
+            )
+            turn_envelope = self._build_turn_envelope(
+                chat_id,
+                chat_type,
+                analysis_prompt or trimmed_prompt,
+                memories,
+                participants=participants,
+            )
+            messages = self._build_messages(
+                prompt=trimmed_prompt,
+                image_urls=effective_image_urls,
+                history=history,
+                recent_messages=scene_patch,
+                recent_images_messages=recent_images_source,
+                chat_type=chat_type,
+                group_id=str(chat_id),
+                current_sender_name=sender_name,
+                current_user_id=str(user_id),
+                quoted_text=quoted_prompt,
+                quoted_sender_name=quoted_sender_name,
+                quoted_user_id=quoted_user_id,
+                quoted_image_urls=request_quoted_image_urls,
+                quoted_is_bot_self=quoted_is_bot_self,
+                forward_text=normalized_forward_text,
+                forward_image_urls=request_forward_image_urls,
+                image_descriptions=image_descriptions or None,
+                include_recent_images=include_recent_images and not is_non_vision,
+                turn_envelope=turn_envelope,
+                projected_history_segments=projected_segments,
+            )
+            return LLMRequest(
+                model=settings.model or provider.default_model,
+                system_prompt=system_prompt,
+                messages=messages,
+                temperature=provider.temperature,
+                max_output_tokens=provider.max_output_tokens,
+                tools=tool_specs,
+                allow_tool_calls=bool(tool_specs),
+                tool_choice="auto",
+                builtin_search=builtin_search_active,
+            )
+
+        def _budget_exceeded_reply() -> dict:
+            return {
+                "reply": "这次对话的上下文已经太长，无法安全发起模型请求，请用清空上下文命令重置后再试。",
+                "rate_limit_key": LLM_RULE_NAME,
+                "rule_name": LLM_RULE_NAME,
+                "llm_used": False,
+                "provider_id": provider.id,
+                "model": request.model,
+            }
+
         # §8.3 先降级再拒绝：超限时锚点强制缩到热水位（付费 miss 一次），
-        # 重载可见历史与 Loop 投影后重建请求重试一次；仍超限才终止本轮。
+        # 复用首轮补丁重建请求重试一次；仍超限才终止本轮。
+        request = _assemble_request()
         budget_retry_used = False
         while True:
             try:
@@ -1446,89 +1490,18 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                     scope_key, provider.id, request.model, exc,
                 )
                 if budget_retry_used:
-                    return {
-                        "reply": "这次对话的上下文已经太长，无法安全发起模型请求，请用清空上下文命令重置后再试。",
-                        "rate_limit_key": LLM_RULE_NAME,
-                        "rule_name": LLM_RULE_NAME,
-                        "llm_used": False,
-                        "provider_id": provider.id,
-                        "model": request.model,
-                    }
-                budget_retry_used = True
+                    return _budget_exceeded_reply()
                 degraded = self._epochs.force_advance_to_hot(
                     epoch_key, store=self.store, params=epoch_params
                 )
                 if degraded is None:
-                    return {
-                        "reply": "这次对话的上下文已经太长，无法安全发起模型请求，请用清空上下文命令重置后再试。",
-                        "rate_limit_key": LLM_RULE_NAME,
-                        "rule_name": LLM_RULE_NAME,
-                        "llm_used": False,
-                        "provider_id": provider.id,
-                        "model": request.model,
-                    }
+                    return _budget_exceeded_reply()
+                budget_retry_used = True
                 logger.info(
                     "epoch hot degrade for budget scope=%s anchor=%d->%d",
                     scope_key, degraded.old_anchor_id, degraded.new_anchor_id,
                 )
-                history, participants, scene_patch, projected_segments = (
-                    self._load_scrubbed_history_and_participants(
-                        chat_id=chat_id,
-                        chat_type=chat_type,
-                        scope_key=scope_key,
-                        settings=settings,
-                        sensitive=sensitive,
-                        user_id=user_id,
-                        sender_name=sender_name,
-                        recent_messages=recent_messages,
-                        message_id=message_id,
-                        quoted_sender_name=quoted_sender_name,
-                        quoted_user_id=quoted_user_id,
-                        epoch_key=epoch_key,
-                        epoch_params=epoch_params,
-                        provider=provider,
-                    )
-                )
-                turn_envelope = self._build_turn_envelope(
-                    chat_id,
-                    chat_type,
-                    analysis_prompt or trimmed_prompt,
-                    memories,
-                    participants=participants,
-                )
-                messages = self._build_messages(
-                    prompt=trimmed_prompt,
-                    image_urls=effective_image_urls,
-                    history=history,
-                    recent_messages=scene_patch,
-                    recent_images_messages=recent_images_source,
-                    chat_type=chat_type,
-                    group_id=str(chat_id),
-                    current_sender_name=sender_name,
-                    current_user_id=str(user_id),
-                    quoted_text=quoted_prompt,
-                    quoted_sender_name=quoted_sender_name,
-                    quoted_user_id=quoted_user_id,
-                    quoted_image_urls=request_quoted_image_urls,
-                    quoted_is_bot_self=quoted_is_bot_self,
-                    forward_text=normalized_forward_text,
-                    forward_image_urls=request_forward_image_urls,
-                    image_descriptions=image_descriptions or None,
-                    include_recent_images=include_recent_images and not is_non_vision,
-                    turn_envelope=turn_envelope,
-                    projected_history_segments=projected_segments,
-                )
-                request = LLMRequest(
-                    model=settings.model or provider.default_model,
-                    system_prompt=system_prompt,
-                    messages=messages,
-                    temperature=provider.temperature,
-                    max_output_tokens=provider.max_output_tokens,
-                    tools=tool_specs,
-                    allow_tool_calls=bool(tool_specs),
-                    tool_choice="auto",
-                    builtin_search=builtin_search_active,
-                )
+                request = _assemble_request(reuse_patch=True)
         tool_context = ToolExecutionContext(
             group_id=chat_id,
             user_id=user_id,

--- a/src/quickquip/llm/token_estimate.py
+++ b/src/quickquip/llm/token_estimate.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import math
+from typing import Any
 
 CJK_TOKEN_RATIO = 0.7
 ASCII_TOKEN_RATIO = 0.35
@@ -13,8 +14,54 @@ ASCII_TOKEN_RATIO = 0.35
 # 粗判 CJK 与全角符号的下界（⼀ U+2E80 起），之上的码位按中文比率计。
 _CJK_ORD_FLOOR = 0x2E80
 
+# 协议原生块内媒体载荷（inlineData/fileData）的固定档估算（与请求预算口径一致）。
+NATIVE_MEDIA_FLAT_TOKENS = 1200
+# 每个原生块的结构开销（块类型、id、字段名的 wire 折算下界）。
+_NATIVE_BLOCK_STRUCTURE_TOKENS = 8
+
 
 def estimate_tokens(text: str) -> int:
     """按字符类别加权的 token 粗估，向上取整；空串为 0。"""
     cjk = sum(1 for ch in text if ord(ch) >= _CJK_ORD_FLOOR)
     return math.ceil(cjk * CJK_TOKEN_RATIO + (len(text) - cjk) * ASCII_TOKEN_RATIO)
+
+
+def _estimate_block_value(value: Any) -> int:
+    if isinstance(value, str):
+        return estimate_tokens(value)
+    if isinstance(value, dict):
+        return estimate_native_block_tokens(value)
+    if isinstance(value, bool) or value is None:
+        return 1
+    if isinstance(value, (int, float)):
+        return 2
+    if isinstance(value, list):
+        return sum(_estimate_block_value(item) for item in value)
+    return estimate_tokens(str(value))
+
+
+def estimate_native_block_tokens(block: Any) -> int:
+    """协议原生内容块的字段级估算：遍历字段取载荷，未知形态保底非零。
+
+    字符串字段（thinking/text/signature/参数 JSON 串等）按字符类别估；
+    dict 字段（tool_use.input、functionCall.args 等）递归；
+    媒体载荷（inlineData/fileData）按固定档，避免 base64 全量高估。
+    """
+    if not isinstance(block, dict):
+        return estimate_tokens(str(block)) + _NATIVE_BLOCK_STRUCTURE_TOKENS
+    total = _NATIVE_BLOCK_STRUCTURE_TOKENS
+    for key, value in block.items():
+        if key in ("inlineData", "fileData"):
+            total += NATIVE_MEDIA_FLAT_TOKENS
+            continue
+        total += _estimate_block_value(value)
+    return total
+
+
+def estimate_native_blocks_tokens(blocks: list[Any] | None) -> int:
+    """一组原生/中间表示内容块的估算；None/空为 0。"""
+    if not blocks:
+        return 0
+    return sum(estimate_native_block_tokens(block) for block in blocks)
+
+

--- a/tests/unit/adapters/test_delivery_sink.py
+++ b/tests/unit/adapters/test_delivery_sink.py
@@ -62,6 +62,7 @@ async def test_missing_message_id_is_unknown_not_sent():
     receipt = await sink("dlv_1", {"text": "正文"})
     assert receipt.status == DeliveryStatus.UNKNOWN
     assert receipt.error_code == "missing_message_id"
+    assert sink.sent_texts == []
 
 
 async def test_timeout_classified_unknown_and_plain_error_failed():
@@ -81,6 +82,19 @@ async def test_timeout_classified_unknown_and_plain_error_failed():
     receipt2 = await sink2("dlv_1", {"text": "正文"})
     assert receipt2.status == DeliveryStatus.FAILED
     assert receipt2.error_code == "RuntimeError"
+    assert sink2.sent_texts == []
+
+
+async def test_timeout_is_not_recorded_as_visible_text():
+    reset_delivery_throttle()
+
+    async def timeout_send(text):
+        raise asyncio.TimeoutError("Request timed out")
+
+    sink = OneBotDeliverySink(timeout_send, scope_key="g-timeout", interval_ms=0)
+    receipt = await sink("dlv_1", {"text": "可能已送达"})
+    assert receipt.status == DeliveryStatus.UNKNOWN
+    assert sink.sent_texts == []
 
 
 async def test_same_scope_sends_are_throttled():

--- a/tests/unit/llm/test_epoch.py
+++ b/tests/unit/llm/test_epoch.py
@@ -344,3 +344,28 @@ def test_epoch_row_budget_ignores_native_state() -> None:
     }
     assert _row_budget(row) == estimate_tokens("字" * 100) + ROW_OVERHEAD_TOKENS
     assert estimate_rows_budget([row]) == estimate_tokens("字" * 100) + ROW_OVERHEAD_TOKENS
+
+
+def test_force_advance_to_hot_applies_rows_backstop(store: LLMStore) -> None:
+    # 口径锁定：容量降级同样先做行数兜底——窗口超 1024 行时绝不靠
+    # 范围读 LIMIT 截断（那会截掉最新端）。
+    big_cap = EpochParams(
+        context_tokens=200,
+        cold_idle_seconds=300,
+        cold_target_tokens=100,
+        cold_trigger_tokens=150,
+        hot_target_tokens=400,
+        cap_tokens=10_000_000,
+    )
+    # 先小窗口初始化锚点，再灌入超过 DEFAULT_EPOCH_MAX_ROWS 的行量，
+    # 让窗口行数越界（模拟锚点不动、对话持续增长的真实形态）。
+    _seed_pairs(store, "1001", pairs=4, chars=10)
+    mgr = EpochManager(clock=FakeClock())
+    mgr.maybe_advance(_KEY, store=store, params=big_cap)
+    _seed_pairs(store, "1001", pairs=600, chars=10)  # 窗口 > 1024 行
+    grown_rows = _rows_since(store, "1001", mgr.current_anchor(_KEY) or 0)
+    assert len(grown_rows) > DEFAULT_EPOCH_MAX_ROWS, "前置：窗口行数已越界"
+    event = mgr.force_advance_to_hot(_KEY, store=store, params=big_cap)
+    assert event is not None
+    rows = _rows_since(store, "1001", mgr.current_anchor(_KEY))
+    assert len(rows) <= DEFAULT_EPOCH_MAX_ROWS

--- a/tests/unit/llm/test_epoch.py
+++ b/tests/unit/llm/test_epoch.py
@@ -293,3 +293,54 @@ def test_oldest_anchor_returns_min_across_keys(store: LLMStore) -> None:
     # key_a 冷场缩窗后锚点更新（id 更大），key_b 窗口更大锚点更老
     assert mgr.current_anchor(key_a) > mgr.current_anchor(key_b)
     assert oldest == mgr.current_anchor(key_b)
+
+
+# ── 容量 reset 路径（force_advance_to_hot）与口径锁定 ────────────
+
+
+def test_force_advance_to_hot_shrinks_to_hot_watermark(store: LLMStore) -> None:
+    # 模拟真实流：小窗口初始化 → 窗口增长超过热水位 → 容量 reset 强制收缩。
+    _seed_pairs(store, "1001", pairs=4, chars=40)
+    mgr = EpochManager(clock=FakeClock())
+    mgr.maybe_advance(_KEY, store=store, params=_SMALL)
+    _seed_pairs(store, "1001", pairs=12, chars=40)
+    grown = estimate_rows_budget(_rows_since(store, "1001", mgr.current_anchor(_KEY) or 0))
+    assert grown > _SMALL.hot_target_tokens, "前置：窗口已超过热水位"
+    event = mgr.force_advance_to_hot(_KEY, store=store, params=_SMALL)
+    assert event is not None
+    assert event.reason == "hot"
+    assert event.new_anchor_id > event.old_anchor_id
+    rows = _rows_since(store, "1001", mgr.current_anchor(_KEY))
+    # 推进后窗口收敛到热水位附近（允许一行对齐余量）。
+    per_row_max = max(estimate_rows_budget([row]) for row in rows) if rows else 0
+    assert estimate_rows_budget(rows) <= _SMALL.hot_target_tokens + per_row_max
+
+
+def test_force_advance_to_hot_stateless_and_converges(store: LLMStore) -> None:
+    _seed_pairs(store, "1001", pairs=10, chars=40)
+    mgr = EpochManager(clock=FakeClock())
+    # 本进程无该键状态：返回 None，由调用方走终止路径。
+    assert mgr.force_advance_to_hot(_KEY, store=store, params=_SMALL) is None
+    mgr.maybe_advance(_KEY, store=store, params=_SMALL)
+    # 反复收缩在热水位（含逐行对齐余量）内收敛：最终返回 None。
+    for _ in range(32):
+        if mgr.force_advance_to_hot(_KEY, store=store, params=_SMALL) is None:
+            break
+    else:
+        pytest.fail("force_advance_to_hot 未收敛")
+    assert mgr.force_advance_to_hot(_KEY, store=store, params=_SMALL) is None
+
+
+def test_epoch_row_budget_ignores_native_state() -> None:
+    # 口径锁定：纪元预算只读可见行正文，执行记录的原生状态不参与计量。
+    from quickquip.llm.epoch import ROW_OVERHEAD_TOKENS, _row_budget
+    from quickquip.llm.token_estimate import estimate_tokens
+
+    row = {
+        "raw_content": "字" * 100,
+        "content": "",
+        "native_state_json": "n" * 10_000,
+        "agent_loop_id": "loop_1",
+    }
+    assert _row_budget(row) == estimate_tokens("字" * 100) + ROW_OVERHEAD_TOKENS
+    assert estimate_rows_budget([row]) == estimate_tokens("字" * 100) + ROW_OVERHEAD_TOKENS

--- a/tests/unit/llm/test_projection_budget.py
+++ b/tests/unit/llm/test_projection_budget.py
@@ -136,3 +136,129 @@ def test_within_budget_projection_untouched():
     assert result.decisions[0].path == PATH_STRUCTURED
     assert result.decisions[0].reason is None
     assert [m.content for m in result.messages if m.role == "assistant"] == ["短正文。"]
+
+
+# ── 原生 CoT 计量与首档剥离 ──────────────────────────────────────
+
+
+def _native_estimate(messages) -> int:
+    """与实现同口径的估算（含原生/thinking 块）。"""
+    from quickquip.llm.token_estimate import estimate_native_blocks_tokens
+
+    total = 0
+    for message in messages:
+        total += estimate_tokens(message.content)
+        for call in message.tool_calls:
+            total += estimate_tokens(call.arguments_json)
+        total += estimate_native_blocks_tokens(message.thinking_blocks)
+        total += estimate_native_blocks_tokens(message.native_content)
+    return total
+
+
+def _cot_loop(thinking_chars: int):
+    blocks = [
+        {"type": "thinking", "thinking": "思" * thinking_chars, "signature": "sig"},
+        {"type": "tool_use", "id": "call_exec_0", "name": "get_identity", "input": {}},
+    ]
+    return _loop(
+        "loop_cot",
+        (
+            _turn(
+                "turn_0",
+                tools=(_tool_exec("exec_0"),),
+                native_state=_native_state(OWNER, blocks),
+                owner=_owner_dict(OWNER),
+            ),
+        ),
+    )
+
+
+def test_native_cot_counted_into_projection_estimate():
+    loop = _cot_loop(thinking_chars=4000)
+    full = project_loops_with_budget(
+        [loop], target=OWNER, protocol="claude", budget_tokens=10**9
+    )
+    assert _native_estimate(full.messages) > estimate_tokens("思" * 4000)
+
+
+def test_native_thinking_stripped_before_native_dropped():
+    loop = _cot_loop(thinking_chars=4000)
+    full = project_loops_with_budget(
+        [loop], target=OWNER, protocol="claude", budget_tokens=10**9
+    )
+    full_estimate = _native_estimate(full.messages)
+    # 预算略低于全量：剥 thinking（≈4000×0.7 token）即达标，不应走到 native_dropped。
+    result = project_loops_with_budget(
+        [loop], target=OWNER, protocol="claude", budget_tokens=full_estimate - 200
+    )
+    decision = result.decisions[0]
+    assert decision.reason == "reduced:native_thinking_stripped"
+    assistant = [m for m in result.messages if m.role == "assistant"][0]
+    assert assistant.native_content is not None
+    types = [block.get("type") for block in assistant.native_content]
+    assert "thinking" not in types
+    assert "tool_use" in types, "工具声明保留，配对完整"
+    assert any(m.role == "tool" for m in result.messages), "工具结果保留"
+
+
+def test_native_thinking_stripped_gemini_thought_parts():
+    from dataclasses import replace
+
+    gemini_owner = replace(OWNER, protocol="gemini")
+    blocks = [
+        {"text": "想" * 4000, "thought": True},
+        {"functionCall": {"name": "get_identity", "args": {}}},
+    ]
+    loop = _loop(
+        "loop_gcot",
+        (
+            _turn(
+                "turn_0",
+                tools=(_tool_exec("exec_0"),),
+                native_state=_native_state(gemini_owner, blocks),
+                owner=_owner_dict(gemini_owner),
+            ),
+        ),
+    )
+    full = project_loops_with_budget(
+        [loop], target=gemini_owner, protocol="gemini", budget_tokens=10**9
+    )
+    full_estimate = _native_estimate(full.messages)
+    result = project_loops_with_budget(
+        [loop], target=gemini_owner, protocol="gemini", budget_tokens=full_estimate - 200
+    )
+    decision = result.decisions[0]
+    assert decision.reason == "reduced:native_thinking_stripped"
+    assistant = [m for m in result.messages if m.role == "assistant"][0]
+    assert assistant.native_content is not None
+    assert all(not block.get("thought") for block in assistant.native_content)
+    assert any("functionCall" in block for block in assistant.native_content)
+
+
+def test_huge_native_cot_still_reaches_deeper_ladder():
+    # 大 CoT + 大工具结果：剥 thinking 后仍超限，继续走到 native_dropped
+    # 或更深档位，签名块不再上 wire。
+    blocks = [
+        {"type": "thinking", "thinking": "思" * 100_000, "signature": "sig"},
+        {"type": "tool_use", "id": "call_exec_0", "name": "get_identity", "input": {}},
+    ]
+    loop = _loop(
+        "loop_cot_deep",
+        (
+            _turn(
+                "turn_0",
+                tools=(_big_result_exec("exec_0", 8000),),
+                native_state=_native_state(OWNER, blocks),
+                owner=_owner_dict(OWNER),
+            ),
+        ),
+    )
+    result = project_loops_with_budget(
+        [loop], target=OWNER, protocol="claude", budget_tokens=400
+    )
+    decision = result.decisions[0]
+    assert decision.reason is not None
+    assert "reduced:native_thinking_stripped" in (decision.reason or "")
+    assert "reduced:native_dropped" in (decision.reason or "")
+    for message in result.messages:
+        assert message.native_content is None

--- a/tests/unit/llm/test_projection_budget.py
+++ b/tests/unit/llm/test_projection_budget.py
@@ -142,17 +142,10 @@ def test_within_budget_projection_untouched():
 
 
 def _native_estimate(messages) -> int:
-    """与实现同口径的估算（含原生/thinking 块）。"""
-    from quickquip.llm.token_estimate import estimate_native_blocks_tokens
+    """与实现同口径的估算（含原生/thinking 块；与 test_epoch 导入私有函数同例）。"""
+    from quickquip.llm.history_projection import _estimate_messages_tokens
 
-    total = 0
-    for message in messages:
-        total += estimate_tokens(message.content)
-        for call in message.tool_calls:
-            total += estimate_tokens(call.arguments_json)
-        total += estimate_native_blocks_tokens(message.thinking_blocks)
-        total += estimate_native_blocks_tokens(message.native_content)
-    return total
+    return _estimate_messages_tokens(messages)
 
 
 def _cot_loop(thinking_chars: int):
@@ -262,3 +255,54 @@ def test_huge_native_cot_still_reaches_deeper_ladder():
     assert "reduced:native_dropped" in (decision.reason or "")
     for message in result.messages:
         assert message.native_content is None
+
+
+def test_native_thinking_stripped_empty_turn_gets_placeholder():
+    # 纯 thinking 轮（零正文零工具）剥空后退占位正文：空 text 块会被 Claude 拒 400。
+    blocks = [{"type": "thinking", "thinking": "思" * 200, "signature": "sig"}]
+    loop = _loop(
+        "loop_pure_thinking",
+        (
+            _turn(
+                "turn_0",
+                text="",
+                tools=(),
+                native_state=_native_state(OWNER, blocks),
+                owner=_owner_dict(OWNER),
+            ),
+        ),
+    )
+    full = project_loops_with_budget(
+        [loop], target=OWNER, protocol="claude", budget_tokens=10**9
+    )
+    result = project_loops_with_budget(
+        [loop], target=OWNER, protocol="claude", budget_tokens=_native_estimate(full.messages) - 5
+    )
+    assert result.decisions[0].reason == "reduced:native_thinking_stripped"
+    stripped_assistant = [m for m in result.messages if m.role == "assistant"][0]
+    assert stripped_assistant.native_content is None
+    assert stripped_assistant.content, "剥空轮必须有非空占位正文"
+    assert estimate_tokens(stripped_assistant.content) > 0
+
+
+def test_native_message_text_not_double_counted():
+    # 原生消息正文内含于 native 块（serializer 忽略通用字段），估算不得双计。
+    from quickquip.llm.history_projection import _estimate_messages_tokens
+    from quickquip.llm.tools import LLMConversationMessage
+
+    body = "正文内容。" * 50
+    native_msg = LLMConversationMessage(
+        role="assistant",
+        content=body,
+        native_content=[{"type": "text", "text": body}],
+    )
+    counted_once = _estimate_messages_tokens([native_msg])
+    empty_body = LLMConversationMessage(
+        role="assistant",
+        content="",
+        native_content=[{"type": "text", "text": body}],
+    )
+    assert _estimate_messages_tokens([empty_body]) == counted_once
+    # 通用消息（无 native）仍单计 content。
+    plain = LLMConversationMessage(role="assistant", content=body)
+    assert _estimate_messages_tokens([plain]) == estimate_tokens(body)

--- a/tests/unit/llm/test_request_budget.py
+++ b/tests/unit/llm/test_request_budget.py
@@ -1,0 +1,236 @@
+"""请求预算（§8.3）单测：原生块计量、预算解析优先级与重放预算推导。"""
+from __future__ import annotations
+
+import pytest
+
+from quickquip.llm.config import LLMConfig, ProviderConfig
+from quickquip.llm.context_windows import (
+    lookup_builtin_context_window,
+    resolve_context_window,
+)
+from quickquip.llm.provider import LLMRequest
+from quickquip.llm.request_budget import (
+    RequestBudgetExceeded,
+    check_request_budget,
+    count_wire_items,
+    derive_replay_budget,
+    enforce_request_budget,
+    estimate_request_tokens,
+    resolve_input_budget,
+)
+from quickquip.llm.tools import LLMConversationMessage
+from quickquip.llm.token_estimate import (
+    NATIVE_MEDIA_FLAT_TOKENS,
+    estimate_native_blocks_tokens,
+    estimate_tokens,
+)
+
+
+def _provider(**overrides) -> ProviderConfig:
+    defaults = dict(
+        id="p1",
+        protocol="openai",
+        base_url="https://example.test",
+        api_key_env="K",
+        default_model="custom-model-x",
+        models=["custom-model-x"],
+    )
+    defaults.update(overrides)
+    return ProviderConfig(**defaults)
+
+
+def _request(messages, *, model: str = "custom-model-x", max_output: int = 800) -> LLMRequest:
+    return LLMRequest(
+        model=model,
+        system_prompt="",
+        messages=messages,
+        temperature=0.8,
+        max_output_tokens=max_output,
+    )
+
+
+# ── 原生块计量 ───────────────────────────────────────────────────
+
+
+def test_estimate_request_tokens_counts_native_content():
+    thinking = "思" * 4000
+    native_msg = LLMConversationMessage(
+        role="assistant",
+        content="",
+        native_content=[{"type": "thinking", "thinking": thinking, "signature": "sig"}],
+    )
+    plain_msg = LLMConversationMessage(role="assistant", content="")
+    with_native = estimate_request_tokens(_request([native_msg]))
+    without_native = estimate_request_tokens(_request([plain_msg]))
+    assert with_native >= without_native + estimate_tokens(thinking)
+
+
+def test_estimate_request_tokens_counts_thinking_blocks():
+    thinking = "理" * 2000
+    msg = LLMConversationMessage(
+        role="assistant", content="", thinking_blocks=[{"type": "reasoning", "reasoning_content": thinking}]
+    )
+    base = estimate_request_tokens(_request([LLMConversationMessage(role="assistant", content="")]))
+    assert estimate_request_tokens(_request([msg])) >= base + estimate_tokens(thinking)
+
+
+def test_estimate_request_tokens_media_not_double_counted_in_native():
+    media_block = {"inlineData": {"mimeType": "image/png", "data": "A" * 100_000}}
+    msg = LLMConversationMessage(role="user", content="", native_content=[media_block])
+    assert estimate_request_tokens(_request([msg])) <= NATIVE_MEDIA_FLAT_TOKENS + 64
+
+
+def test_count_wire_items_counts_native_and_thinking_parts():
+    msg = LLMConversationMessage(
+        role="assistant",
+        content="",
+        thinking_blocks=[{"type": "reasoning", "reasoning_content": "x"}],
+        native_content=[{"type": "text", "text": "a"}, {"type": "text", "text": "b"}],
+    )
+    assert count_wire_items(_request([msg])) == 4  # 1 消息 + 1 thinking + 2 native parts
+
+
+# ── 窗口解析 ─────────────────────────────────────────────────────
+
+
+def test_resolve_context_window_explicit_beats_builtin():
+    explicit = {"gpt-4o": 60_000}
+    assert resolve_context_window(explicit, "gpt-4o") == 60_000
+    assert lookup_builtin_context_window("gpt-4o-mini") == 128_000
+
+
+def test_resolve_context_window_builtin_prefix_and_unknown():
+    assert resolve_context_window({}, "claude-sonnet-4-5-20260101") == 200_000
+    assert resolve_context_window({}, "GEMINI-2.5-PRO") == 1_000_000
+    assert resolve_context_window({}, "relay-private-model") is None
+
+
+# ── 输入预算（仲裁者）解析 ────────────────────────────────────────
+
+
+def test_resolve_input_budget_provider_explicit_wins():
+    config = LLMConfig()
+    provider = _provider(request_input_token_budget=50_000)
+    assert resolve_input_budget(config, provider, "custom-model-x") == 50_000
+
+
+def test_resolve_input_budget_window_derived_when_known():
+    config = LLMConfig()
+    provider = _provider(model_context_windows={"custom-model-x": 262_144})
+    # 窗口 − (max_output 800 + 1024)
+    assert resolve_input_budget(config, provider, "custom-model-x") == 262_144 - 800 - 1024
+
+
+def test_resolve_input_budget_runtime_default_when_unknown():
+    config = LLMConfig()
+    provider = _provider()
+    assert resolve_input_budget(config, provider, "custom-model-x") == 96_000
+
+
+def test_resolve_input_budget_window_can_shrink_below_runtime_default():
+    config = LLMConfig()
+    provider = _provider(model_context_windows={"custom-model-x": 60_000})
+    assert resolve_input_budget(config, provider, "custom-model-x") == 60_000 - 800 - 1024
+
+
+# ── 重放预算推导 ─────────────────────────────────────────────────
+
+
+def test_derive_replay_budget_provider_override_verbatim():
+    config = LLMConfig()
+    provider = _provider(agent_replay_loop_tokens=8_192)
+    assert derive_replay_budget(config, provider, "custom-model-x") == 8_192
+
+
+def test_derive_replay_budget_unknown_window_keeps_runtime_value():
+    config = LLMConfig()
+    provider = _provider()
+    # capacity unknown：推导耗尽后落在 runtime 下限（4096），与旧行为一致。
+    assert derive_replay_budget(config, provider, "custom-model-x") == 4_096
+
+
+def test_derive_replay_budget_scales_with_window():
+    config = LLMConfig()
+    provider_256k = _provider(model_context_windows={"custom-model-x": 262_144})
+    assert derive_replay_budget(config, provider_256k, "custom-model-x") > 100_000
+    provider_1m = _provider(model_context_windows={"custom-model-x": 1_000_000})
+    assert derive_replay_budget(config, provider_1m, "custom-model-x") > 500_000
+
+
+def test_derive_replay_budget_smaller_epoch_cap_frees_replay():
+    config = LLMConfig()
+    wide = _provider(
+        model_context_windows={"custom-model-x": 262_144},
+        epoch_hot_target_tokens=32_000,
+        epoch_cap_tokens=64_000,
+    )
+    narrow = _provider(
+        model_context_windows={"custom-model-x": 262_144},
+        epoch_hot_target_tokens=16_000,
+        epoch_cap_tokens=32_000,
+    )
+    assert derive_replay_budget(config, narrow, "custom-model-x") > derive_replay_budget(
+        config, wide, "custom-model-x"
+    )
+
+
+def test_derive_replay_budget_runtime_value_is_floor():
+    config = LLMConfig()
+    config.runtime.agent_replay_loop_tokens = 200_000
+    provider = _provider()  # capacity unknown：仲裁者 96000，推导值更小
+    assert derive_replay_budget(config, provider, "custom-model-x") == 200_000
+
+
+# ── 检查与拒绝 ───────────────────────────────────────────────────
+
+
+def test_check_request_budget_capacity_flag_and_margin():
+    config = LLMConfig()
+    unknown = _request(
+        [LLMConversationMessage(role="user", content="a" * 10_000)]
+    )
+    check = check_request_budget(config, _provider(), unknown)
+    assert check.capacity_unknown is True
+    assert check.context_window is None
+
+    known_provider = _provider(model_context_windows={"custom-model-x": 200_000})
+    check = check_request_budget(config, known_provider, unknown)
+    assert check.capacity_unknown is False
+    # 比例余量：窗口 − 输出预留 − max(1024, 10% 估算)
+    margin = max(1024, int(check.estimated_input_tokens * 0.10))
+    assert check.context_window == 200_000 - 800 - 1024 - margin
+
+
+def test_enforce_rejects_over_budget_payload():
+    config = LLMConfig()
+    provider = _provider(request_input_token_budget=2_000)
+    request = _request([LLMConversationMessage(role="user", content="a" * 100_000)])
+    with pytest.raises(RequestBudgetExceeded, match="超出应用输入预算"):
+        enforce_request_budget(config, provider, request)
+
+
+def test_enforce_rejects_native_payload_over_window():
+    config = LLMConfig()
+    # 窗口 8k + 显式预算放宽到 50k：原生块计量后超窗口，走窗口拒绝路径。
+    provider = _provider(
+        request_input_token_budget=50_000,
+        model_context_windows={"custom-model-x": 8_000},
+    )
+    request = _request(
+        [
+            LLMConversationMessage(
+                role="assistant",
+                content="",
+                native_content=[
+                    {"type": "thinking", "thinking": "思" * 60_000, "signature": "sig"}
+                ],
+            )
+        ]
+    )
+    with pytest.raises(RequestBudgetExceeded, match="模型上下文余量"):
+        enforce_request_budget(config, provider, request)
+
+
+def test_native_block_unknown_shape_still_counted():
+    blocks = [{"type": "future_kind", "payload": "x" * 2_000}]
+    assert estimate_native_blocks_tokens(blocks) > 0

--- a/tests/unit/llm/test_request_budget.py
+++ b/tests/unit/llm/test_request_budget.py
@@ -20,7 +20,6 @@ from quickquip.llm.request_budget import (
 )
 from quickquip.llm.tools import LLMConversationMessage
 from quickquip.llm.token_estimate import (
-    NATIVE_MEDIA_FLAT_TOKENS,
     estimate_tokens,
 )
 
@@ -74,9 +73,10 @@ def test_estimate_request_tokens_counts_thinking_blocks():
 
 
 def test_estimate_request_tokens_media_not_double_counted_in_native():
+    # 精确断言：1200 媒体固定档 + 8 结构开销，base64 全量计入会被立刻检出。
     media_block = {"inlineData": {"mimeType": "image/png", "data": "A" * 100_000}}
     msg = LLMConversationMessage(role="user", content="", native_content=[media_block])
-    assert estimate_request_tokens(_request([msg])) <= NATIVE_MEDIA_FLAT_TOKENS + 64
+    assert estimate_request_tokens(_request([msg])) == 1200 + 8
 
 
 def test_count_wire_items_counts_native_and_thinking_parts():

--- a/tests/unit/llm/test_request_budget.py
+++ b/tests/unit/llm/test_request_budget.py
@@ -21,7 +21,6 @@ from quickquip.llm.request_budget import (
 from quickquip.llm.tools import LLMConversationMessage
 from quickquip.llm.token_estimate import (
     NATIVE_MEDIA_FLAT_TOKENS,
-    estimate_native_blocks_tokens,
     estimate_tokens,
 )
 
@@ -231,6 +230,41 @@ def test_enforce_rejects_native_payload_over_window():
         enforce_request_budget(config, provider, request)
 
 
-def test_native_block_unknown_shape_still_counted():
-    blocks = [{"type": "future_kind", "payload": "x" * 2_000}]
-    assert estimate_native_blocks_tokens(blocks) > 0
+def test_estimate_request_tokens_no_double_count_for_native_messages():
+    body = "正文内容。" * 50
+    native_msg = LLMConversationMessage(
+        role="assistant",
+        content=body,
+        native_content=[{"type": "text", "text": body}],
+    )
+    with_body = estimate_request_tokens(_request([native_msg]))
+    without_body = estimate_request_tokens(
+        _request(
+            [
+                LLMConversationMessage(
+                    role="assistant",
+                    content="",
+                    native_content=[{"type": "text", "text": body}],
+                )
+            ]
+        )
+    )
+    assert with_body == without_body, "native 消息的通用正文不得双计"
+
+
+def test_derive_replay_budget_provider_override_clamped():
+    config = LLMConfig()
+    huge = _provider(agent_replay_loop_tokens=99_999_999)
+    assert derive_replay_budget(config, huge, "custom-model-x") == 4_194_304
+    tiny = _provider(agent_replay_loop_tokens=1)
+    assert derive_replay_budget(config, tiny, "custom-model-x") == 512
+
+
+def test_builtin_table_conservative_entries():
+    # Deep-CR 修正后的保守条目（存疑取低）：直连构造也按界钳制。
+    assert lookup_builtin_context_window("glm-4.5-air") == 128_000
+    assert lookup_builtin_context_window("glm-4.6") == 200_000
+    assert lookup_builtin_context_window("kimi-k2-0905") == 128_000
+    assert lookup_builtin_context_window("kimi-k2-thinking") == 256_000
+    assert lookup_builtin_context_window("qwen3-235b-a22b") == 32_768
+    assert lookup_builtin_context_window("qwen3-2507") == 262_144

--- a/tests/unit/llm/test_token_estimate.py
+++ b/tests/unit/llm/test_token_estimate.py
@@ -58,14 +58,18 @@ def test_estimate_native_block_tokens_gemini_function_call():
 
 
 def test_estimate_native_block_tokens_unknown_shape_nonzero():
-    assert estimate_native_block_tokens({"type": "future_block", "payload": "x" * 100}) > 0
+    # 载荷长度下界：固定值兜底实现（如恒返 1）无法通过。
+    assert estimate_native_block_tokens(
+        {"type": "future_block", "payload": "x" * 100}
+    ) >= math.ceil(100 * ASCII_TOKEN_RATIO)
     assert estimate_native_block_tokens("raw-string-block") > 0
     assert estimate_native_block_tokens(None) > 0
 
 
 def test_estimate_native_block_tokens_media_flat_not_base64_inflated():
+    # 精确断言：1200 媒体固定档 + 8 结构开销——base64 全量计入会被立刻检出。
     block = {"inlineData": {"mimeType": "image/png", "data": "A" * 200_000}}
-    assert estimate_native_block_tokens(block) <= 1200 + 128
+    assert estimate_native_block_tokens(block) == 1200 + 8
 
 
 def test_estimate_native_blocks_tokens_none_and_empty():

--- a/tests/unit/llm/test_token_estimate.py
+++ b/tests/unit/llm/test_token_estimate.py
@@ -1,6 +1,12 @@
 import math
 
-from quickquip.llm.token_estimate import ASCII_TOKEN_RATIO, CJK_TOKEN_RATIO, estimate_tokens
+from quickquip.llm.token_estimate import (
+    ASCII_TOKEN_RATIO,
+    CJK_TOKEN_RATIO,
+    estimate_native_block_tokens,
+    estimate_native_blocks_tokens,
+    estimate_tokens,
+)
 
 
 def test_estimate_tokens_empty():
@@ -32,15 +38,11 @@ def test_estimate_tokens_mixed_rounds_up():
 # ── 协议原生块估算 ───────────────────────────────────────────────
 
 def test_estimate_native_block_tokens_claude_thinking_payload():
-    from quickquip.llm.token_estimate import estimate_native_block_tokens
-
     block = {"type": "thinking", "thinking": "思" * 100, "signature": "sig-123"}
     assert estimate_native_block_tokens(block) >= math.ceil(100 * CJK_TOKEN_RATIO)
 
 
 def test_estimate_native_block_tokens_tool_use_input_dict():
-    from quickquip.llm.token_estimate import estimate_native_block_tokens
-
     block = {
         "type": "tool_use",
         "id": "call_1",
@@ -51,32 +53,21 @@ def test_estimate_native_block_tokens_tool_use_input_dict():
 
 
 def test_estimate_native_block_tokens_gemini_function_call():
-    from quickquip.llm.token_estimate import estimate_native_block_tokens
-
     block = {"functionCall": {"name": "search_web", "args": {"query": "镜子"}}}
     assert estimate_native_block_tokens(block) > 0
 
 
 def test_estimate_native_block_tokens_unknown_shape_nonzero():
-    from quickquip.llm.token_estimate import estimate_native_block_tokens
-
     assert estimate_native_block_tokens({"type": "future_block", "payload": "x" * 100}) > 0
     assert estimate_native_block_tokens("raw-string-block") > 0
     assert estimate_native_block_tokens(None) > 0
 
 
 def test_estimate_native_block_tokens_media_flat_not_base64_inflated():
-    from quickquip.llm.token_estimate import (
-        NATIVE_MEDIA_FLAT_TOKENS,
-        estimate_native_block_tokens,
-    )
-
     block = {"inlineData": {"mimeType": "image/png", "data": "A" * 200_000}}
-    assert estimate_native_block_tokens(block) <= NATIVE_MEDIA_FLAT_TOKENS + 128
+    assert estimate_native_block_tokens(block) <= 1200 + 128
 
 
 def test_estimate_native_blocks_tokens_none_and_empty():
-    from quickquip.llm.token_estimate import estimate_native_blocks_tokens
-
     assert estimate_native_blocks_tokens(None) == 0
     assert estimate_native_blocks_tokens([]) == 0

--- a/tests/unit/llm/test_token_estimate.py
+++ b/tests/unit/llm/test_token_estimate.py
@@ -27,3 +27,56 @@ def test_estimate_tokens_mixed_rounds_up():
     cjk = sum(1 for ch in text if ord(ch) >= 0x2E80)
     expected = math.ceil(cjk * CJK_TOKEN_RATIO + (len(text) - cjk) * ASCII_TOKEN_RATIO)
     assert estimate_tokens(text) == expected
+
+
+# ── 协议原生块估算 ───────────────────────────────────────────────
+
+def test_estimate_native_block_tokens_claude_thinking_payload():
+    from quickquip.llm.token_estimate import estimate_native_block_tokens
+
+    block = {"type": "thinking", "thinking": "思" * 100, "signature": "sig-123"}
+    assert estimate_native_block_tokens(block) >= math.ceil(100 * CJK_TOKEN_RATIO)
+
+
+def test_estimate_native_block_tokens_tool_use_input_dict():
+    from quickquip.llm.token_estimate import estimate_native_block_tokens
+
+    block = {
+        "type": "tool_use",
+        "id": "call_1",
+        "name": "search_web",
+        "input": {"query": "镜子", "limit": 3},
+    }
+    assert estimate_native_block_tokens(block) > 0
+
+
+def test_estimate_native_block_tokens_gemini_function_call():
+    from quickquip.llm.token_estimate import estimate_native_block_tokens
+
+    block = {"functionCall": {"name": "search_web", "args": {"query": "镜子"}}}
+    assert estimate_native_block_tokens(block) > 0
+
+
+def test_estimate_native_block_tokens_unknown_shape_nonzero():
+    from quickquip.llm.token_estimate import estimate_native_block_tokens
+
+    assert estimate_native_block_tokens({"type": "future_block", "payload": "x" * 100}) > 0
+    assert estimate_native_block_tokens("raw-string-block") > 0
+    assert estimate_native_block_tokens(None) > 0
+
+
+def test_estimate_native_block_tokens_media_flat_not_base64_inflated():
+    from quickquip.llm.token_estimate import (
+        NATIVE_MEDIA_FLAT_TOKENS,
+        estimate_native_block_tokens,
+    )
+
+    block = {"inlineData": {"mimeType": "image/png", "data": "A" * 200_000}}
+    assert estimate_native_block_tokens(block) <= NATIVE_MEDIA_FLAT_TOKENS + 128
+
+
+def test_estimate_native_blocks_tokens_none_and_empty():
+    from quickquip.llm.token_estimate import estimate_native_blocks_tokens
+
+    assert estimate_native_blocks_tokens(None) == 0
+    assert estimate_native_blocks_tokens([]) == 0


### PR DESCRIPTION
## 意图

修复 1.15 Agent Loop 的预算计量缺口并重标定重放/请求两层：协议原生内容块（含 Claude/Gemini 完整思考链）此前不参与任何预算计量，4096 的重放预算与 96000 的请求预算对原生重放不设防。本 PR 让计量可信，并让重放/请求预算按真实模型窗口推导；纪元层缺省数值与口径（只计量可见行）保持不变。

## 关键行为变化

| 层 | 变更 |
|---|---|
| 统计层 | 原生/中间表示块按字段级遍历计入投影预算与最终请求预算估算（媒体固定档、未知形态保底非零）；wire part 数计入条目兜底；窗口检查追加 10% 比例估算余量 |
| 窗口解析 | 新增内置常见模型上下文窗口表（家族前缀保守策展）；解析优先级：显式配置精确匹配 > 内置表 > capacity unknown |
| 请求层 | 输入预算按「provider 显式覆盖 > 窗口−输出预留 > 全局缺省 96000」解析；预检超限先强制缩纪元到热水位并重建请求重试一次，仍超限才拒绝；工具循环内逐轮门禁维持中止语义 |
| 重放层 | 投影预算按「仲裁者 − 纪元可见窗上限 − system/工具预留 − 当前 Loop 比例预留」推导，`agent_replay_loop_tokens` 转为推导下限；新增 provider 级硬覆盖；钳制上限 65536 放宽到 4 MiB |
| 精简阶梯 | 首档新增 `native_thinking_stripped`：剥 thinking/thought 部分、保 tool_use/functionCall 配对；其后沿用 native_dropped → 工具结果收紧 → 档案 → 逐出 |
| 纪元层 | 缺省不动；新增 `force_advance_to_hot` 供容量降级路径调用 |

推导数值示例：capacity unknown → 恰为旧值 4096（成本政策不变）；窗口 256k → 约 14.1 万；窗口 1M → 约 76.8 万。

## 验证

- 全项目 pytest：1781 passed（新增 32 个用例：计量口径、解析优先级、推导分支、阶梯首档、纪元口径锁定、force 收敛行为）
- `.venv/bin/ruff check .` 通过；`scripts/ci/validate_toml_examples.py` 12 文件通过
- 未验证项：service 预检降级路径无服务级集成测试（epoch/budget 组件级单测覆盖，接线留待 dogfood smoke）；真实 provider smoke 未执行

## 评审

按 Huge PR 执行 Tier 2 Deep-CR（五透镜 + 交叉复核），结论将汇总至本 PR 评论。

## Changelog 草稿

**变更**
- Agent Loop 历史重放的预算口径修复与重标定：协议原生内容块（含 Claude/Gemini 的完整思考链）现计入重放投影预算与最终请求预算的 token 估算，wire part 数计入条目兜底；此前原生路径的重放内容不参与任何预算计量。
- 请求输入预算按「provider 显式覆盖 > 模型上下文窗口推导 > 全局缺省 96000」解析；窗口已知时按真实窗口减输出预留与比例估算余量仲裁。
- 历史 Loop 重放投影预算按窗口推导（此前固定 4096 总量），配置了模型容量的 provider 自动放大到窗口量级；`agent_replay_loop_tokens` 转为推导下限，新增 provider 级同名硬覆盖。
- 新增内置常见模型上下文窗口表（按家族前缀保守解析，显式配置优先），未命中模型仍按 capacity unknown 处理。
- 重放精简阶梯新增首档「原生块剥思考」：保工具调用结构与配对，仅剥离 thinking/thought 部分。
- 请求预算超限时先把纪元窗口缩到热水位并重建请求重试一次，仍超限才提示清空上下文；工具循环内的逐轮预算门禁维持中止语义。
- 纪元窗口缺省参数保持不变；纪元预算继续只计量可见消息行，历史思考链不参与纪元推进。

**修复**
- 最终请求预算与模块契约声明不一致的问题：原生块此前未计入估算，配置了模型容量的场景下可能放行超出模型上下文的请求。
