### PR TITLE
fix(llm): 修复取消收尾与被动触发记录

### DIFF
--- a/docs/dev/llm-module.md
+++ b/docs/dev/llm-module.md
@@ -26,6 +26,12 @@ QuickQuip 的 LLM 模块是建立在原有规则机器人之上的**显式触发
 
 LLM 运行时在 `LLM_TRACE_FLAG_FILE` 指向的开关文件存在时，把每次 HTTP 尝试写入 `data/llm_trace.db`。请求正文取自实际交给 HTTP 客户端的 UTF-8 JSON 序列化文本；普通响应保留 JSON 解析前的服务端文本；流式响应完整消费 SSE 后，由协议客户端重建 OpenAI Chat Completion、Claude Message 或 Gemini GenerateContent 完整响应对象，同时保留 SSE 传输原文供管理员按需核对。索引、正文和单调递增的状态事件分开存储，Web Admin 先读取轻量调用元数据，管理员选择记录后再加载完整 Header 与正文。`run_tool_call_loop` 为一轮完整交互分配 Agent Loop ID，重试、故障切换和工具结果回送产生的 HTTP 调用按组内序号排列。
 
+### 1.1 执行记录的请求边界
+
+群聊和私聊生成请求创建的执行记录按请求携带的 `trigger_kind` 保存触发类型；未显式指定时，群聊默认为 `group_direct`，私聊默认为 `private_direct`。被动群触发保存为 `group_passive`，供 Loop 详情与历史档案使用。历史记录保留已存分类，缺少原始触发证据时不推断回填。
+
+请求在模型调用、工具执行或分段发送期间被取消时，服务将已创建的 Loop 关闭为 `interrupted`，终止原因为 `request_cancelled`，并继续向调用方传播取消异常。收尾复用存储层的幂等关闭：已完成的 Turn、工具结果和发送回执保留；声明但未启动的工具收束为 `not_executed`，运行中且未记录结果的工具收束为 `indeterminate`，计划交付收束为 `skipped`，发送中且未记录回执的交付收束为 `unknown`。收尾不重试工具或消息发送；存储正常时，同会话后续请求可以创建新的 Loop。
+
 ---
 
 ## 2. 当前代码结构

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -1543,6 +1543,7 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 # 同 _persist_turn_and_build_reply 的落库口径：他人近期图注不落触发者名下。
                 image_descriptions=[d for d in image_descriptions if not d.context_label.startswith(RECENT_IMAGE_CONTEXT_PREFIX)] or None,
                 delivery_sink=delivery_sink,
+                trigger_kind=trigger_kind,
                 agent_delivery_enabled=settings.agent_delivery_enabled,
             )
             with (
@@ -1571,6 +1572,10 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                     turn_recorder=recorder,
                     request_guard=self._build_request_guard(provider),
                 )
+        except asyncio.CancelledError:
+            if recorder is not None:
+                recorder.close(LoopStatus.INTERRUPTED, "request_cancelled")
+            raise
         except DeliveryAborted as exc:
             if recorder is not None:
                 recorder.close(LoopStatus.INTERRUPTED, str(exc) or "delivery_aborted")

--- a/tests/integration/test_agent_loop_request_lifecycle.py
+++ b/tests/integration/test_agent_loop_request_lifecycle.py
@@ -1,0 +1,191 @@
+"""Request cancellation and trigger attribution across the real service/store boundary."""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from quickquip.llm.agent_records import TriggerKind
+from quickquip.llm.provider import LLMResponse
+from quickquip.llm.tools import LLMToolCall
+from tests.fixtures.agent_loop import CollectingSink
+
+
+async def _reply(service, *, private=False, **kwargs):
+    args = dict(user_id="2002", sender_name="Tester", prompt="Check the result.", **kwargs)
+    if private:
+        return await service.generate_private_reply(**args)
+    return await service.generate_reply(group_id=1001, **args)
+
+
+@pytest.mark.parametrize(
+    ("stage", "delivery_enabled", "private"),
+    [
+        ("first_provider", True, False),
+        ("first_provider", False, False),
+        ("first_provider", True, True),
+        ("next_provider", True, False),
+        ("tool", True, False),
+        ("delivery", True, False),
+    ],
+)
+async def test_cancellation_closes_loop_preserves_facts_and_allows_next_request(
+    llm_service, patch_provider_builder, monkeypatch, stage, delivery_enabled, private
+):
+    if private:
+        llm_service.start_private_session(2002)
+    runtime = llm_service.config.runtime
+    monkeypatch.setattr(runtime, "agent_delivery_enabled", delivery_enabled)
+    monkeypatch.setattr(runtime, "reply_split_threshold_chars", 120)
+    monkeypatch.setattr(runtime, "reply_chunk_max_chars", 240)
+    text = "A" * 120 + "\n\n" + "B" * 120 + "\n\n" + "C" * 120
+    blocked = asyncio.Event()
+
+    async def wait_for_cancellation():
+        blocked.set()
+        await asyncio.Future()
+
+    async def complete(request):
+        if stage == "first_provider" or client.complete.await_count == 2:
+            await wait_for_cancellation()
+        return LLMResponse(
+            text=text, model=request.model, finish_reason="tool_calls",
+            tool_calls=[
+                LLMToolCall(id=f"call-{i}", name="get_identity", arguments_json='{"query":"2002"}')
+                for i in range(2)
+            ],
+        )
+
+    client = AsyncMock()
+    client.complete.side_effect = complete
+    patch_provider_builder(lambda provider: client)
+    original_execute = llm_service.tool_registry.execute
+
+    async def execute(call, context):
+        if stage == "tool" and call.id == "call-1":
+            await wait_for_cancellation()
+        return await original_execute(call, context)
+
+    execute_mock = AsyncMock(side_effect=execute)
+    monkeypatch.setattr(llm_service.tool_registry, "execute", execute_mock)
+    sink = CollectingSink()
+
+    async def deliver(delivery_id, payload):
+        if stage == "delivery" and delivery_mock.await_count == 2:
+            await wait_for_cancellation()
+        return await sink(delivery_id, payload)
+
+    delivery_mock = AsyncMock(side_effect=deliver)
+    task = asyncio.create_task(
+        _reply(llm_service, private=private, delivery_sink=delivery_mock)
+    )
+    try:
+        await asyncio.wait_for(blocked.wait(), timeout=5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        if not task.done():
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    with llm_service.store._connect() as conn:
+        loop = dict(conn.execute("SELECT * FROM agent_loops").fetchone())
+        turns = [dict(row) for row in conn.execute("SELECT * FROM agent_turns")]
+        tools = [dict(row) for row in conn.execute(
+            "SELECT * FROM agent_tool_executions ORDER BY call_index"
+        )]
+        deliveries = [dict(row) for row in conn.execute(
+            "SELECT * FROM agent_deliveries ORDER BY delivery_index"
+        )]
+        attempts = [dict(row) for row in conn.execute(
+            "SELECT * FROM agent_delivery_attempts ORDER BY rowid"
+        )]
+
+    assert task.cancelled()
+    assert loop["status"] == "interrupted"
+    assert loop["closed_at"] is not None
+    assert loop["terminal_reason"] == "request_cancelled"
+    assert loop["scope_key"] == ("private:2002" if private else "1001")
+    if stage == "first_provider":
+        assert turns == tools == deliveries == attempts == []
+        assert execute_mock.await_count == delivery_mock.await_count == 0
+    else:
+        assert len(turns) == 1
+        assert [row["status"] for row in tools] == {
+            "next_provider": ["succeeded", "succeeded"],
+            "tool": ["succeeded", "indeterminate"],
+            "delivery": ["not_executed", "not_executed"],
+        }[stage]
+        assert [row["status"] for row in deliveries] == (
+            ["sent", "unknown", "skipped"] if stage == "delivery" else ["sent"] * 3
+        )
+        assert [row["status"] for row in attempts] == (
+            ["sent", "unknown"] if stage == "delivery" else ["sent"] * 3
+        )
+        assert execute_mock.await_count == (0 if stage == "delivery" else 2)
+        assert delivery_mock.await_count == (2 if stage == "delivery" else 3)
+        assert all(row["result_json"] for row in tools if row["status"] == "succeeded")
+    assert client.complete.await_count == (2 if stage == "next_provider" else 1)
+
+    client.complete.side_effect = None
+    client.complete.return_value = LLMResponse(text=text, model="gpt-test")
+    next_sink = CollectingSink()
+    tool_attempts_before = execute_mock.await_count
+    delivery_attempts_before = delivery_mock.await_count
+    result = await _reply(llm_service, private=private, delivery_sink=next_sink)
+
+    assert result["agent_turn_row_id"] is not None
+    assert result["reply"] == ("" if delivery_enabled else text)
+    assert len(next_sink.deliveries) == (3 if delivery_enabled else 0)
+    assert execute_mock.await_count == tool_attempts_before
+    assert delivery_mock.await_count == delivery_attempts_before
+    with llm_service.store._connect() as conn:
+        loops = [dict(row) for row in conn.execute("SELECT * FROM agent_loops ORDER BY rowid")]
+        assert len(loops) == 2
+        assert loops[0] == loop
+        assert loops[1]["status"] == "completed"
+        assert loops[1]["closed_at"] is not None
+        assert [dict(row) for row in conn.execute(
+            "SELECT * FROM agent_turns WHERE loop_id = ?", (loop["loop_id"],)
+        )] == turns
+        assert [dict(row) for row in conn.execute(
+            "SELECT * FROM agent_tool_executions ORDER BY call_index"
+        )] == tools
+        assert [dict(row) for row in conn.execute(
+            "SELECT * FROM agent_deliveries WHERE loop_id = ? ORDER BY delivery_index",
+            (loop["loop_id"],),
+        )] == deliveries
+
+
+@pytest.mark.parametrize(
+    ("private", "trigger", "expected"),
+    [
+        (False, TriggerKind.GROUP_PASSIVE, "group_passive"),
+        (False, TriggerKind.GROUP_DIRECT, "group_direct"),
+        (False, None, "group_direct"),
+        (True, TriggerKind.PRIVATE_DIRECT, "private_direct"),
+        (True, None, "private_direct"),
+    ],
+)
+async def test_request_trigger_is_persisted(
+    llm_service, patch_provider_builder, private, trigger, expected
+):
+    if private:
+        llm_service.start_private_session(2002)
+    client = AsyncMock()
+    client.complete.return_value = LLMResponse(text="Done.", model="gpt-test")
+    patch_provider_builder(lambda provider: client)
+    result = await _reply(llm_service, private=private, trigger_kind=trigger)
+
+    assert result["reply"] == "Done."
+    assert result["agent_turn_row_id"] is not None
+    with llm_service.store._connect() as conn:
+        row = conn.execute("SELECT trigger_kind, status FROM agent_loops").fetchone()
+    assert row["trigger_kind"] == expected
+    assert row["status"] == "completed"
+    loops = llm_service.store.load_closed_loops("private:2002" if private else "1001")
+    assert len(loops) == 1
+    assert loops[0].trigger_kind == expected


### PR DESCRIPTION
取消 LLM 请求时，执行记录会关闭为 `interrupted/request_cancelled`，随后继续传播取消异常；同会话下一次请求可以创建新的 Loop。被动群触发的 `trigger_kind` 同时传入记录器，使 Loop 详情与历史档案保留正确分类。

收尾复用已有幂等存储语义，保留完成的工具结果与发送回执，收束尚未完成的工具及交付，不重试工具或重发消息。未指定触发类型时保留既有群聊/私聊默认值；没有原始证据的历史分类不回填。

## 验证

- 新增 11 项真实服务与隔离数据库集成用例，覆盖首轮/后续 provider、工具、分段交付取消，后续请求可用性及触发分类，全部通过。
- 独立 Tier 1 审查及本批五透镜 Deep-CR 均无待修问题。
- 包含本 PR 的本批汇总代码：1871 项 pytest、Ruff、前端 type-check、12 份 TOML 示例与 ID literals 检查通过。真实 provider/MCP 网络请求未纳入本轮验收。

## Changelog 草稿

- 取消 LLM 请求时关闭当前执行记录，保留已完成的工具与发送事实，使同会话后续请求继续正常记录并分段交付。
- 群聊被动触发在执行记录与历史档案中显示正确的触发分类，便于查询与排查自动回复。

Closes #222

Closes #223
