### PR TITLE
fix(llm): backfill message_id on no-record fallback replies

### DIFF
--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -1157,6 +1157,9 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             "llm_used": True,
             "provider_id": provider.id,
             "model": model,
+            # 发送回执按群回填无记录路径的 assistant 行（无 agent_turn_row_id 时
+            # record_final_receipt 依赖此键定位）
+            "scope_key": scope_key,
             # 工具外发图片（base64 PNG），适配层拼在文本后发送；上限见 MAX_OUTBOUND_TOOL_IMAGES
             "images": outbound_images_payload(tool_context),
         }
@@ -1660,7 +1663,6 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             if recorder.final_turn_record is not None:
                 result_payload = dict(result_payload)
                 result_payload["agent_turn_row_id"] = recorder.final_turn_record.message_row_id
-                result_payload["scope_key"] = scope_key
         if recorder is not None and self.config.runtime.agent_delivery_enabled:
             # 逐 Turn 模式：正文已由 sink 交付，reply 不再二次发送（§5.1）。
             # 无记录路径（同 scope 并发触发 / store 不可用）没有任何 sink 交付，

--- a/tests/integration/test_agent_loop_baseline.py
+++ b/tests/integration/test_agent_loop_baseline.py
@@ -102,6 +102,9 @@ async def test_final_only_mode_records_every_turn_and_sends_final(
     assert [row["content"] for row in assistant_rows] == list(FIVE_TURN_TEXTS)
     # 最终正文沿现有单次交付方式。
     assert result["reply"] == FIVE_TURN_TEXTS[4]
+    # 带 recorder 的路径：精确回填行号与按群回退键同时携带。
+    assert result["agent_turn_row_id"] is not None
+    assert result["scope_key"] == "1001"
     # 非最终正文标记 suppressed_by_policy；最终 Turn 在关闭模式下不建交付行
     #（最终正文沿现有单次交付，回执由兼容列回填记录）。
     with scenario_service.store._connect() as conn:

--- a/tests/integration/test_agent_loop_delivery_failure.py
+++ b/tests/integration/test_agent_loop_delivery_failure.py
@@ -185,9 +185,49 @@ async def test_no_record_fallback_keeps_reply_when_delivery_enabled(
     assert len(client.requests) == 5  # 完整跑完五 Turn
     assert sink.deliveries == []  # 无记录路径不经 sink
     assert result["reply"] == FIVE_TURN_TEXTS[4]
+    # 回执按群回填的钥匙必须携带；无 recorder 行号，精确回填键不出现。
+    assert result["scope_key"] == "1001"
+    assert "agent_turn_row_id" not in result
     with service.store._connect() as conn:
         loop_count = conn.execute("SELECT COUNT(*) FROM agent_loops").fetchone()[0]
     assert loop_count == 1  # 只有占位 Loop，本轮未建新 Loop
+
+
+async def test_no_record_fallback_receipt_backfills_assistant_row(
+    tmp_path: Path, patch_provider_builder
+):
+    """无记录路径的发送回执：按 scope 回填刚插入的 assistant 行 message_id。
+
+    2026-09-07 生产回归：该路径返回值缺 scope_key，record_final_receipt 两个
+    分支都拿不到钥匙，撤回遮蔽/引用定位按回执找不到这条消息。
+    """
+    from quickquip.adapters.nonebot._llm_reply import record_final_receipt
+    from quickquip.llm.agent_records import TriggerKind
+    from quickquip.llm.store_parts.agent_records import UserTriggerPayload
+    from tests.fixtures.agent_loop import CollectingSink, FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    service.config.runtime.agent_delivery_enabled = True
+    service.bind_delivery_sink(CollectingSink())
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+    generation, _ = service.store.agent_scope_state("1001")
+    service.store.begin_loop(
+        "1001", generation, TriggerKind.GROUP_DIRECT,
+        UserTriggerPayload(user_id="3003", sender_name="先手", content="先来的那条"),
+    )
+
+    result = await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+    record_final_receipt(service, result, "qq-77")
+
+    with service.store._connect() as conn:
+        row = conn.execute(
+            "SELECT message_id FROM conversation_messages"
+            " WHERE role='assistant' ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    assert row["message_id"] == "qq-77"
 
 
 async def test_no_record_fallback_surfaces_abort_when_delivery_enabled(


### PR DESCRIPTION
## 问题

开启 `agent_delivery_enabled` 的 1.15 试运行中，同 scope 并发触发会退回无记录路径：回复经 `reply` 单次发送成功，但 `conversation_messages` 里这条 assistant 行的 `message_id` 始终为 NULL，撤回遮蔽与引用定位按发送回执找不到它。带 recorder 的同批回复均正常回填，属低严重度 1.15 回归。

## 根因

无记录路径的 assistant 行由 `_persist_turn_and_build_reply` 以旧方式插入，其返回字典不含 `scope_key`；`record_final_receipt` 的两个回填分支（`agent_turn_row_id` 精确回填 / `scope_key` 按群回填）都拿不到钥匙，于是什么都不做。1.14.3 适配层发送成功后无条件按群回填，该路径总能落 id。

## 修复

- `service.py`：`_persist_turn_and_build_reply` 返回字典加 `scope_key`。该函数只在真的插入了 assistant 行的路径被调用，按群回填必命中刚插入的行；recorder 路径冗余的 `scope_key` 赋值删除，`agent_turn_row_id` 精确回填优先级不变。
- 错误分支（`DeliveryAborted` / `LLMProviderError` / `Exception`）返回值刻意不带 `scope_key`：错误提示没有对应 assistant 行，按群回填会把 id 错盖到更早的 NULL 行（1.14 的老毛病，1.15 精确回填设计正为避开它）。

## 测试

- 现有 `test_no_record_fallback_keeps_reply_when_delivery_enabled` 追加断言：`scope_key` 在、`agent_turn_row_id` 不在。
- 新增 `test_no_record_fallback_receipt_backfills_assistant_row`：占位 Loop 逼出无记录路径，`record_final_receipt` 回填后断言最新 assistant 行 `message_id` 为发送 ID（合成 ID）。修复前失败。
- baseline `test_final_only_mode_records_every_turn_and_sends_final` 补断言：带 recorder 路径同时携带 `agent_turn_row_id` 与 `scope_key`。

## 验证

- 新测试修复前失败、修复后通过（stash 摘除修复验证）
- `pytest -n auto`：1790 passed（基线 1789）
- `ruff check .`：clean；pre-push 全量钩子（type-check、示例配置校验）通过

## CHANGELOG 条目（fixed）

- 无记录路径发出的回复现在同样回填消息 ID，撤回遮蔽与引用定位能找到这条消息。