### PR TITLE
feat(llm): per-scope agent delivery opt-in with /llm delivery command

### DIFF
--- a/config/llm.toml.example
+++ b/config/llm.toml.example
@@ -50,9 +50,10 @@ tool_max_calls_per_round = 16
 # agent_record_max_loops_per_scope = 1000
 # agent_record_max_bytes_per_scope = 67108864
 
-# 逐 Turn 交付（默认关闭：安装新版本不改变群内消息量；记录与重放始终工作）
+# 逐 Turn 交付（全局默认关闭：安装新版本不改变群内消息量；记录与重放始终工作）
 # 开启后每次模型响应的普通正文先于工具执行分段外发；阈值/上限为 Unicode
 # code point 口径，独立于 OneBot 协议报文长度限制。
+# 各群/私聊会话可用 /llm delivery on|off|reset|status 按会话覆盖此默认。
 # agent_delivery_enabled = false
 # reply_split_threshold_chars = 800
 # reply_chunk_max_chars = 1200

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -139,7 +139,7 @@ GHCR 分发镜像和 `prod.example/Dockerfile` 均基于 Playwright Python 镜�
 | `agent_record_max_loops_per_scope` | 每会话已关闭 Loop 数量上限，先触顶者触发清理最旧完整 Loop | `1000` |
 | `agent_record_max_bytes_per_scope` | 每会话 Loop 业务记录字节上限（UTF-8 计量） | `67108864` |
 | `agent_replay_loop_tokens` | 历史 Loop 重放投影预算的推导下限（token 估算，512-4194304）：实际预算按「请求输入预算 − 纪元可见窗上限 − system/工具预留 − 当前 Loop 比例预留」推导（配置了模型容量的 provider 自动放大到窗口量级），超限按固定阶梯确定性精简（先剥原生 thinking，再丢原生副本，再收工具结果）；可在 `[[providers]]` 段按 provider 硬覆盖 | `4096` |
-| `agent_delivery_enabled` | 逐 Turn 交付开关：开启后每次模型响应的普通正文先于工具执行分段外发；关闭时仅最终正文单发，记录不受影响 | `false` |
+| `agent_delivery_enabled` | 逐 Turn 交付的全局默认：开启后每次模型响应的普通正文先于工具执行分段外发；关闭时仅最终正文单发，记录不受影响。各群/私聊会话可用 `/llm delivery on/off/reset/status` 或 Web Admin「群设置」按会话覆盖 | `false` |
 | `reply_split_threshold_chars` | 回复超过该长度（Unicode code point）才进行自然分段 | `800` |
 | `reply_chunk_max_chars` | 单段源文本上限，独立于 OneBot 协议报文长度 | `1200` |
 | `reply_send_interval_ms` | 同会话相邻发送开始时间的最小间隔（0-10000） | `800` |

--- a/docs/user/group-commands.md
+++ b/docs/user/group-commands.md
@@ -146,6 +146,7 @@ QuickQuip 在群里有两类能力：规则回复（复读、接龙、时区猜�
 | `/llm trigger at on / off` | 开关艾特触发（仅群聊有此命令） |
 | `/llm memory on / off` | 开关记忆注入 |
 | `/llm auto_memory on / off / reset / status` | 自动记忆抽取的开关、跟随全局默认、查看 |
+| `/llm delivery on / off / reset / status` | 分段发送（长回复按自然段拆成多条消息）的开关、跟随全局默认、查看；默认关闭 |
 | `/llm context_limit <条数>`（`reset` 或 `off` 恢复默认） | 把本群上下文改为固定保留最新 n 条（上限 1024；默认由会话纪元自动管理，窗口随对话增长、冷场后收缩）；重启和 `/llm clear_context` 不影响此设置 |
 | `/llm clear_context` | 清空本群短期上下文，AI“串台”或记错上下文时用 |
 | `/llm delete_msg` | 引用一条消息发送本命令，或 `/llm delete_msg <消息ID>`，从上下文删除该条 |

--- a/docs/user/private-commands.md
+++ b/docs/user/private-commands.md
@@ -64,6 +64,7 @@ provider 指 AI 的服务来源（如 Gemini、OpenAI），一个 provider 下�
 | `/llm trigger prefix_mode on / off` | 开关前缀触发 |
 | `/llm memory on / off` | 开关记忆注入 |
 | `/llm auto_memory on / off / reset / status` | 自动记忆抽取的开关、重置为全局默认、查看 |
+| `/llm delivery on / off / reset / status` | 分段发送（长回复按自然段拆成多条消息）的开关、重置为全局默认、查看；默认关闭 |
 | `/llm context_limit <条数>`（`reset` 或 `off` 恢复默认） | 把本会话改为固定保留最新 n 条（上限 1024；默认由会话纪元自动管理） |
 | `/llm clear_context` | 清空短期上下文，“串台”或记错上下文时用 |
 | `/llm delete_msg` | 引用一条消息发送本命令，或 `/llm delete_msg <消息ID>`，从上下文删除该条 |

--- a/frontend/src/api/groupSettings.ts
+++ b/frontend/src/api/groupSettings.ts
@@ -5,6 +5,7 @@ export type GroupOverrideField =
   | 'enabled'
   | 'memory_enabled'
   | 'auto_memory_enabled'
+  | 'agent_delivery_enabled'
   | 'provider_id'
   | 'model'
   | 'persona_id'
@@ -28,6 +29,7 @@ export interface GroupOverrideDraft {
   enabled: boolean | null
   memory_enabled: boolean | null
   auto_memory_enabled: boolean | null
+  agent_delivery_enabled: boolean | null
   provider_id: string | null
   model: string | null
   persona_id: string | null
@@ -70,6 +72,7 @@ export interface GroupSettingsDefaults {
   enabled?: boolean
   memory_enabled?: boolean
   auto_memory_enabled?: boolean
+  agent_delivery_enabled?: boolean
   provider_id?: string | null
   persona_id?: string | null
   trigger_prefix?: string | null

--- a/frontend/src/composables/useGroupOverrideDraft.ts
+++ b/frontend/src/composables/useGroupOverrideDraft.ts
@@ -8,7 +8,7 @@ import type {
 
 /** 可编辑字段表：草稿/原始快照/diff 的键集合唯一来源 */
 const FIELDS: readonly GroupOverrideField[] = [
-  'enabled', 'memory_enabled', 'auto_memory_enabled', 'provider_id', 'model', 'persona_id',
+  'enabled', 'memory_enabled', 'auto_memory_enabled', 'agent_delivery_enabled', 'provider_id', 'model', 'persona_id',
   'trigger_prefix', 'allow_prefix', 'allow_at', 'history_limit',
 ]
 

--- a/frontend/src/views/GroupSettingsView.vue
+++ b/frontend/src/views/GroupSettingsView.vue
@@ -93,7 +93,7 @@
 
           <section class="form-section">
             <h4>运行状态</h4>
-            <div class="form-grid form-grid--three">
+            <div class="form-grid">
               <div class="field">
                 <label>LLM 启用</label>
                 <select v-model="draftTriState.enabled">
@@ -114,6 +114,14 @@
                 <label>自动记忆抽取<UiInfoTip text="开启后自动从该会话的对话中提炼记忆条目，结果可在「记忆」页查看与编辑。" /></label>
                 <select v-model="draftTriState.auto_memory_enabled">
                   <option :value="null">跟随默认（{{ defaultHint('auto_memory_enabled') }}）</option>
+                  <option :value="true">开</option>
+                  <option :value="false">关</option>
+                </select>
+              </div>
+              <div class="field">
+                <label>分段发送<UiInfoTip text="开启后该会话的 LLM 回复按自然段拆成多条消息发出；关闭时长回复合并为一条。全局默认在 llm.toml 的 agent_delivery_enabled 配置。" /></label>
+                <select v-model="draftTriState.agent_delivery_enabled">
+                  <option :value="null">跟随默认（{{ defaultHint('agent_delivery_enabled') }}）</option>
                   <option :value="true">开</option>
                   <option :value="false">关</option>
                 </select>
@@ -575,10 +583,6 @@ reloadAll()
   gap: var(--qq-gap-md);
 }
 
-.form-grid--three {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
 .field {
   display: flex;
   min-width: 0;
@@ -623,8 +627,7 @@ reloadAll()
   }
 
   .default-strip,
-  .form-grid,
-  .form-grid--three {
+  .form-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/src/quickquip/adapters/nonebot/command_parts/llm.py
+++ b/src/quickquip/adapters/nonebot/command_parts/llm.py
@@ -213,6 +213,26 @@ def register_llm_commands(on_command, Message, MessageSegment) -> None:
                     f"{scope_label}自动记忆抽取：{current}（全局默认 {default}）"
                 )
 
+        if tokens[:1] == ["delivery"] and len(tokens) >= 2:
+            sub = tokens[1].lower()
+            if sub == "on":
+                svc.set_chat_agent_delivery_enabled(chat_id, True, chat_type=chat_type)
+                await llm_cmd.finish(f"{scope_label}分段发送已开启")
+            if sub == "off":
+                svc.set_chat_agent_delivery_enabled(chat_id, False, chat_type=chat_type)
+                await llm_cmd.finish(f"{scope_label}分段发送已关闭")
+            if sub == "reset":
+                svc.set_chat_agent_delivery_enabled(chat_id, None, chat_type=chat_type)
+                default = "开" if svc.config.runtime.agent_delivery_enabled else "关"
+                await llm_cmd.finish(f"{scope_label}分段发送已跟随全局默认（当前：{default}）")
+            if sub == "status":
+                settings = svc.get_chat_settings(chat_id, chat_type=chat_type)
+                default = "开" if svc.config.runtime.agent_delivery_enabled else "关"
+                current = "开" if settings.agent_delivery_enabled else "关"
+                await llm_cmd.finish(
+                    f"{scope_label}分段发送：{current}（全局默认 {default}）"
+                )
+
         if tokens[:1] == ["context_limit"] and len(tokens) >= 2:
             value = tokens[1].lower()
             if value in {"reset", "off"}:
@@ -234,7 +254,8 @@ def register_llm_commands(on_command, Message, MessageSegment) -> None:
         await llm_cmd.finish(
             "LLM 命令用法：/llm status|current|on|off|providers|probe|models [provider]|use <provider> [model]|"
             "personas|persona use <id>|trigger prefix <value>|trigger prefix_mode on|off|trigger at on|off|"
-            "memory status|memory on|memory off|auto_memory on|off|reset|status|context_limit <n>|context_limit reset|clear_context|reload|mcp status"
+            "memory status|memory on|memory off|auto_memory on|off|reset|status|delivery on|off|reset|status|"
+            "context_limit <n>|context_limit reset|clear_context|reload|mcp status"
         )
 
     search_cmd = on_command("search", priority=10, block=True)

--- a/src/quickquip/app/web/routes/group_settings.py
+++ b/src/quickquip/app/web/routes/group_settings.py
@@ -39,6 +39,7 @@ class GroupSettingsBody(BaseModel):
     enabled: bool | None = None
     memory_enabled: bool | None = None
     auto_memory_enabled: bool | None = None
+    agent_delivery_enabled: bool | None = None
     provider_id: str | None = Field(default=None, max_length=64)
     model: str | None = Field(default=None, max_length=128)
     persona_id: str | None = Field(default=None, max_length=64)
@@ -76,6 +77,7 @@ def get_options():
         "enabled": cfg.runtime.enabled,
         "memory_enabled": cfg.runtime.memory_enabled,
         "auto_memory_enabled": cfg.runtime.auto_memory_enabled,
+        "agent_delivery_enabled": cfg.runtime.agent_delivery_enabled,
         "provider_id": cfg.runtime.default_provider,
         "persona_id": cfg.runtime.default_persona,
         "trigger_prefix": cfg.triggers.default_prefix,
@@ -99,6 +101,7 @@ def _format_group_entry(group_id: str, row) -> dict:
         "enabled": None,
         "memory_enabled": None,
         "auto_memory_enabled": None,
+        "agent_delivery_enabled": None,
         "provider_id": None,
         "model": None,
         "persona_id": None,
@@ -113,6 +116,7 @@ def _format_group_entry(group_id: str, row) -> dict:
             "enabled": None if row["enabled"] is None else bool(row["enabled"]),
             "memory_enabled": None if row["memory_enabled"] is None else bool(row["memory_enabled"]),
             "auto_memory_enabled": None if row["auto_memory_enabled"] is None else bool(row["auto_memory_enabled"]),
+            "agent_delivery_enabled": None if row["agent_delivery_enabled"] is None else bool(row["agent_delivery_enabled"]),
             "provider_id": row["provider_id"],
             "model": row["model"],
             "persona_id": row["persona_id"],
@@ -139,7 +143,7 @@ def list_group_settings():
         with store._connect() as conn:
             rows = conn.execute(
                 """
-                SELECT group_id, enabled, memory_enabled, auto_memory_enabled, provider_id, model, persona_id,
+                SELECT group_id, enabled, memory_enabled, auto_memory_enabled, agent_delivery_enabled, provider_id, model, persona_id,
                        trigger_prefix, allow_prefix, allow_at, history_limit, updated_at
                 FROM group_settings
                 ORDER BY updated_at DESC

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -695,7 +695,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         image_descriptions: list[ImageDescription] | None,
         delivery_sink=None,
         trigger_kind: TriggerKind | None = None,
-        agent_delivery_enabled: bool = False,
+        agent_delivery_enabled: bool,
     ):
         """创建 Loop 与 user 触发行（§5.3.1），返回 TurnRecorder。
 

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -695,6 +695,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         image_descriptions: list[ImageDescription] | None,
         delivery_sink=None,
         trigger_kind: TriggerKind | None = None,
+        agent_delivery_enabled: bool = False,
     ):
         """创建 Loop 与 user 触发行（§5.3.1），返回 TurnRecorder。
 
@@ -752,7 +753,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             store=self.store,
             handle=handle,
             config=RecorderConfig(
-                agent_delivery_enabled=runtime.agent_delivery_enabled,
+                agent_delivery_enabled=agent_delivery_enabled,
                 reply_split_threshold_chars=runtime.reply_split_threshold_chars,
                 reply_chunk_max_chars=runtime.reply_chunk_max_chars,
                 reply_max_chunks_per_loop=runtime.reply_max_chunks_per_loop,
@@ -1536,6 +1537,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 # 同 _persist_turn_and_build_reply 的落库口径：他人近期图注不落触发者名下。
                 image_descriptions=[d for d in image_descriptions if not d.context_label.startswith(RECENT_IMAGE_CONTEXT_PREFIX)] or None,
                 delivery_sink=delivery_sink,
+                agent_delivery_enabled=settings.agent_delivery_enabled,
             )
             with (
                 usage_scope("chat", group_id=scope_key, persona_id=settings.persona_id or None),
@@ -1569,7 +1571,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             # 逐 Turn 模式下静默：已交付的分段就是用户看到的全部。无记录路径
             # 同样可能在这里终止（逐轮预算门禁不依赖 recorder），但它没有任何
             # sink 交付，必须给出可见的中止提示而不是空串。
-            aborted_silently = recorder is not None and self.config.runtime.agent_delivery_enabled
+            aborted_silently = recorder is not None and settings.agent_delivery_enabled
             return {
                 "reply": "" if aborted_silently else "本次回复未确认送达，已停止后续生成。",
                 "rate_limit_key": LLM_RULE_NAME,
@@ -1663,7 +1665,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             if recorder.final_turn_record is not None:
                 result_payload = dict(result_payload)
                 result_payload["agent_turn_row_id"] = recorder.final_turn_record.message_row_id
-        if recorder is not None and self.config.runtime.agent_delivery_enabled:
+        if recorder is not None and settings.agent_delivery_enabled:
             # 逐 Turn 模式：正文已由 sink 交付，reply 不再二次发送（§5.1）。
             # 无记录路径（同 scope 并发触发 / store 不可用）没有任何 sink 交付，
             # reply 仍是唯一出口，置空会把整条回复静默吞掉。

--- a/src/quickquip/llm/service_parts/state.py
+++ b/src/quickquip/llm/service_parts/state.py
@@ -128,6 +128,12 @@ class StateMixin:
         value = None if enabled is None else int(enabled)
         self._update_chat_settings(chat_id, chat_type, auto_memory_enabled=value)
 
+    def set_chat_agent_delivery_enabled(
+        self, chat_id: int | str, enabled: bool | None, chat_type: str = "group"
+    ) -> None:
+        value = None if enabled is None else int(enabled)
+        self._update_chat_settings(chat_id, chat_type, agent_delivery_enabled=value)
+
     def set_chat_history_limit(self, chat_id: int | str, limit: int, chat_type: str = "group") -> None:
         self._update_chat_settings(chat_id, chat_type, history_limit=limit)
 

--- a/src/quickquip/llm/settings.py
+++ b/src/quickquip/llm/settings.py
@@ -15,6 +15,7 @@ class ResolvedGroupSettings:
     allow_prefix: bool
     allow_at: bool
     history_limit: int | None = None
+    agent_delivery_enabled: bool = False
 
 
 def resolve_group_settings(store, config, group_id: int | str) -> ResolvedGroupSettings:
@@ -34,6 +35,11 @@ def resolve_group_settings(store, config, group_id: int | str) -> ResolvedGroupS
             overrides.auto_memory_enabled
             if overrides.auto_memory_enabled is not None
             else config.runtime.auto_memory_enabled
+        ),
+        agent_delivery_enabled=(
+            overrides.agent_delivery_enabled
+            if overrides.agent_delivery_enabled is not None
+            else config.runtime.agent_delivery_enabled
         ),
         provider_id=provider_id,
         model=model,

--- a/src/quickquip/llm/store_parts/_base.py
+++ b/src/quickquip/llm/store_parts/_base.py
@@ -58,6 +58,7 @@ class GroupSettingsOverride:
     enabled: bool | None = None
     memory_enabled: bool | None = None
     auto_memory_enabled: bool | None = None
+    agent_delivery_enabled: bool | None = None
     provider_id: str | None = None
     model: str | None = None
     persona_id: str | None = None
@@ -114,6 +115,8 @@ class _StoreBase:
                     group_id TEXT PRIMARY KEY,
                     enabled INTEGER,
                     memory_enabled INTEGER,
+                    auto_memory_enabled INTEGER,
+                    agent_delivery_enabled INTEGER,
                     provider_id TEXT,
                     model TEXT,
                     persona_id TEXT,
@@ -178,6 +181,8 @@ class _StoreBase:
                 conn.execute("ALTER TABLE group_settings ADD COLUMN history_limit INTEGER")
             if "auto_memory_enabled" not in existing_columns:
                 conn.execute("ALTER TABLE group_settings ADD COLUMN auto_memory_enabled INTEGER")
+            if "agent_delivery_enabled" not in existing_columns:
+                conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_enabled INTEGER")
             conversation_columns = {
                 row["name"]
                 for row in conn.execute("PRAGMA table_info(conversation_messages)").fetchall()

--- a/src/quickquip/llm/store_parts/group_settings.py
+++ b/src/quickquip/llm/store_parts/group_settings.py
@@ -14,7 +14,7 @@ class GroupSettingsMixin:
         with self._connect() as conn:
             row = conn.execute(
                 """
-                SELECT enabled, memory_enabled, auto_memory_enabled, provider_id, model, persona_id, trigger_prefix, allow_prefix, allow_at, history_limit
+                SELECT enabled, memory_enabled, auto_memory_enabled, agent_delivery_enabled, provider_id, model, persona_id, trigger_prefix, allow_prefix, allow_at, history_limit
                 FROM group_settings
                 WHERE group_id = ?
                 """,
@@ -26,6 +26,7 @@ class GroupSettingsMixin:
             enabled=None if row["enabled"] is None else bool(row["enabled"]),
             memory_enabled=None if row["memory_enabled"] is None else bool(row["memory_enabled"]),
             auto_memory_enabled=None if row["auto_memory_enabled"] is None else bool(row["auto_memory_enabled"]),
+            agent_delivery_enabled=None if row["agent_delivery_enabled"] is None else bool(row["agent_delivery_enabled"]),
             provider_id=row["provider_id"],
             model=row["model"],
             persona_id=row["persona_id"],
@@ -43,6 +44,7 @@ class GroupSettingsMixin:
             "enabled",
             "memory_enabled",
             "auto_memory_enabled",
+            "agent_delivery_enabled",
             "provider_id",
             "model",
             "persona_id",

--- a/tests/integration/test_agent_delivery_optin.py
+++ b/tests/integration/test_agent_delivery_optin.py
@@ -1,0 +1,84 @@
+"""按会话 opt-in 的分段交付：三态覆盖优先于全局默认，两个方向都验证。
+
+覆盖开/关优先于全局；未覆盖（reset/NULL）跟随全局默认。与
+test_agent_loop_baseline.py 的差别：那边钉全局开关的行为，这边钉
+per-scope 覆盖的解析与生效。每次运行用独立 scope：五 Turn 剧本客户端
+按请求内 assistant 行数计轮次，同 scope 复跑会耗尽剧本。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from plugins.llm_runtime import LLMService
+from tests.fixtures.agent_loop import (
+    AGENT_LOOP_TEST_SPLIT,
+    FIVE_TURN_TEXTS,
+    CollectingSink,
+    FiveTurnScenarioClient,
+)
+from tests.fixtures.configs import write_llm_config_bundle
+
+
+async def _service(tmp_path: Path) -> LLMService:
+    paths = write_llm_config_bundle(
+        tmp_path,
+        config_toml=write_llm_config_bundle.__globals__["MIN_LLM_CONFIG_TOML"].replace(
+            "tool_max_rounds = 2", "tool_max_rounds = 8"
+        ),
+    )
+    service = LLMService(**paths)
+    for attr, value in [
+        ("reply_split_threshold_chars", AGENT_LOOP_TEST_SPLIT["threshold"]),
+        ("reply_chunk_max_chars", AGENT_LOOP_TEST_SPLIT["chunk_max"]),
+    ]:
+        setattr(service.config.runtime, attr, value)
+    return service
+
+
+async def _run(service: LLMService, patch_provider_builder, group_id: int) -> tuple[dict, CollectingSink]:
+    sink = CollectingSink()
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+    result = await service.generate_reply(
+        group_id=group_id, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+    return result, sink
+
+
+async def test_delivery_default_off_and_group_override_enables(
+    tmp_path: Path, patch_provider_builder
+):
+    """全局默认关：无覆盖走单发；覆盖开的群分段交付。"""
+    service = await _service(tmp_path)
+
+    result, sink = await _run(service, patch_provider_builder, group_id=1001)
+    assert sink.deliveries == []
+    assert result["reply"] == FIVE_TURN_TEXTS[4]
+    # recorder 仍工作：精确回填键齐全（关闭模式沿现有单发交付）。
+    assert result["agent_turn_row_id"] is not None
+    assert result["scope_key"] == "1001"
+
+    service.set_chat_agent_delivery_enabled(1002, True, chat_type="group")
+    result2, sink2 = await _run(service, patch_provider_builder, group_id=1002)
+    assert len(sink2.deliveries) == 7
+    assert result2["reply"] == ""
+
+
+async def test_delivery_override_false_beats_global_on_and_reset_follows(
+    tmp_path: Path, patch_provider_builder
+):
+    """群覆盖关优先于全局开；清空覆盖后跟随全局。"""
+    service = await _service(tmp_path)
+    service.config.runtime.agent_delivery_enabled = True
+
+    service.set_chat_agent_delivery_enabled(1001, False, chat_type="group")
+    result, sink = await _run(service, patch_provider_builder, group_id=1001)
+    assert sink.deliveries == []
+    assert result["reply"] == FIVE_TURN_TEXTS[4]
+
+    service.set_chat_agent_delivery_enabled(1001, None, chat_type="group")
+    assert service.store.get_group_settings("1001").agent_delivery_enabled is None
+    result2, sink2 = await _run(service, patch_provider_builder, group_id=1003)
+    assert len(sink2.deliveries) == 7
+    assert result2["reply"] == ""

--- a/tests/integration/test_agent_delivery_optin.py
+++ b/tests/integration/test_agent_delivery_optin.py
@@ -16,15 +16,13 @@ from tests.fixtures.agent_loop import (
     CollectingSink,
     FiveTurnScenarioClient,
 )
-from tests.fixtures.configs import write_llm_config_bundle
+from tests.fixtures.configs import MIN_LLM_CONFIG_TOML, write_llm_config_bundle
 
 
 async def _service(tmp_path: Path) -> LLMService:
     paths = write_llm_config_bundle(
         tmp_path,
-        config_toml=write_llm_config_bundle.__globals__["MIN_LLM_CONFIG_TOML"].replace(
-            "tool_max_rounds = 2", "tool_max_rounds = 8"
-        ),
+        config_toml=MIN_LLM_CONFIG_TOML.replace("tool_max_rounds = 2", "tool_max_rounds = 8"),
     )
     service = LLMService(**paths)
     for attr, value in [

--- a/tests/unit/llm/test_store.py
+++ b/tests/unit/llm/test_store.py
@@ -303,6 +303,16 @@ def test_group_settings_bool_conversion(store: LLMStore) -> None:
     assert override.allow_at is False
 
 
+def test_group_settings_agent_delivery_roundtrip(store: LLMStore) -> None:
+    store.update_group_settings(3003, agent_delivery_enabled=True)
+    assert store.get_group_settings(3003).agent_delivery_enabled is True
+    store.update_group_settings(3003, agent_delivery_enabled=False)
+    assert store.get_group_settings(3003).agent_delivery_enabled is False
+    # 显式 None 清空覆盖（回到跟随全局默认）
+    store.update_group_settings(3003, agent_delivery_enabled=None)
+    assert store.get_group_settings(3003).agent_delivery_enabled is None
+
+
 # ── _unavailable 守卫路径 ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## 问题

逐 Turn 分段交付目前只有 `[runtime] agent_delivery_enabled` 全局开关（试运行中全局开启 + 低阈值），但并非每个群都喜欢长回复拆成多条消息。

## 方案

`agent_delivery_enabled` 升级为 **group_settings 三态按会话覆盖**（仓库标准模板，同 memory_enabled）：

- **存储**：`group_settings` 表加 `agent_delivery_enabled INTEGER` 列（含 ALTER 迁移，照抄既有三次加列先例）；NULL = 跟随全局默认。
- **解析**：`ResolvedGroupSettings` 三态合并——覆盖开/关优先，未覆盖回退 `[runtime]` 全局默认（config 缺省 `false`，即缺省关闭）。私聊自动获得按会话（`private:USER_ID`）开关。
- **生效**：recorder 快照（`_begin_agent_recorder` 新参数）、DeliveryAborted 静默判定、最终 reply 置空三处全部改用同一按会话解析值，与该 Loop 策略同源，不会中途双发或吞回复。阈值/上限/间隔保持全局。
- **命令**：`/llm delivery on|off|reset|status`（管理权限收口内，范本同 `auto_memory`）。
- **Web Admin**：「群设置」页新增三态下拉（路由 body/options/list + 前端 FIELDS 表驱动，一处各加一字段）。
- 每日总结/周月报/命令输出不经此链路，不受影响（分段只作用于走 `generate_reply` 的 LLM 聊天回复）。

## 测试

- 新增集成 `test_agent_delivery_optin.py`：覆盖开（全局关）→ 七段交付 + reply 置空；覆盖关（全局开）→ 单发；reset 清覆盖跟随全局；两个方向都钉住。
- store 单测：覆盖列 true/false/NULL roundtrip。
- 既有 agent loop 测试（走"未覆盖回退全局"路径）原样全绿。

## 验证

- `pytest -n auto`：1794 passed（基线 1791）
- `ruff check .`：clean；`pnpm --dir frontend type-check` / `build`：通过

## CHANGELOG 条目（added）

- 分段发送（长回复按自然段拆成多条消息发出）现可按群或私聊会话单独开启：群内用 `/llm delivery on/off/reset/status` 设置，Web Admin「群设置」页同步支持；缺省关闭，未设置的会话跟随全局默认。