### PR TITLE
fix(llm): keep reply on no-record fallback with delivery enabled

### DIFF
--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -1657,8 +1657,10 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 result_payload = dict(result_payload)
                 result_payload["agent_turn_row_id"] = recorder.final_turn_record.message_row_id
                 result_payload["scope_key"] = scope_key
-        if self.config.runtime.agent_delivery_enabled:
+        if recorder is not None and self.config.runtime.agent_delivery_enabled:
             # 逐 Turn 模式：正文已由 sink 交付，reply 不再二次发送（§5.1）。
+            # 无记录路径（同 scope 并发触发 / store 不可用）没有任何 sink 交付，
+            # reply 仍是唯一出口，置空会把整条回复静默吞掉。
             result_payload = dict(result_payload)
             result_payload["reply"] = ""
         return result_payload

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -1563,8 +1563,12 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         except DeliveryAborted as exc:
             if recorder is not None:
                 recorder.close(LoopStatus.INTERRUPTED, str(exc) or "delivery_aborted")
+            # 逐 Turn 模式下静默：已交付的分段就是用户看到的全部。无记录路径
+            # 同样可能在这里终止（逐轮预算门禁不依赖 recorder），但它没有任何
+            # sink 交付，必须给出可见的中止提示而不是空串。
+            aborted_silently = recorder is not None and self.config.runtime.agent_delivery_enabled
             return {
-                "reply": "" if self.config.runtime.agent_delivery_enabled else "本次回复未确认送达，已停止后续生成。",
+                "reply": "" if aborted_silently else "本次回复未确认送达，已停止后续生成。",
                 "rate_limit_key": LLM_RULE_NAME,
                 "rule_name": LLM_RULE_NAME,
                 "llm_used": True,

--- a/tests/integration/test_agent_loop_delivery_failure.py
+++ b/tests/integration/test_agent_loop_delivery_failure.py
@@ -150,3 +150,41 @@ async def test_middle_chunk_failure_keeps_earlier_facts(tmp_path: Path, patch_pr
     # 前两轮正文 = fixture 前两 Turn。
     assert sink.attempts[0][1][:20] == FIVE_TURN_TEXTS[0][:20]
     assert sink.attempts[1][1][:20] == FIVE_TURN_TEXTS[1][:20]
+
+
+async def test_no_record_fallback_keeps_reply_when_delivery_enabled(
+    tmp_path: Path, patch_provider_builder
+):
+    """同 scope 已有未关闭 Loop（并发触发）时退回无记录路径：reply 必须保留。
+
+    无记录路径没有 sink 交付，最终正文只能靠 reply 单次发送；逐 Turn 开关
+    不得在这条路径上把 reply 置空（2026-09-07 生产回归：同群并发触发的第二
+    条回复被静默吞掉）。
+    """
+    from quickquip.llm.agent_records import TriggerKind
+    from quickquip.llm.store_parts.agent_records import UserTriggerPayload
+    from tests.fixtures.agent_loop import CollectingSink, FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    service.config.runtime.agent_delivery_enabled = True
+    sink = CollectingSink()
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+    # 模拟同群另一条触发仍在跑：scope 1001 上留一个未关闭 Loop。
+    generation, _ = service.store.agent_scope_state("1001")
+    service.store.begin_loop(
+        "1001", generation, TriggerKind.GROUP_DIRECT,
+        UserTriggerPayload(user_id="3003", sender_name="先手", content="先来的那条"),
+    )
+
+    result = await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+
+    assert len(client.requests) == 5  # 完整跑完五 Turn
+    assert sink.deliveries == []  # 无记录路径不经 sink
+    assert result["reply"] == FIVE_TURN_TEXTS[4]
+    with service.store._connect() as conn:
+        loop_count = conn.execute("SELECT COUNT(*) FROM agent_loops").fetchone()[0]
+    assert loop_count == 1  # 只有占位 Loop，本轮未建新 Loop

--- a/tests/integration/test_agent_loop_delivery_failure.py
+++ b/tests/integration/test_agent_loop_delivery_failure.py
@@ -188,3 +188,48 @@ async def test_no_record_fallback_keeps_reply_when_delivery_enabled(
     with service.store._connect() as conn:
         loop_count = conn.execute("SELECT COUNT(*) FROM agent_loops").fetchone()[0]
     assert loop_count == 1  # 只有占位 Loop，本轮未建新 Loop
+
+
+async def test_no_record_fallback_surfaces_abort_when_delivery_enabled(
+    tmp_path: Path, patch_provider_builder, monkeypatch
+):
+    """无记录路径上逐轮预算门禁触发 DeliveryAborted：必须给出可见提示而非空串。
+
+    门禁不依赖 recorder，所以并发退化的那轮同样可能中途超限；该轮没有任何
+    sink 交付，若沿逐 Turn 模式静默处理，用户什么都收不到。
+    """
+    import quickquip.llm.service as service_module
+    from quickquip.llm.agent_records import TriggerKind
+    from quickquip.llm.request_budget import RequestBudgetExceeded
+    from quickquip.llm.store_parts.agent_records import UserTriggerPayload
+    from tests.fixtures.agent_loop import CollectingSink, FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    service.config.runtime.agent_delivery_enabled = True
+    sink = CollectingSink()
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+    generation, _ = service.store.agent_scope_state("1001")
+    service.store.begin_loop(
+        "1001", generation, TriggerKind.GROUP_DIRECT,
+        UserTriggerPayload(user_id="3003", sender_name="先手", content="先来的那条"),
+    )
+    # 预检与逐轮门禁共用 enforce_request_budget：前两次放行（预检 + 第一轮），
+    # 第三次（工具结果撑大请求后的第二轮）超限。
+    calls = {"n": 0}
+
+    def _budget(config, provider, request):
+        calls["n"] += 1
+        if calls["n"] >= 3:
+            raise RequestBudgetExceeded("input 9999 > budget 1")
+
+    monkeypatch.setattr(service_module, "enforce_request_budget", _budget)
+
+    result = await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+
+    assert len(client.requests) == 1  # 第二轮被门禁拦下
+    assert sink.deliveries == []
+    assert result["reply"] == "本次回复未确认送达，已停止后续生成。"


### PR DESCRIPTION
## 问题

开启 `agent_delivery_enabled` 后，同 scope 并发触发会让 `begin_loop` 抛 `LoopNotWritable`，本轮退回无记录路径（无 TurnRecorder）。该路径没有任何 sink 交付，但 `generate_reply` 末尾仍按开关无条件把 `reply` 置空，于是整条回复静默丢失。2026-09-07 生产试运行中同群并发触发的回复 3/6 丢失，已回滚。

## 修复

- `service.py`：置空 `reply` 增加 `recorder is not None` 前置条件。无记录路径下 reply 仍是唯一出口。
- 新增集成测试：在 scope 上留一个未关闭 Loop 模拟并发，开着交付开关跑五 Turn 剧本，断言 sink 无交付、`reply` 为末 Turn 全文、未新建 Loop。修复前该测试失败（`reply == ""`）。

无记录路径的其他行为不变（无 Loop 记录、历史不带工具事实，等同 1.14 行为）；并发触发按 scope 排队属另一议题。

## 验证

- 新测试修复前失败、修复后通过
- `pytest -n auto`：1788 passed
- `ruff check .`：clean

## CHANGELOG 条目（fixed）

- 开启逐 Turn 交付后，同群并发触发落入无记录路径的那条回复不再被静默吞掉：无记录路径没有分段交付，最终正文仍按单次发送出口发出。