### PR TITLE
refactor(deploy): 统一 v4 发布、迁移与回滚

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,6 +8,9 @@
 *.bat text eol=crlf
 *.cmd text eol=crlf
 
+# Cross-platform production templates use UTF-8 with LF.
+prod.example/*.ps1 text eol=lf
+
 # Image assets
 *.png binary
 *.jpg binary

--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -19,6 +19,24 @@ LLM 模块的详细结构、边界和群内命令说明见 [docs/dev/llm-module.
 
 ## 部署步骤
 
+### 自动部署与版本回滚
+
+日常部署推荐使用 `prod/deploy-v4.sh`（Bash）或 `prod/deploy-v4.ps1`（PowerShell）。两端共享远端事务执行器，按清单上传应用文件，预检和构建成功后切换版本目录，并验证容器、OneBot 连接与 Web Admin HTTP。完整前提、参数与目录结构见 [生产模板说明](../../prod.example/README.md)。服务器需具备 rsync、flock、Python ≥ 3.11.8 和 Docker Compose ≥ 2.27。
+
+```bash
+# 在本地项目目录执行，使用自己的 SSH alias
+bash prod/deploy-v4.sh -DryRun
+bash prod/deploy-v4.sh -HostAlias quickquip-prod
+bash prod/deploy-v4.sh -Status -HostAlias quickquip-prod
+bash prod/deploy-v4.sh -Rollback -HostAlias quickquip-prod
+```
+
+已有平铺部署首次使用 `-Migrate`：先保存服务器上的旧代码与运行镜像作为基线，再部署候选版本。新服务器首次尚未扫码时可显式使用 `-SkipHealth`，之后完成扫码与健康核验。PowerShell 使用同名参数，指定回滚版本时使用 `-Rollback -ReleaseId <id>`。
+
+部署失败时自动恢复本次修改的共享文件并验证旧版本健康；手动回滚保留当前根 `.env` 和数据库。数据迁移与外部副作用不随代码回滚，部署前应核对版本升级说明。`-DryRun` 会本地构建前端，PowerShell 还会临时打包，两者均不连接远端。
+
+运行态位于部署根目录的 `data/` 和 `prod/`，版本内容位于 `releases/<id>/`，`current` 与 `previous` 指向当前和前一版本。运维命令需按 [模板中的手动访问步骤](../../prod.example/README.md#manual-compose-access) 导出部署根目录和版本标识。下列步骤说明手动平铺安装；版本目录部署由上述脚本管理。
+
 ### 1. 服务器上安装 Docker
 
 ```bash
@@ -78,6 +96,7 @@ cp -r prod.example prod  # prod/ 已存在时会嵌套成 prod/prod.example（�
 
 ```bash
 cd /path/to/QuickQuip/prod
+docker compose --env-file ../.env build quickquip
 docker compose --env-file ../.env up -d
 ```
 
@@ -98,7 +117,7 @@ docker compose --env-file ../.env up -d
 
 - **`DRIVER` 以 `.env` 为最终生效值**：compose 的 `environment:` 插值与 `env_file:` 都会读到同一份 `.env`，在其中写 `DRIVER=~fastapi` 会同时穿透两层覆盖模板默认。要让 QuickQuip 正向 WebSocket 连接协议端（`ONEBOT_WS_URLS` 指向适配器的 WS 服务端，当前默认模板为 `ws://llbot:3001/`），`DRIVER` 必须是 `~fastapi+~websockets`（纯 `~fastapi` 无 WS client 能力，`ONEBOT_WS_URLS` 会被忽略并告警）。替代拓扑：在适配器管理界面启用反向 WS 指向 QuickQuip 的 `ws://<bot地址>:8080/onebot/v11/ws`，此时 QuickQuip 侧不需要 WS client（连接拓扑详见 [onebot-adapters.md](onebot-adapters.md)）。deploy 脚本在 `prod/llbot-data` 存在时会自动把 `ONEBOT_ACCESS_TOKEN` 同步进 LLBot 反向 WS 配置，正反拓扑可并存。
 - `config/llm.toml`、`config/awakening.toml`、`llm_about/vocab.yaml`、`llm_about/identities.yaml` 及群级覆盖文件虽然是 bind mount，但 `quickquip` 会在进程启动时把它们读入内存；`awakening.toml` 是这些文件中唯一的例外：bot 每 30 秒检测其 mtime，外部修改会自动重载
-- 因此部署脚本在同步文件后会额外强制重建 `quickquip` 容器，避免新 persona 或词表已经上传但运行时仍在使用旧配置
+- 部署脚本在切换发行目录后强制重建应用容器一次，使源码和配置挂载指向本次发行目录
 - 如果只是在线微调配置而不走部署脚本，也可以在群里手动执行 `/llm reload`；重载后会探活当前群实际生效的 provider/model，探活会发一条 max_tokens=1 的真实请求，可能产生 provider 计费
 
 ### 4.1 首次准备贴吧登录态
@@ -229,7 +248,7 @@ WEB_ADMIN_COOKIE_SECURE=auto
 
   ```bash
   cd /path/to/QuickQuip/prod
-  docker compose --env-file ../.env build quickquip web-admin
+  docker compose --env-file ../.env build quickquip
   docker compose --env-file ../.env up -d quickquip web-admin
   ```
 
@@ -244,7 +263,7 @@ docker compose --env-file ../.env restart quickquip web-admin
 
 # 更新依赖/Dockerfile/pyproject 后重建
 cd /path/to/QuickQuip/prod
-docker compose --env-file ../.env build quickquip web-admin
+docker compose --env-file ../.env build quickquip
 docker compose --env-file ../.env up -d quickquip web-admin
 
 # 查看日志

--- a/prod.example/README.md
+++ b/prod.example/README.md
@@ -1,53 +1,90 @@
 # QuickQuip Production Template
 
-This directory is the tracked template for the private `prod/` directory.
-
-Copy it before first use (Windows or Linux):
-
-```powershell
-# Windows (PowerShell)
-Copy-Item -Recurse prod.example prod
-```
+Copy this directory to the ignored `prod/` directory, then configure your SSH alias, compose topology and the project-root `.env`.
 
 ```bash
-# Linux / macOS
 cp -r prod.example prod
 ```
 
-> ⚠️ If `prod/` already exists (initialized before), the copy commands above will
-> **nest** into `prod/prod.example` instead of overwriting the old directory — the
-> deploy script would then run with your old production settings and upload
-> `prod/sendkey.env` to the remote host. Both deploy scripts detect the nesting and
-> abort; move the old `prod/` aside first, then re-copy the template.
+```powershell
+Copy-Item -Recurse prod.example prod
+```
 
-Then edit only files under `prod/` and the project root `.env`.
+When `prod/` already exists, move it aside before copying. The drivers reject a nested `prod/prod.example` directory.
 
-- `.env` at the repository root is the only QuickQuip application secret/config source.
-- `QUICKQUIP_SEARXNG_BASE_URL` may be set in `.env` if the containers should use a search service outside this compose project.
-- `prod/sendkey.env` is optional and used only by maintenance scripts.
-- `prod/` is ignored by git and may contain production-only operational state.
-- `quickquip-prod` in the helper scripts is a placeholder SSH host alias; change it under `prod/` before use.
+## Requirements
 
-Local helper scripts (run from the project root on your machine; both variants SSH into the server and share the same server-side workers):
+- Server: Linux, Bash, GNU coreutils/find, rsync, flock, Python >= 3.11.8, Docker and Docker Compose >= 2.27. The deployment user needs Docker access and write access to the deployment root. Root-owned LLBot configuration files use noninteractive sudo for shared-file snapshot, apply and restore; without permission the action stops before activation.
+- Bash client: Bash, rsync, SSH/SCP, tar, Node.js and pnpm.
+- PowerShell client: PowerShell 5.1 or 7, SSH/SCP, tar, Node.js and pnpm on PATH. The server materializes its archive with rsync.
+- Initialize SSH host trust before unattended use. `quickquip-prod` is a placeholder SSH alias.
+- Fill root `.env`, `config/llm.toml` and other enabled feature configuration. Set `QUICKQUIP_SEARXNG_BASE_URL` for the external search service.
 
-| Action | Windows | Linux |
+## Commands
+
+Both local drivers share `remote-deploy-v4.sh` and `deploy-state.py`.
+
+| Action | Bash | PowerShell |
 |---|---|---|
-| Deploy | `.\prod\deploy-v4.ps1` | `bash prod/deploy-v4.sh` |
-| Status / QR login | `.\prod\check_bot.ps1` | `bash prod/check_bot_local.sh` |
+| Deploy | `bash prod/deploy-v4.sh` | `prod/deploy-v4.ps1` |
+| Local preview | `bash prod/deploy-v4.sh -DryRun` | `prod/deploy-v4.ps1 -DryRun` |
+| Status | `bash prod/deploy-v4.sh -Status` | `prod/deploy-v4.ps1 -Status` |
+| Previous release | `bash prod/deploy-v4.sh -Rollback` | `prod/deploy-v4.ps1 -Rollback` |
+| Explicit rollback | `bash prod/deploy-v4.sh -Rollback <id>` | `prod/deploy-v4.ps1 -Rollback -ReleaseId <id>` |
+| Flat-layout migration and deploy | `bash prod/deploy-v4.sh -Migrate` | `prod/deploy-v4.ps1 -Migrate` |
+| First deployment awaiting QQ login | `bash prod/deploy-v4.sh -SkipHealth` | `prod/deploy-v4.ps1 -SkipHealth` |
 
-`check_bot_local.sh` uses a `_local` suffix because `check_bot.sh` is the server-side worker it invokes remotely — the whole `prod/` directory is synced to the server during deploy, so the names must not collide. `cron_check_bot.sh` runs on the server via cron.
+Shared parameters: `-HostAlias`, `-RemoteDir` (default `/opt/QuickQuip`), `-KeepReleases` (2..100, default 4). Remote paths use letters, digits, dot, slash, underscore or hyphen.
 
-On the server, run compose commands from `prod/`:
+`-DryRun` builds the frontend locally and previews the upload; PowerShell creates and removes a temporary archive. It makes no remote connection. `-LocalCheck` is a compatibility alias. Combining preview with migration, rollback or status is rejected. `-SkipHealth` applies only to deployment/migration and explicitly marks the result unverified; manual rollback always requires health verification.
 
-```bash
-cd /opt/QuickQuip/prod
-docker compose --env-file ../.env up -d --build
+For first login, use `bash prod/check_bot_local.sh` or `prod/check_bot.ps1` after an explicit `-SkipHealth` deployment. Pass their `-Server` and `-RemoteDir` parameters for a custom target. The server worker is `prod/check_bot.sh`; `prod/cron_check_bot.sh` remains the cron entry.
+
+## Layout and Transaction
+
+```text
+<root>/
+  .env                       application credentials
+  data/                      databases, logs, font and optional Tieba state
+  prod/                      LLBot state, maintenance scripts, sendkey.env
+  releases/<id>/             application, config, frontend and compose
+  current -> releases/<id>
+  previous -> releases/<id>
+  .deploy/                   private staging, operation logs and exit status
 ```
 
-The `web-admin` container serves the prebuilt frontend from `frontend/dist`, so build it before bringing the stack up (or just use the deploy scripts, which do this for you):
+`deploy-manifest.txt` lists application paths. Listed directories are recursive: review their contents before deployment. Root `.env`, maintenance scripts and optional `prod/sendkey.env`, font and `data/tieba/storage_state.json` are uploaded separately to private staging. LLBot login directories are never uploaded. For a test server, prepare an isolated checkout without real credentials or Tieba session files.
+
+Each operation has a UTC timestamp plus random suffix. Uploads enter an exclusive private directory; live files are modified only under the server deployment lock. The candidate compose is validated against the staged environment and its image built before shared files are applied. Unchanged application files use rsync hardlinks; release roots and transaction directories restrict access to the deployment user. Web Admin configuration writes use atomic file replacement, preserving older hardlinked content.
+
+Before activation, the server snapshots shared files that it will replace, including existing LLBot WebSocket configuration. It applies the candidate environment, switches `current`, and recreates application containers once. The health gate checks all three services, the bot connection log and Web Admin HTTP inside its container. SSH disconnects do not stop the detached transaction; drivers reconnect to its log.
+
+Successful operations remove private staging and rollback copies, retaining `.deploy/<id>.log` and `.exit`. Interrupted uploads can leave staging directories; inspect operation status before manually removing these. Failed recovery retains its private backup and returns exit code 2. The requested action still returns nonzero when automatic recovery succeeds.
+
+## Migration and Recovery
+
+`-Migrate` snapshots the server's existing application files and pins actual running images of `llbot`, `quickquip` and `web-admin` as a baseline, then deploys the local candidate. Flat files remain in place so existing bind mounts stay valid during preparation. Custom services or unsupported external bind mounts require an explicit migration design; the script stops before activation. Baselines are not automatically collected.
+
+Automatic recovery restores pre-operation shared files, links and containers, then verifies health. Manual rollback selects an existing release and its local images, retains the current root `.env` and runtime data, and verifies health. Missing rollback images are never pulled or rebuilt. Do not prune retained release tags manually.
+
+Database migrations and external effects are outside filesystem rollback. Check upgrade notes and prepare a separate data backup when required; code rollback can require coordinated data restore. Server-side configuration edits belong to their release; subsequent deployments use local candidate configuration.
+
+Retention removes older successfully deployed release directories and application images, protecting `current`, `previous` and migration baselines. Failed candidates and operation logs remain for manual inspection. Root `.env` remains the application credential source; transaction copies are private and transient.
+
+`deploy-v4-bak.sh` and `deploy-v4-bak.ps1` preserve the archived flat-layout drivers for inspection and controlled legacy tests. They refuse targets with a release directory or a current link. Use `deploy-v4` for current deployments.
+
+## Manual Compose Access
+
+On a release-layout server, export the root and release identity:
 
 ```bash
-cd frontend && pnpm install --frozen-lockfile && pnpm build
+export QUICKQUIP_ROOT=/opt/QuickQuip
+export QUICKQUIP_ENV_FILE="$QUICKQUIP_ROOT/.env"
+export QUICKQUIP_RELEASE="$(basename "$(readlink "$QUICKQUIP_ROOT/current")")"
+cd "$QUICKQUIP_ROOT/current/prod"
+docker compose --env-file "$QUICKQUIP_ENV_FILE" logs -f quickquip
 ```
 
-For the full prerequisite checklist (Node.js/pnpm, `.env` keys, fonts, Tieba login state), see [docs/admin/deployment.md](../docs/admin/deployment.md).
+For manual flat-layout installation, build the frontend, then run `docker compose --env-file ../.env build quickquip` and `docker compose --env-file ../.env up -d` from `prod/`. Both application services use the same image.
+
+Application prerequisites and platform notes: [deployment guide](../docs/admin/deployment.md).

--- a/prod.example/check_bot.ps1
+++ b/prod.example/check_bot.ps1
@@ -16,7 +16,7 @@ function Write-OK($msg) { Write-Host $msg -ForegroundColor Green }
 function Write-Err($msg) { Write-Host $msg -ForegroundColor Red }
 
 function Invoke-Server($cmd) {
-    $full = "bash $RemoteDir/prod/check_bot.sh $cmd"
+    $full = "REMOTE_DIR='$RemoteDir' bash '$RemoteDir/prod/check_bot.sh' $cmd"
     $result = ssh -o StrictHostKeyChecking=no $Server $full 2>&1 | ForEach-Object { "$_" }
     $result = ($result -join "`n").Trim()
     if ($LASTEXITCODE -ne 0) {

--- a/prod.example/check_bot.sh
+++ b/prod.example/check_bot.sh
@@ -4,12 +4,20 @@
 
 REMOTE_DIR="${REMOTE_DIR:-/opt/QuickQuip}"
 NULL_DEVICE="/d""ev/null"
-cd "$REMOTE_DIR/prod" 2>"$NULL_DEVICE" || { echo "ERROR: cannot cd to $REMOTE_DIR/prod"; exit 1; }
+if [ -L "$REMOTE_DIR/current" ]; then
+    export QUICKQUIP_ROOT="$REMOTE_DIR"
+    export QUICKQUIP_ENV_FILE="$REMOTE_DIR/.env"
+    QUICKQUIP_RELEASE="$(basename "$(readlink "$REMOTE_DIR/current")")"
+    export QUICKQUIP_RELEASE
+    cd "$REMOTE_DIR/current/prod" || exit 1
+else
+    cd "$REMOTE_DIR/prod" || exit 1
+fi
 
 BACKEND="${BACKEND:-llbot}"
 cmd="${1:-status}"
 
-COMPOSE=(docker compose --env-file ../.env)
+COMPOSE=(docker compose --env-file "$REMOTE_DIR/.env")
 
 if [ "$cmd" = "status" ]; then
     if ! "${COMPOSE[@]}" ps "$BACKEND" 2>"$NULL_DEVICE" | grep -q 'Up'; then
@@ -90,8 +98,8 @@ fi
 if [ "$cmd" = "force-recreate" ]; then
     echo "Force recreating $BACKEND container (fresh device fingerprint)..."
     "${COMPOSE[@]}" rm -sf "$BACKEND" 2>&1
-    rm -rf llbot-qq llbot-data 2>"$NULL_DEVICE" || true
-    mkdir -p llbot-qq llbot-data
+    rm -rf "$REMOTE_DIR/prod/llbot-qq" "$REMOTE_DIR/prod/llbot-data" 2>"$NULL_DEVICE" || true
+    mkdir -p "$REMOTE_DIR/prod/llbot-qq" "$REMOTE_DIR/prod/llbot-data"
     "${COMPOSE[@]}" up -d "$BACKEND" 2>&1
     sleep 5
     exec bash "$0" gen-qr

--- a/prod.example/check_bot_local.sh
+++ b/prod.example/check_bot_local.sh
@@ -41,7 +41,7 @@ ProjectRoot="$(cd "$ScriptDir/.." && pwd)"
 
 invoke_server() {
     local cmd="$1" result rc
-    result=$(ssh -o StrictHostKeyChecking=no "$Server" "bash $RemoteDir/prod/check_bot.sh $cmd" 2>&1)
+    result=$(ssh -o StrictHostKeyChecking=no "$Server" "REMOTE_DIR='$RemoteDir' bash '$RemoteDir/prod/check_bot.sh' $cmd" 2>&1)
     rc=$?
     if [ "$rc" -ne 0 ]; then
         err "SSH failed: $result"

--- a/prod.example/deploy-manifest.txt
+++ b/prod.example/deploy-manifest.txt
@@ -1,0 +1,11 @@
+.dockerignore
+bot.py
+web_api.py
+pyproject.toml
+requirements.txt
+config
+frontend/dist
+llm_about
+src
+prod/Dockerfile
+prod/docker-compose.yml

--- a/prod.example/deploy-state.py
+++ b/prod.example/deploy-state.py
@@ -1,0 +1,205 @@
+"""Filesystem transactions and flat-layout snapshots for the deployment runner."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+
+
+SHARED_FILES = {
+    ".env": 0o600,
+    "prod/sendkey.env": 0o600,
+    "prod/check_bot.sh": 0o700,
+    "prod/cron_check_bot.sh": 0o700,
+    "data/fonts/NotoSansSC-Regular.ttf": 0o644,
+    "data/tieba/storage_state.json": 0o600,
+}
+SERVICES = ("llbot", "quickquip", "web-admin")
+
+
+def atomic_write(path: Path, data: bytes, mode: int, new_owner: tuple[int, int] | None = None) -> None:
+    missing_parents = []
+    parent = path.parent
+    while new_owner is not None and not parent.exists():
+        missing_parents.append(parent)
+        parent = parent.parent
+    path.parent.mkdir(parents=True, exist_ok=True)
+    for parent in reversed(missing_parents):
+        os.chmod(parent, 0o755)
+        if os.geteuid() == 0:
+            os.chown(parent, *new_owner)
+    owner = path.stat() if path.exists() else None
+    fd, name = tempfile.mkstemp(prefix=".deploy-", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as output:
+            output.write(data)
+            output.flush()
+            os.fsync(output.fileno())
+        os.chmod(name, mode)
+        if owner is not None and os.geteuid() == 0:
+            os.chown(name, owner.st_uid, owner.st_gid)
+        elif new_owner is not None and os.geteuid() == 0:
+            os.chown(name, *new_owner)
+        os.replace(name, path)
+    finally:
+        Path(name).unlink(missing_ok=True)
+
+
+def checked_path(root: Path, relative: str) -> Path:
+    path = root / relative
+    if not path.resolve().is_relative_to(root.resolve()):
+        raise ValueError(f"path outside deployment root: {relative}")
+    if path.is_symlink():
+        raise ValueError(f"symlink not permitted: {relative}")
+    return path
+
+
+def extract(archive: Path, destination: Path) -> None:
+    destination.mkdir()
+    with tarfile.open(archive) as bundle:
+        members = bundle.getmembers()
+        for member in members:
+            checked_path(destination, member.name)
+            if not (member.isfile() or member.isdir()):
+                raise ValueError(f"unsupported archive entry: {member.name}")
+        bundle.extractall(destination, members=members, filter="data")
+
+
+def validate_tree(root: Path) -> None:
+    for path in root.rglob("*"):
+        if path.is_symlink() or not (path.is_file() or path.is_dir()):
+            raise ValueError(f"unsupported release entry: {path.relative_to(root)}")
+
+
+def snapshot_shared(root: Path, incoming: Path, backup: Path) -> None:
+    backup.mkdir(mode=0o700)
+    names = [name for name in SHARED_FILES if (incoming / "shared" / name).is_file()]
+    llbot = root / "prod/llbot-data"
+    names += [str(path.relative_to(root)) for path in (
+        [llbot / "default_config.json"] + sorted((llbot / "data").glob("config_*.json"))
+    ) if path.is_file()]
+    records = []
+    for name in names:
+        path = checked_path(root, name)
+        parent = path.parent
+        while not parent.exists():
+            parent = parent.parent
+        if not os.access(parent, os.W_OK):
+            raise PermissionError(f"deployment user cannot replace {name}")
+        present = path.exists()
+        mode = stat.S_IMODE(path.stat().st_mode) if present else SHARED_FILES.get(name, 0o600)
+        if present:
+            atomic_write(backup / name, path.read_bytes(), 0o600)
+        records.append({"name": name, "present": present, "mode": mode})
+    atomic_write(backup / "index.json", json.dumps(records).encode(), 0o600)
+
+
+def apply_shared(root: Path, incoming: Path, backup: Path) -> None:
+    records = json.loads((backup / "index.json").read_text())
+    compose = json.loads((incoming / "candidate-compose.json").read_text())
+    token = compose["services"]["quickquip"].get("environment", {}).get("ONEBOT_ACCESS_TOKEN", "")
+    for record in records:
+        name = record["name"]
+        path = checked_path(root, name)
+        source = incoming / "shared" / name
+        if name in SHARED_FILES:
+            data = source.read_bytes()
+            if name.endswith((".env", ".sh")) or name == ".env":
+                data = data.replace(b"\r\n", b"\n")
+            deploy_owner = (int(os.environ.get("SUDO_UID", os.getuid())),
+                            int(os.environ.get("SUDO_GID", os.getgid())))
+            atomic_write(path, data, SHARED_FILES[name], deploy_owner)
+        else:
+            data = json.loads((backup / name).read_text(encoding="utf-8"))
+            connections = data.setdefault("ob11", {}).setdefault("connect", [])
+            while len(connections) <= 1:
+                connections.append({})
+            connections[1]["url"] = "ws://quickquip:8080/onebot/v11/ws/"
+            connections[1]["token"] = token or ""
+            atomic_write(path, (json.dumps(data, ensure_ascii=False, indent=4) + "\n").encode(), record["mode"])
+
+
+def restore_shared(root: Path, backup: Path) -> None:
+    for record in json.loads((backup / "index.json").read_text()):
+        path = checked_path(root, record["name"])
+        if record["present"]:
+            atomic_write(path, (backup / record["name"]).read_bytes(), record["mode"])
+        else:
+            path.unlink(missing_ok=True)
+
+
+def capture_baseline(root: Path, baseline: Path) -> None:
+    """Capture server files and running image IDs without moving live bind sources."""
+    command = ["docker", "compose", "--env-file", str(root / ".env"), "-f", str(root / "prod/docker-compose.yml")]
+    # No interpolation also preserves env_file references on Compose 2.27+.
+    raw = subprocess.check_output(command + ["config", "--no-interpolate", "--format", "json"])
+    config = json.loads(raw)
+    if set(config["services"]) != set(SERVICES):
+        raise ValueError("migration requires exactly llbot, quickquip and web-admin; review custom services first")
+    # Keep private runtime files out of the snapshot; copy only mounted app assets.
+    baseline.mkdir(mode=0o700)
+    for name in ("src", "config", "llm_about", "frontend/dist", "bot.py", "web_api.py", "pyproject.toml", "requirements.txt", ".dockerignore"):
+        source = checked_path(root, name)
+        if source.is_dir():
+            validate_tree(source)
+            shutil.copytree(source, baseline / name, dirs_exist_ok=True)
+        elif source.is_file():
+            atomic_write(baseline / name, source.read_bytes(), 0o644)
+    for service, spec in config["services"].items():
+        container = spec.get("container_name")
+        if not container:
+            raise ValueError(f"migration needs container_name for {service}")
+        image = subprocess.check_output(["docker", "inspect", "--format", "{{.Image}}", container], text=True).strip()
+        tag = f"quickquip-{service}:{baseline.name}"
+        subprocess.run(["docker", "tag", image, tag], check=True)
+        spec["image"] = tag
+        spec.pop("build", None)
+        spec.pop("pull_policy", None)
+        # Normalize the root env reference without expanding its credentials.
+        if service != "llbot":
+            spec["env_file"] = [str(root / ".env")]
+        for volume in spec.get("volumes", []):
+            if volume.get("type") != "bind":
+                continue
+            source = Path(volume["source"])
+            if not source.is_absolute():
+                source = (root / "prod" / source).resolve()
+            if not source.is_relative_to(root):
+                raise ValueError(f"external bind mount requires manual migration: {source}")
+            relative = source.relative_to(root)
+            if relative.parts[0] == "data" or str(relative) in ("prod/llbot-qq", "prod/llbot-data", ".env"):
+                volume["source"] = str(source)
+            elif (baseline / relative).exists():
+                volume["source"] = str(baseline / relative)
+            else:
+                raise ValueError(f"unsupported bind mount: {relative}")
+    atomic_write(baseline / "prod/docker-compose.yml", json.dumps(config).encode(), 0o600)
+    subprocess.run(["docker", "compose", "--env-file", str(root / ".env"), "-f", str(baseline / "prod/docker-compose.yml"), "config", "--quiet"], check=True)
+
+
+def main() -> None:
+    action, *args = sys.argv[1:]
+    paths = [Path(arg).absolute() for arg in args]
+    actions = {
+        "extract": extract,
+        "validate": validate_tree,
+        "snapshot": snapshot_shared,
+        "apply": apply_shared,
+        "restore": restore_shared,
+        "baseline": capture_baseline,
+    }
+    actions[action](*paths)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except PermissionError as exc:
+        print(f"deployment filesystem permission denied: {exc.filename or 'shared files'}", file=sys.stderr)
+        raise SystemExit(3) from None

--- a/prod.example/deploy-v4-bak.ps1
+++ b/prod.example/deploy-v4-bak.ps1
@@ -1,0 +1,327 @@
+# Archived flat-layout deployment driver. Use deploy-v4.ps1 for releases.
+# Usage: run from project root:
+#   .\prod\deploy-v4.ps1
+# Local archive check:
+#   .\prod\deploy-v4.ps1 -LocalCheck
+
+param(
+    [switch]$LocalCheck,
+    [string]$HostAlias = "quickquip-prod",
+    [string]$RemoteDir = "/opt/QuickQuip"
+)
+
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [System.Text.UTF8Encoding]::new($false)
+
+$TempArchive = "$env:TEMP\quickquip-deploy.tar.gz"
+$TiebaStateArchive = "$env:TEMP\quickquip-tieba-state.tar.gz"
+$ProjectRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$LocalPrivateWorkspace = "d" + "ev"
+$TiebaStateFile = "data/tieba/storage_state.json"
+$SendkeyEnvFile = "prod/sendkey.env"
+$FontFile = "data/fonts/NotoSansSC-Regular.ttf"
+$SshArgs = @(
+    "-o", "StrictHostKeyChecking=no",
+    "-o", "BatchMode=yes",
+    "-o", "ConnectTimeout=15",
+    "-o", "ServerAliveInterval=15",
+    "-o", "ServerAliveCountMax=3"
+)
+$ScpArgs = @(
+    "-o", "StrictHostKeyChecking=no",
+    "-o", "BatchMode=yes",
+    "-o", "ConnectTimeout=15",
+    "-o", "ServerAliveInterval=15",
+    "-o", "ServerAliveCountMax=3"
+)
+
+function Initialize-NodeToolchainPath {
+    $preferred = @()
+    $voltaProgram = "C:\Program Files\Volta"
+    $voltaUserBin = Join-Path $env:LOCALAPPDATA "Volta\bin"
+    foreach ($path in @($voltaProgram, $voltaUserBin)) {
+        if ($path -and (Test-Path $path)) {
+            $preferred += $path
+        }
+    }
+
+    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $items = @()
+    foreach ($path in ($preferred + ($env:Path -split ';'))) {
+        if (-not $path) {
+            continue
+        }
+        $trimmed = $path.Trim()
+        if (-not $trimmed) {
+            continue
+        }
+        $normalized = $trimmed.TrimEnd('\')
+        if ($seen.Add($normalized)) {
+            $items += $trimmed
+        }
+    }
+    $env:Path = ($items -join ';')
+}
+
+function Get-PnpmCommand {
+    foreach ($candidate in @(
+        "C:\Program Files\Volta\pnpm.cmd",
+        "C:\Program Files\Volta\pnpm.exe",
+        (Join-Path $env:LOCALAPPDATA "Volta\bin\pnpm.cmd"),
+        (Join-Path $env:LOCALAPPDATA "Volta\bin\pnpm.exe")
+    )) {
+        if ($candidate -and (Test-Path $candidate)) {
+            return $candidate
+        }
+    }
+
+    $command = Get-Command "pnpm.exe" -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $command = Get-Command "pnpm.cmd" -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    throw "No usable pnpm found. Install pnpm (e.g. volta install pnpm) or fix Volta."
+}
+
+function Invoke-Native {
+    param([string]$Desc, [scriptblock]$Cmd)
+    & $Cmd
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "FAILED: $Desc (exit $LASTEXITCODE)" -ForegroundColor Red
+        exit $LASTEXITCODE
+    }
+}
+
+Push-Location $ProjectRoot
+
+Initialize-NodeToolchainPath
+$PnpmCommand = Get-PnpmCommand
+
+foreach ($requiredPath in @(".env", "prod/Dockerfile", "prod/docker-compose.yml", "pyproject.toml", "requirements.txt", "src/quickquip", "src/plugins", "config/llm.toml", "llm_about/_example/vocab.yaml", "llm_about/_example/identities.yaml", "docker/searxng/settings.yml")) {
+    if (-not (Test-Path $requiredPath)) {
+        Write-Host "Missing required file: $requiredPath" -ForegroundColor Red
+        Pop-Location
+        exit 1
+    }
+}
+
+# Nested prod/prod.example means the template was copied into an existing prod/
+# (Copy-Item -Recurse does not overwrite); abort so the script never runs with
+# production settings or uploads prod/sendkey.env. See prod.example/README.md.
+if (Test-Path -PathType Container "prod/prod.example") {
+    Write-Host "prod/prod.example exists: the template was nested into an existing prod/ by 'Copy-Item -Recurse prod.example prod'." -ForegroundColor Red
+    Write-Host "This script would run with your production settings and upload prod/sendkey.env. Move the old prod/ aside and re-copy the template." -ForegroundColor Red
+    Pop-Location
+    exit 1
+}
+
+Write-Host "Building frontend..." -ForegroundColor Cyan
+Push-Location "frontend"
+Invoke-Native "pnpm install --frozen-lockfile" { & $PnpmCommand install --frozen-lockfile }
+Invoke-Native "pnpm build" { & $PnpmCommand build }
+Pop-Location
+
+Write-Host "Packing project..." -ForegroundColor Cyan
+Invoke-Native "tar archive" {
+    tar czf $TempArchive `
+        --exclude='.git' `
+        --exclude='.github' `
+        --exclude='__pycache__' `
+        --exclude='.venv' `
+        --exclude='.vscode' `
+        --exclude='.claude' `
+        --exclude='.gemini' `
+        --exclude='AGENTS.md' `
+        --exclude='AGENTS.override.md' `
+        --exclude='CLAUDE.md' `
+        --exclude='./data' `
+        --exclude="$LocalPrivateWorkspace" `
+        --exclude='prod/sendkey.env' `
+        --exclude='prod/sendkey.env.example' `
+        --exclude='prod/README.md' `
+        --exclude='prod/llbot-qq' `
+        --exclude='prod/llbot-data' `
+        --exclude='prod/napcat-data' `
+        --exclude='prod/home_router_ed25519' `
+        --exclude='prod/home_router_ed25519.pub' `
+        --exclude='frontend/node_modules' `
+        --exclude='./tests' `
+        --exclude='test_*.py' `
+        --exclude='./scripts' `
+        --exclude='requirements-dev.txt' `
+        --exclude='.pytest-tmp-*' `
+        --exclude='*.tar' `
+        --exclude='*.tar.gz' `
+        .
+}
+if (Test-Path $TiebaStateFile) {
+    Write-Host "Packing Tieba storage state..." -ForegroundColor Cyan
+    Invoke-Native "Tieba state archive" {
+        tar czf $TiebaStateArchive $TiebaStateFile
+    }
+}
+Pop-Location
+
+if (-not (Test-Path $TempArchive)) {
+    Write-Host "Archive was not created; aborting." -ForegroundColor Red
+    exit 1
+}
+
+if ($LocalCheck) {
+    $archiveInfo = Get-Item $TempArchive
+    $archiveSizeMB = [Math]::Round($archiveInfo.Length / 1MB, 2)
+    Write-Host "Local check complete. Archive size: ${archiveSizeMB} MB" -ForegroundColor Green
+    Remove-Item -Force $TempArchive -ErrorAction SilentlyContinue
+    Remove-Item -Force $TiebaStateArchive -ErrorAction SilentlyContinue
+    exit 0
+}
+
+if ($RemoteDir -cnotmatch '^/[a-zA-Z0-9_./-]+$' -or $RemoteDir -eq '/' -or $RemoteDir.Contains('/../')) { throw "Invalid deployment root" }
+Invoke-Native "legacy layout guard; release layouts require deploy-v4" {
+    ssh @SshArgs $HostAlias "test ! -e '$RemoteDir/releases' && test ! -L '$RemoteDir/current'"
+}
+Write-Host "Uploading to server..." -ForegroundColor Cyan
+Invoke-Native "scp archive" {
+    scp @ScpArgs $TempArchive "${HostAlias}:/tmp/quickquip-deploy.tar.gz"
+}
+if (Test-Path $TiebaStateArchive) {
+    Invoke-Native "scp Tieba state" {
+        scp @ScpArgs $TiebaStateArchive "${HostAlias}:/tmp/quickquip-tieba-state.tar.gz"
+    }
+}
+if (Test-Path $SendkeyEnvFile) {
+    Write-Host "Uploading ops notification env..." -ForegroundColor DarkCyan
+    Invoke-Native "scp sendkey env" {
+        scp @ScpArgs $SendkeyEnvFile "${HostAlias}:/tmp/quickquip-sendkey.env"
+    }
+}
+if (Test-Path $FontFile) {
+    Write-Host "Uploading wordcloud font..." -ForegroundColor DarkCyan
+    $fontInfo = Get-Item $FontFile
+    $fontSizeMB = [Math]::Round($fontInfo.Length / 1MB, 2)
+    Invoke-Native "ssh create font dir" {
+        ssh @SshArgs $HostAlias "mkdir -p $RemoteDir/data/fonts"
+    }
+    Write-Host "Uploading font (${fontSizeMB} MB)..." -ForegroundColor DarkCyan
+    Invoke-Native "scp font" {
+        scp @ScpArgs $FontFile "${HostAlias}:${RemoteDir}/data/fonts/NotoSansSC-Regular.ttf"
+    }
+}
+
+Write-Host "Extracting and rebuilding containers..." -ForegroundColor Cyan
+$RemoteDeployScript = @'
+set -eu
+REMOTE_DIR="__REMOTE_DIR__"
+NULL_DEVICE="/d""ev/null"
+mkdir -p "$REMOTE_DIR"
+cd "$REMOTE_DIR"
+
+tar xzf /tmp/quickquip-deploy.tar.gz
+rm -f "$REMOTE_DIR/AGENTS.md" "$REMOTE_DIR/AGENTS.override.md" "$REMOTE_DIR/CLAUDE.md" "$REMOTE_DIR"/test_*.py
+rm -f "$REMOTE_DIR/requirements-dev.txt" "$REMOTE_DIR/docs/GROUP_COMMANDS.md"
+rm -rf "$REMOTE_DIR/.gemini" "$REMOTE_DIR/tests" "$REMOTE_DIR/scripts" "$REMOTE_DIR/frontend-v1" "$REMOTE_DIR/frontend-v2"
+
+if [ -f /tmp/quickquip-sendkey.env ]; then
+    mkdir -p "$REMOTE_DIR/prod"
+    install -m 600 /tmp/quickquip-sendkey.env "$REMOTE_DIR/prod/sendkey.env"
+fi
+
+if [ -f /tmp/quickquip-tieba-state.tar.gz ]; then
+    mkdir -p "$REMOTE_DIR/data/tieba"
+    tar xzf /tmp/quickquip-tieba-state.tar.gz -C "$REMOTE_DIR"
+fi
+
+sed -i 's/\r$//' "$REMOTE_DIR/.env" 2>"$NULL_DEVICE" || true
+chmod 600 "$REMOTE_DIR/.env" 2>"$NULL_DEVICE" || true
+
+if [ -f "$REMOTE_DIR/prod/sendkey.env" ]; then
+    sed -i 's/\r$//' "$REMOTE_DIR/prod/sendkey.env" 2>"$NULL_DEVICE" || true
+    chmod 600 "$REMOTE_DIR/prod/sendkey.env" 2>"$NULL_DEVICE" || true
+fi
+
+if [ -d "$REMOTE_DIR/prod/llbot-data" ]; then
+    LLBOT_PYTHON=python3
+    for candidate in "$REMOTE_DIR/prod/llbot-data/default_config.json" "$REMOTE_DIR"/prod/llbot-data/data/config_*.json; do
+        if [ -e "$candidate" ] && [ ! -w "$candidate" ]; then
+            LLBOT_PYTHON="sudo -n python3"
+            break
+        fi
+    done
+    $LLBOT_PYTHON - "$REMOTE_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+remote_dir = Path(sys.argv[1])
+
+def read_env_value(path: Path, key: str) -> str:
+    try:
+        lines = path.read_text(encoding="utf-8-sig").splitlines()
+    except OSError:
+        return ""
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        if name == key:
+            value = value.strip()
+            if (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            ):
+                value = value[1:-1]
+            return value
+    return ""
+
+token = read_env_value(remote_dir / ".env", "ONEBOT_ACCESS_TOKEN")
+if not token:
+    raise SystemExit(0)
+
+paths = [remote_dir / "prod/llbot-data/default_config.json"]
+paths.extend(sorted((remote_dir / "prod/llbot-data/data").glob("config_*.json")))
+for path in paths:
+    if not path.exists():
+        continue
+    data = json.loads(path.read_text(encoding="utf-8"))
+    connect = data.setdefault("ob11", {}).setdefault("connect", [])
+    while len(connect) <= 1:
+        connect.append({})
+    connect[1]["url"] = "ws://quickquip:8080/onebot/v11/ws/"
+    connect[1]["token"] = token
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=4) + "\n", encoding="utf-8")
+    print(f"Synced LLBot OneBot reverse WebSocket config: {path}")
+PY
+fi
+
+chmod 750 "$REMOTE_DIR" "$REMOTE_DIR/prod" 2>"$NULL_DEVICE" || true
+if [ -f "$REMOTE_DIR/data/tieba/pool.json" ]; then
+    sudo chown "$(id -u):$(id -g)" "$REMOTE_DIR/data/tieba/pool.json" 2>"$NULL_DEVICE" || true
+fi
+
+rm -f /tmp/quickquip-deploy.tar.gz /tmp/quickquip-tieba-state.tar.gz /tmp/quickquip-sendkey.env
+
+cd "$REMOTE_DIR/prod"
+docker compose --env-file ../.env config --quiet
+docker compose --env-file ../.env build quickquip web-admin
+docker compose --env-file ../.env up -d --remove-orphans llbot quickquip web-admin
+docker compose --env-file ../.env up -d --force-recreate quickquip web-admin
+docker compose --env-file ../.env ps
+docker builder prune --filter 'until=48h' --force
+docker image prune -f
+'@
+$RemoteDeployScript = $RemoteDeployScript.Replace("__REMOTE_DIR__", $RemoteDir) -replace "`r`n", "`n"
+Invoke-Native "ssh remote deploy" {
+    $RemoteDeployScript | ssh @SshArgs $HostAlias "tr -d '\r' | bash -s"
+}
+
+Write-Host "Deploy complete." -ForegroundColor Green
+Write-Host "QuickQuip logs: ssh $HostAlias 'cd $RemoteDir/prod && docker compose --env-file ../.env logs -f quickquip'" -ForegroundColor Yellow
+Write-Host "Web Admin logs: ssh $HostAlias 'cd $RemoteDir/prod && docker compose --env-file ../.env logs -f web-admin'" -ForegroundColor Yellow
+
+Remove-Item -Force $TempArchive -ErrorAction SilentlyContinue
+Remove-Item -Force $TiebaStateArchive -ErrorAction SilentlyContinue

--- a/prod.example/deploy-v4-bak.sh
+++ b/prod.example/deploy-v4-bak.sh
@@ -1,0 +1,251 @@
+#!/bin/bash
+# Archived flat-layout deployment driver. Use deploy-v4.sh for releases.
+# Linux equivalent of deploy-v4.ps1: builds the frontend locally, packs the
+# project, uploads it via scp, and runs the remote deploy over ssh.
+#
+# Usage (run from project root):
+#   bash prod/deploy-v4.sh
+#   bash prod/deploy-v4.sh -LocalCheck        # pack + report size, no upload
+#   bash prod/deploy-v4.sh -HostAlias <host> -RemoteDir </opt/QuickQuip>
+#
+# quickquip-prod is a placeholder SSH host alias; change it via -HostAlias.
+
+set -euo pipefail
+
+HostAlias="quickquip-prod"
+RemoteDir="/opt/QuickQuip"
+LocalCheck=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -LocalCheck|--local-check) LocalCheck=1 ;;
+        -HostAlias|--host-alias) HostAlias="${2:?missing value for -HostAlias}"; shift ;;
+        -RemoteDir|--remote-dir) RemoteDir="${2:?missing value for -RemoteDir}"; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -t 1 ]; then
+    C=$'\033[0;36m'; G=$'\033[0;32m'; R=$'\033[0;31m'; Y=$'\033[1;33m'; D=$'\033[0;36m'; N=$'\033[0m'
+else
+    C=''; G=''; R=''; Y=''; D=''; N=''
+fi
+
+ScriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ProjectRoot="$(cd "$ScriptDir/.." && pwd)"
+cd "$ProjectRoot"
+
+TmpBase="${TMPDIR:-/tmp}"
+TempArchive="$TmpBase/quickquip-deploy.tar.gz"
+TiebaStateArchive="$TmpBase/quickquip-tieba-state.tar.gz"
+TiebaStateFile="data/tieba/storage_state.json"
+SendkeyEnvFile="prod/sendkey.env"
+FontFile="data/fonts/NotoSansSC-Regular.ttf"
+LocalPrivateWorkspace="d""ev"
+
+ssh_args=(-o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
+
+run_step() {
+    local desc="$1"; shift
+    local rc=0
+    "$@" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        echo "${R}FAILED: $desc (exit $rc)${N}" >&2
+        exit 1
+    fi
+}
+
+for required_path in ".env" "prod/Dockerfile" "prod/docker-compose.yml" "pyproject.toml" "requirements.txt" "src/quickquip" "src/plugins" "config/llm.toml" "llm_about/_example/vocab.yaml" "llm_about/_example/identities.yaml" "docker/searxng/settings.yml"; do
+    [ -e "$required_path" ] || { echo "${R}Missing required file: $required_path${N}" >&2; exit 1; }
+done
+
+# Nested prod/prod.example means the template was copied into an existing prod/
+# (cp -r does not overwrite); abort so the script never runs with production
+# settings or uploads prod/sendkey.env. See prod.example/README.md.
+if [ -d "prod/prod.example" ]; then
+    echo "${R}prod/prod.example exists: the template was nested into an existing prod/ by 'cp -r prod.example prod'.${N}" >&2
+    echo "${R}This script would run with your production settings and upload prod/sendkey.env. Move the old prod/ aside and re-copy the template.${N}" >&2
+    exit 1
+fi
+
+echo "${C}Building frontend...${N}"
+run_step "frontend build" bash -c 'cd frontend && pnpm install --frozen-lockfile && pnpm build'
+
+echo "${C}Packing project...${N}"
+run_step "tar archive" tar czf "$TempArchive" \
+    --exclude='.git' \
+    --exclude='.github' \
+    --exclude='__pycache__' \
+    --exclude='.venv' \
+    --exclude='.vscode' \
+    --exclude='.claude' \
+    --exclude='.gemini' \
+    --exclude='AGENTS.md' \
+    --exclude='AGENTS.override.md' \
+    --exclude='CLAUDE.md' \
+    --exclude='./data' \
+    --exclude="$LocalPrivateWorkspace" \
+    --exclude='prod/sendkey.env' \
+    --exclude='prod/sendkey.env.example' \
+    --exclude='prod/README.md' \
+    --exclude='prod/llbot-qq' \
+    --exclude='prod/llbot-data' \
+    --exclude='prod/napcat-data' \
+    --exclude='prod/home_router_ed25519' \
+    --exclude='prod/home_router_ed25519.pub' \
+    --exclude='frontend/node_modules' \
+    --exclude='./tests' \
+    --exclude='test_*.py' \
+    --exclude='./scripts' \
+    --exclude='requirements-dev.txt' \
+    --exclude='.pytest-tmp-*' \
+    --exclude='*.tar' \
+    --exclude='*.tar.gz' \
+    .
+
+if [ -e "$TiebaStateFile" ]; then
+    echo "${C}Packing Tieba storage state...${N}"
+    run_step "Tieba state archive" tar czf "$TiebaStateArchive" "$TiebaStateFile"
+fi
+
+[ -e "$TempArchive" ] || { echo "${R}Archive was not created; aborting.${N}" >&2; exit 1; }
+
+if [ "$LocalCheck" -eq 1 ]; then
+    sizeMB=$(awk -v b="$(wc -c < "$TempArchive")" 'BEGIN{printf "%.2f", b/1048576}')
+    echo "${G}Local check complete. Archive size: ${sizeMB} MB${N}"
+    rm -f "$TempArchive" "$TiebaStateArchive"
+    exit 0
+fi
+
+[[ "$RemoteDir" =~ ^/[a-zA-Z0-9_./-]+$ && "$RemoteDir" != / && "$RemoteDir" != *'/../'* ]] || exit 2
+run_step "legacy layout guard" ssh "${ssh_args[@]}" "$HostAlias" \
+    "test ! -e '$RemoteDir/releases' && test ! -L '$RemoteDir/current'" \
+    || { echo "Release layout detected; use deploy-v4." >&2; exit 1; }
+echo "${C}Uploading to server...${N}"
+run_step "scp archive" scp "${ssh_args[@]}" "$TempArchive" "${HostAlias}:/tmp/quickquip-deploy.tar.gz"
+if [ -e "$TiebaStateArchive" ]; then
+    run_step "scp Tieba state" scp "${ssh_args[@]}" "$TiebaStateArchive" "${HostAlias}:/tmp/quickquip-tieba-state.tar.gz"
+fi
+if [ -e "$SendkeyEnvFile" ]; then
+    echo "${D}Uploading ops notification env...${N}"
+    run_step "scp sendkey env" scp "${ssh_args[@]}" "$SendkeyEnvFile" "${HostAlias}:/tmp/quickquip-sendkey.env"
+fi
+if [ -e "$FontFile" ]; then
+    echo "${D}Uploading wordcloud font...${N}"
+    run_step "ssh create font dir" ssh "${ssh_args[@]}" "$HostAlias" "mkdir -p $RemoteDir/data/fonts"
+    run_step "scp font" scp "${ssh_args[@]}" "$FontFile" "${HostAlias}:${RemoteDir}/data/fonts/NotoSansSC-Regular.ttf"
+fi
+
+echo "${C}Extracting and rebuilding containers...${N}"
+remote_script=$(cat <<'REMOTE'
+set -eu
+REMOTE_DIR="__REMOTE_DIR__"
+NULL_DEVICE="/d""ev/null"
+mkdir -p "$REMOTE_DIR"
+cd "$REMOTE_DIR"
+
+tar xzf /tmp/quickquip-deploy.tar.gz
+rm -f "$REMOTE_DIR/AGENTS.md" "$REMOTE_DIR/AGENTS.override.md" "$REMOTE_DIR/CLAUDE.md" "$REMOTE_DIR"/test_*.py
+rm -f "$REMOTE_DIR/requirements-dev.txt" "$REMOTE_DIR/docs/GROUP_COMMANDS.md"
+rm -rf "$REMOTE_DIR/.gemini" "$REMOTE_DIR/tests" "$REMOTE_DIR/scripts" "$REMOTE_DIR/frontend-v1" "$REMOTE_DIR/frontend-v2"
+
+if [ -f /tmp/quickquip-sendkey.env ]; then
+    mkdir -p "$REMOTE_DIR/prod"
+    install -m 600 /tmp/quickquip-sendkey.env "$REMOTE_DIR/prod/sendkey.env"
+fi
+
+if [ -f /tmp/quickquip-tieba-state.tar.gz ]; then
+    mkdir -p "$REMOTE_DIR/data/tieba"
+    tar xzf /tmp/quickquip-tieba-state.tar.gz -C "$REMOTE_DIR"
+fi
+
+sed -i 's/\r$//' "$REMOTE_DIR/.env" 2>"$NULL_DEVICE" || true
+chmod 600 "$REMOTE_DIR/.env" 2>"$NULL_DEVICE" || true
+
+if [ -f "$REMOTE_DIR/prod/sendkey.env" ]; then
+    sed -i 's/\r$//' "$REMOTE_DIR/prod/sendkey.env" 2>"$NULL_DEVICE" || true
+    chmod 600 "$REMOTE_DIR/prod/sendkey.env" 2>"$NULL_DEVICE" || true
+fi
+
+if [ -d "$REMOTE_DIR/prod/llbot-data" ]; then
+    LLBOT_PYTHON=python3
+    for candidate in "$REMOTE_DIR/prod/llbot-data/default_config.json" "$REMOTE_DIR"/prod/llbot-data/data/config_*.json; do
+        if [ -e "$candidate" ] && [ ! -w "$candidate" ]; then
+            LLBOT_PYTHON="sudo -n python3"
+            break
+        fi
+    done
+    $LLBOT_PYTHON - "$REMOTE_DIR" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+remote_dir = Path(sys.argv[1])
+
+def read_env_value(path: Path, key: str) -> str:
+    try:
+        lines = path.read_text(encoding="utf-8-sig").splitlines()
+    except OSError:
+        return ""
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        if name == key:
+            value = value.strip()
+            if (value.startswith('"') and value.endswith('"')) or (
+                value.startswith("'") and value.endswith("'")
+            ):
+                value = value[1:-1]
+            return value
+    return ""
+
+token = read_env_value(remote_dir / ".env", "ONEBOT_ACCESS_TOKEN")
+if not token:
+    raise SystemExit(0)
+
+paths = [remote_dir / "prod/llbot-data/default_config.json"]
+paths.extend(sorted((remote_dir / "prod/llbot-data/data").glob("config_*.json")))
+for path in paths:
+    if not path.exists():
+        continue
+    data = json.loads(path.read_text(encoding="utf-8"))
+    connect = data.setdefault("ob11", {}).setdefault("connect", [])
+    while len(connect) <= 1:
+        connect.append({})
+    connect[1]["url"] = "ws://quickquip:8080/onebot/v11/ws/"
+    connect[1]["token"] = token
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=4) + "\n", encoding="utf-8")
+    print(f"Synced LLBot OneBot reverse WebSocket config: {path}")
+PY
+fi
+
+chmod 750 "$REMOTE_DIR" "$REMOTE_DIR/prod" 2>"$NULL_DEVICE" || true
+if [ -f "$REMOTE_DIR/data/tieba/pool.json" ]; then
+    sudo chown "$(id -u):$(id -g)" "$REMOTE_DIR/data/tieba/pool.json" 2>"$NULL_DEVICE" || true
+fi
+
+rm -f /tmp/quickquip-deploy.tar.gz /tmp/quickquip-tieba-state.tar.gz /tmp/quickquip-sendkey.env
+
+cd "$REMOTE_DIR/prod"
+docker compose --env-file ../.env config --quiet
+docker compose --env-file ../.env build quickquip web-admin
+docker compose --env-file ../.env up -d --remove-orphans llbot quickquip web-admin
+docker compose --env-file ../.env up -d --force-recreate quickquip web-admin
+docker compose --env-file ../.env ps
+docker builder prune --filter 'until=48h' --force
+docker image prune -f
+REMOTE
+)
+remote_script=${remote_script//__REMOTE_DIR__/$RemoteDir}
+if ! printf '%s\n' "$remote_script" | ssh "${ssh_args[@]}" "$HostAlias" "tr -d '\r' | bash -s"; then
+    echo "${R}FAILED: ssh remote deploy${N}" >&2
+    exit 1
+fi
+
+echo "${G}Deploy complete.${N}"
+echo "${Y}QuickQuip logs: ssh $HostAlias 'cd $RemoteDir/prod && docker compose --env-file ../.env logs -f quickquip'${N}"
+echo "${Y}Web Admin logs: ssh $HostAlias 'cd $RemoteDir/prod && docker compose --env-file ../.env logs -f web-admin'${N}"
+
+rm -f "$TempArchive" "$TiebaStateArchive"

--- a/prod.example/deploy-v4.ps1
+++ b/prod.example/deploy-v4.ps1
@@ -1,323 +1,106 @@
-# QuickQuip production deploy script (IPv4 / PowerShell)
-# Usage: run from project root:
-#   .\prod\deploy-v4.ps1
-# Local archive check:
-#   .\prod\deploy-v4.ps1 -LocalCheck
-
+# Local release driver. Shares the remote transaction with deploy-v4.sh.
 param(
-    [switch]$LocalCheck,
+    [Alias("LocalCheck")][switch]$DryRun,
+    [switch]$Status,
+    [switch]$Rollback,
+    [string]$ReleaseId = "",
+    [switch]$Migrate,
+    [switch]$SkipHealth,
     [string]$HostAlias = "quickquip-prod",
-    [string]$RemoteDir = "/opt/QuickQuip"
+    [string]$RemoteDir = "/opt/QuickQuip",
+    [int]$KeepReleases = 4
 )
-
 $ErrorActionPreference = "Stop"
 $OutputEncoding = [System.Text.UTF8Encoding]::new($false)
-
-$TempArchive = "$env:TEMP\quickquip-deploy.tar.gz"
-$TiebaStateArchive = "$env:TEMP\quickquip-tieba-state.tar.gz"
-$ProjectRoot = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
-$LocalPrivateWorkspace = "d" + "ev"
-$TiebaStateFile = "data/tieba/storage_state.json"
-$SendkeyEnvFile = "prod/sendkey.env"
-$FontFile = "data/fonts/NotoSansSC-Regular.ttf"
-$SshArgs = @(
-    "-o", "StrictHostKeyChecking=no",
-    "-o", "BatchMode=yes",
-    "-o", "ConnectTimeout=15",
-    "-o", "ServerAliveInterval=15",
-    "-o", "ServerAliveCountMax=3"
-)
-$ScpArgs = @(
-    "-o", "StrictHostKeyChecking=no",
-    "-o", "BatchMode=yes",
-    "-o", "ConnectTimeout=15",
-    "-o", "ServerAliveInterval=15",
-    "-o", "ServerAliveCountMax=3"
-)
-
-function Initialize-NodeToolchainPath {
-    $preferred = @()
-    $voltaProgram = "C:\Program Files\Volta"
-    $voltaUserBin = Join-Path $env:LOCALAPPDATA "Volta\bin"
-    foreach ($path in @($voltaProgram, $voltaUserBin)) {
-        if ($path -and (Test-Path $path)) {
-            $preferred += $path
-        }
-    }
-
-    $seen = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
-    $items = @()
-    foreach ($path in ($preferred + ($env:Path -split ';'))) {
-        if (-not $path) {
-            continue
-        }
-        $trimmed = $path.Trim()
-        if (-not $trimmed) {
-            continue
-        }
-        $normalized = $trimmed.TrimEnd('\')
-        if ($seen.Add($normalized)) {
-            $items += $trimmed
-        }
-    }
-    $env:Path = ($items -join ';')
+function Invoke-Native([string]$Description, [scriptblock]$Command) {
+    & $Command
+    if ($LASTEXITCODE -ne 0) { throw "$Description (exit $LASTEXITCODE)" }
 }
-
-function Get-PnpmCommand {
-    foreach ($candidate in @(
-        "C:\Program Files\Volta\pnpm.cmd",
-        "C:\Program Files\Volta\pnpm.exe",
-        (Join-Path $env:LOCALAPPDATA "Volta\bin\pnpm.cmd"),
-        (Join-Path $env:LOCALAPPDATA "Volta\bin\pnpm.exe")
-    )) {
-        if ($candidate -and (Test-Path $candidate)) {
-            return $candidate
-        }
-    }
-
-    $command = Get-Command "pnpm.exe" -ErrorAction SilentlyContinue
-    if ($command) {
-        return $command.Source
-    }
-
-    $command = Get-Command "pnpm.cmd" -ErrorAction SilentlyContinue
-    if ($command) {
-        return $command.Source
-    }
-
-    throw "No usable pnpm found. Install pnpm (e.g. volta install pnpm) or fix Volta."
-}
-
-function Invoke-Native {
-    param([string]$Desc, [scriptblock]$Cmd)
-    & $Cmd
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "FAILED: $Desc (exit $LASTEXITCODE)" -ForegroundColor Red
-        exit $LASTEXITCODE
-    }
-}
-
+$Mode = "deploy"
+if ($Status) { $Mode = "status" }
+if ($Rollback) { $Mode = "rollback" }
+if ($Migrate) { $Mode = "migrate" }
+if (([int]$Status.IsPresent + [int]$Rollback.IsPresent + [int]$Migrate.IsPresent) -gt 1) { throw "Choose only one action" }
+if ($DryRun -and ($Mode -ne "deploy" -or $SkipHealth)) { throw "DryRun supports deployment preview only" }
+if ($SkipHealth -and $Mode -notin @("deploy", "migrate")) { throw "SkipHealth supports deploy/migrate only" }
+if ($ReleaseId -and -not $Rollback) { throw "ReleaseId requires Rollback" }
+if ($ReleaseId -and $ReleaseId -cnotmatch '^[0-9]{8}-[0-9]{6}(-[a-f0-9]{12})?(-baseline)?$') { throw "Invalid release id" }
+if ($RemoteDir -cnotmatch '^/[a-zA-Z0-9_./-]+$' -or $RemoteDir -eq '/' -or $RemoteDir.Contains('/../')) { throw "Invalid absolute deployment root" }
+if ($HostAlias -cnotmatch '^[a-zA-Z0-9_][a-zA-Z0-9_.@-]*$') { throw "Invalid SSH alias" }
+if ($KeepReleases -lt 2 -or $KeepReleases -gt 100) { throw "KeepReleases must be 2..100" }
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$ProjectRoot = Split-Path -Parent $ScriptDir
+$SshArgs = @('-o', 'StrictHostKeyChecking=accept-new', '-o', 'BatchMode=yes', '-o', 'ConnectTimeout=15', '-o', 'ServerAliveInterval=15', '-o', 'ServerAliveCountMax=3')
+$Id = [DateTime]::UtcNow.ToString('yyyyMMdd-HHmmss') + '-' + [Guid]::NewGuid().ToString('N').Substring(0, 12)
+$Incoming = "$RemoteDir/.deploy/incoming/$Id"
+$Temp = Join-Path ([System.IO.Path]::GetTempPath()) "quickquip-$Id"
 Push-Location $ProjectRoot
-
-Initialize-NodeToolchainPath
-$PnpmCommand = Get-PnpmCommand
-
-foreach ($requiredPath in @(".env", "prod/Dockerfile", "prod/docker-compose.yml", "pyproject.toml", "requirements.txt", "src/quickquip", "src/plugins", "config/llm.toml", "llm_about/_example/vocab.yaml", "llm_about/_example/identities.yaml", "docker/searxng/settings.yml")) {
-    if (-not (Test-Path $requiredPath)) {
-        Write-Host "Missing required file: $requiredPath" -ForegroundColor Red
-        Pop-Location
-        exit 1
+try {
+    if (Test-Path -PathType Container 'prod/prod.example') { throw 'Nested prod/prod.example; initialize prod again' }
+    foreach ($file in @('remote-deploy-v4.sh', 'deploy-state.py')) {
+        if (-not (Test-Path (Join-Path $ScriptDir $file))) { throw "Missing $file" }
     }
-}
-
-# Nested prod/prod.example means the template was copied into an existing prod/
-# (Copy-Item -Recurse does not overwrite); abort so the script never runs with
-# production settings or uploads prod/sendkey.env. See prod.example/README.md.
-if (Test-Path -PathType Container "prod/prod.example") {
-    Write-Host "prod/prod.example exists: the template was nested into an existing prod/ by 'Copy-Item -Recurse prod.example prod'." -ForegroundColor Red
-    Write-Host "This script would run with your production settings and upload prod/sendkey.env. Move the old prod/ aside and re-copy the template." -ForegroundColor Red
+    if ($Mode -in @('deploy', 'migrate')) {
+        if (-not (Test-Path '.env')) { throw 'Root .env missing' }
+        $pnpm = Get-Command pnpm.cmd, pnpm.exe, pnpm -ErrorAction SilentlyContinue | Select-Object -First 1
+        if (-not $pnpm) { throw 'Install pnpm and put it on PATH' }
+        Push-Location frontend
+        try {
+            Invoke-Native 'frontend dependencies' { & $pnpm.Source install --frozen-lockfile }
+            Invoke-Native 'frontend build' { & $pnpm.Source build }
+        } finally { Pop-Location }
+        $entries = @(Get-Content (Join-Path $ScriptDir 'deploy-manifest.txt'))
+        foreach ($item in $entries) {
+            if ($item -cnotmatch '^[a-zA-Z0-9_./-]+$' -or $item.StartsWith('/') -or $item.Contains('..')) { throw 'Invalid manifest entry' }
+            if (-not (Test-Path $item)) { throw "Missing manifest entry: $item" }
+        }
+        New-Item -ItemType Directory $Temp | Out-Null
+        $List = Join-Path $Temp 'manifest.txt'
+        $Archive = Join-Path $Temp 'release.tar.gz'
+        [System.IO.File]::WriteAllText($List, (($entries -join "`n") + "`n"), [System.Text.UTF8Encoding]::new($false))
+        Invoke-Native 'release archive' { tar --exclude=__pycache__ --exclude='*.pyc' -czf $Archive -T $List }
+        if ($DryRun) {
+            Invoke-Native 'archive preview' { tar -tzf $Archive }
+            Write-Host 'Preview complete; frontend built locally, temporary archive removed, no remote connection or upload.'
+            return
+        }
+    }
+    Invoke-Native 'remote prerequisites and exclusive staging' {
+        ssh @SshArgs $HostAlias "command -v rsync >/dev/null && command -v flock >/dev/null && docker compose version >/dev/null && umask 077 && mkdir -p '$RemoteDir/.deploy/incoming' && chmod 700 '$RemoteDir/.deploy' '$RemoteDir/.deploy/incoming' && mkdir '$Incoming'"
+    }
+    Invoke-Native 'runner upload' {
+        scp @SshArgs (Join-Path $ScriptDir 'remote-deploy-v4.sh') (Join-Path $ScriptDir 'deploy-state.py') "${HostAlias}:$Incoming/"
+    }
+    if ($Mode -in @('deploy', 'migrate')) {
+        Invoke-Native 'archive upload' { scp @SshArgs $Archive "${HostAlias}:$Incoming/release.tar.gz" }
+        $shared = @('.env', 'prod/check_bot.sh', 'prod/cron_check_bot.sh')
+        foreach ($item in @('prod/sendkey.env', 'data/fonts/NotoSansSC-Regular.ttf', 'data/tieba/storage_state.json')) {
+            if (Test-Path $item) { $shared += $item }
+        }
+        foreach ($item in $shared) {
+            $parent = if ($item.Contains('/')) { $item.Substring(0, $item.LastIndexOf('/')) } else { '' }
+            Invoke-Native 'private shared staging' { ssh @SshArgs $HostAlias "umask 077; mkdir -p '$Incoming/shared/$parent'" }
+            Invoke-Native 'shared upload' { scp @SshArgs $item "${HostAlias}:$Incoming/shared/$item" }
+        }
+    }
+    $skip = if ($SkipHealth) { '1' } else { '0' }
+    Invoke-Native 'launch (if uncertain, inspect operation log before retrying)' {
+        ssh @SshArgs $HostAlias "DETACH=1 SKIP_HEALTH=$skip bash '$Incoming/remote-deploy-v4.sh' '$RemoteDir' '$Id' '$KeepReleases' '$Mode' '$ReleaseId'"
+    }
+    $Log = "$RemoteDir/.deploy/$Id.log"
+    $ExitFile = "$RemoteDir/.deploy/$Id.exit"
+    $attempts = 0
+    while ($true) {
+        ssh @SshArgs $HostAlias "while [ ! -f '$ExitFile' ]; do sleep 1; done & watcher=`$!; tail -n +1 -f --pid=`$watcher '$Log'; wait `$watcher"
+        if ($LASTEXITCODE -eq 0) { break }
+        $attempts++
+        if ($attempts -gt 20) { throw "Connection lost; remote action may continue: $Log" }
+        Start-Sleep -Seconds 5
+    }
+    $code = ssh @SshArgs $HostAlias "cat '$ExitFile'"
+    if ($LASTEXITCODE -ne 0 -or "$code".Trim() -ne '0') { throw "Remote action failed (exit $code): $Log" }
+    Write-Host "$Mode complete. Status: prod/deploy-v4.ps1 -Status -HostAlias $HostAlias -RemoteDir $RemoteDir"
+} finally {
+    if (Test-Path $Temp) { Remove-Item -Recurse -Force $Temp }
     Pop-Location
-    exit 1
 }
-
-Write-Host "Building frontend..." -ForegroundColor Cyan
-Push-Location "frontend"
-Invoke-Native "pnpm install --frozen-lockfile" { & $PnpmCommand install --frozen-lockfile }
-Invoke-Native "pnpm build" { & $PnpmCommand build }
-Pop-Location
-
-Write-Host "Packing project..." -ForegroundColor Cyan
-Invoke-Native "tar archive" {
-    tar czf $TempArchive `
-        --exclude='.git' `
-        --exclude='.github' `
-        --exclude='__pycache__' `
-        --exclude='.venv' `
-        --exclude='.vscode' `
-        --exclude='.claude' `
-        --exclude='.gemini' `
-        --exclude='AGENTS.md' `
-        --exclude='AGENTS.override.md' `
-        --exclude='CLAUDE.md' `
-        --exclude='./data' `
-        --exclude="$LocalPrivateWorkspace" `
-        --exclude='prod/sendkey.env' `
-        --exclude='prod/sendkey.env.example' `
-        --exclude='prod/README.md' `
-        --exclude='prod/llbot-qq' `
-        --exclude='prod/llbot-data' `
-        --exclude='prod/napcat-data' `
-        --exclude='prod/home_router_ed25519' `
-        --exclude='prod/home_router_ed25519.pub' `
-        --exclude='frontend/node_modules' `
-        --exclude='./tests' `
-        --exclude='test_*.py' `
-        --exclude='./scripts' `
-        --exclude='requirements-dev.txt' `
-        --exclude='.pytest-tmp-*' `
-        --exclude='*.tar' `
-        --exclude='*.tar.gz' `
-        .
-}
-if (Test-Path $TiebaStateFile) {
-    Write-Host "Packing Tieba storage state..." -ForegroundColor Cyan
-    Invoke-Native "Tieba state archive" {
-        tar czf $TiebaStateArchive $TiebaStateFile
-    }
-}
-Pop-Location
-
-if (-not (Test-Path $TempArchive)) {
-    Write-Host "Archive was not created; aborting." -ForegroundColor Red
-    exit 1
-}
-
-if ($LocalCheck) {
-    $archiveInfo = Get-Item $TempArchive
-    $archiveSizeMB = [Math]::Round($archiveInfo.Length / 1MB, 2)
-    Write-Host "Local check complete. Archive size: ${archiveSizeMB} MB" -ForegroundColor Green
-    Remove-Item -Force $TempArchive -ErrorAction SilentlyContinue
-    Remove-Item -Force $TiebaStateArchive -ErrorAction SilentlyContinue
-    exit 0
-}
-
-Write-Host "Uploading to server..." -ForegroundColor Cyan
-Invoke-Native "scp archive" {
-    scp @ScpArgs $TempArchive "${HostAlias}:/tmp/quickquip-deploy.tar.gz"
-}
-if (Test-Path $TiebaStateArchive) {
-    Invoke-Native "scp Tieba state" {
-        scp @ScpArgs $TiebaStateArchive "${HostAlias}:/tmp/quickquip-tieba-state.tar.gz"
-    }
-}
-if (Test-Path $SendkeyEnvFile) {
-    Write-Host "Uploading ops notification env..." -ForegroundColor DarkCyan
-    Invoke-Native "scp sendkey env" {
-        scp @ScpArgs $SendkeyEnvFile "${HostAlias}:/tmp/quickquip-sendkey.env"
-    }
-}
-if (Test-Path $FontFile) {
-    Write-Host "Uploading wordcloud font..." -ForegroundColor DarkCyan
-    $fontInfo = Get-Item $FontFile
-    $fontSizeMB = [Math]::Round($fontInfo.Length / 1MB, 2)
-    Invoke-Native "ssh create font dir" {
-        ssh @SshArgs $HostAlias "mkdir -p $RemoteDir/data/fonts"
-    }
-    Write-Host "Uploading font (${fontSizeMB} MB)..." -ForegroundColor DarkCyan
-    Invoke-Native "scp font" {
-        scp @ScpArgs $FontFile "${HostAlias}:${RemoteDir}/data/fonts/NotoSansSC-Regular.ttf"
-    }
-}
-
-Write-Host "Extracting and rebuilding containers..." -ForegroundColor Cyan
-$RemoteDeployScript = @'
-set -eu
-REMOTE_DIR="__REMOTE_DIR__"
-NULL_DEVICE="/d""ev/null"
-mkdir -p "$REMOTE_DIR"
-cd "$REMOTE_DIR"
-
-tar xzf /tmp/quickquip-deploy.tar.gz
-rm -f "$REMOTE_DIR/AGENTS.md" "$REMOTE_DIR/AGENTS.override.md" "$REMOTE_DIR/CLAUDE.md" "$REMOTE_DIR"/test_*.py
-rm -f "$REMOTE_DIR/requirements-dev.txt" "$REMOTE_DIR/docs/GROUP_COMMANDS.md"
-rm -rf "$REMOTE_DIR/.gemini" "$REMOTE_DIR/tests" "$REMOTE_DIR/scripts" "$REMOTE_DIR/frontend-v1" "$REMOTE_DIR/frontend-v2"
-
-if [ -f /tmp/quickquip-sendkey.env ]; then
-    mkdir -p "$REMOTE_DIR/prod"
-    install -m 600 /tmp/quickquip-sendkey.env "$REMOTE_DIR/prod/sendkey.env"
-fi
-
-if [ -f /tmp/quickquip-tieba-state.tar.gz ]; then
-    mkdir -p "$REMOTE_DIR/data/tieba"
-    tar xzf /tmp/quickquip-tieba-state.tar.gz -C "$REMOTE_DIR"
-fi
-
-sed -i 's/\r$//' "$REMOTE_DIR/.env" 2>"$NULL_DEVICE" || true
-chmod 600 "$REMOTE_DIR/.env" 2>"$NULL_DEVICE" || true
-
-if [ -f "$REMOTE_DIR/prod/sendkey.env" ]; then
-    sed -i 's/\r$//' "$REMOTE_DIR/prod/sendkey.env" 2>"$NULL_DEVICE" || true
-    chmod 600 "$REMOTE_DIR/prod/sendkey.env" 2>"$NULL_DEVICE" || true
-fi
-
-if [ -d "$REMOTE_DIR/prod/llbot-data" ]; then
-    LLBOT_PYTHON=python3
-    for candidate in "$REMOTE_DIR/prod/llbot-data/default_config.json" "$REMOTE_DIR"/prod/llbot-data/data/config_*.json; do
-        if [ -e "$candidate" ] && [ ! -w "$candidate" ]; then
-            LLBOT_PYTHON="sudo -n python3"
-            break
-        fi
-    done
-    $LLBOT_PYTHON - "$REMOTE_DIR" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-remote_dir = Path(sys.argv[1])
-
-def read_env_value(path: Path, key: str) -> str:
-    try:
-        lines = path.read_text(encoding="utf-8-sig").splitlines()
-    except OSError:
-        return ""
-    for line in lines:
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        name, value = line.split("=", 1)
-        if name == key:
-            value = value.strip()
-            if (value.startswith('"') and value.endswith('"')) or (
-                value.startswith("'") and value.endswith("'")
-            ):
-                value = value[1:-1]
-            return value
-    return ""
-
-token = read_env_value(remote_dir / ".env", "ONEBOT_ACCESS_TOKEN")
-if not token:
-    raise SystemExit(0)
-
-paths = [remote_dir / "prod/llbot-data/default_config.json"]
-paths.extend(sorted((remote_dir / "prod/llbot-data/data").glob("config_*.json")))
-for path in paths:
-    if not path.exists():
-        continue
-    data = json.loads(path.read_text(encoding="utf-8"))
-    connect = data.setdefault("ob11", {}).setdefault("connect", [])
-    while len(connect) <= 1:
-        connect.append({})
-    connect[1]["url"] = "ws://quickquip:8080/onebot/v11/ws/"
-    connect[1]["token"] = token
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=4) + "\n", encoding="utf-8")
-    print(f"Synced LLBot OneBot reverse WebSocket config: {path}")
-PY
-fi
-
-chmod 750 "$REMOTE_DIR" "$REMOTE_DIR/prod" 2>"$NULL_DEVICE" || true
-if [ -f "$REMOTE_DIR/data/tieba/pool.json" ]; then
-    sudo chown "$(id -u):$(id -g)" "$REMOTE_DIR/data/tieba/pool.json" 2>"$NULL_DEVICE" || true
-fi
-
-rm -f /tmp/quickquip-deploy.tar.gz /tmp/quickquip-tieba-state.tar.gz /tmp/quickquip-sendkey.env
-
-cd "$REMOTE_DIR/prod"
-docker compose --env-file ../.env config --quiet
-docker compose --env-file ../.env build quickquip web-admin
-docker compose --env-file ../.env up -d --remove-orphans llbot quickquip web-admin
-docker compose --env-file ../.env up -d --force-recreate quickquip web-admin
-docker compose --env-file ../.env ps
-docker builder prune --filter 'until=48h' --force
-docker image prune -f
-'@
-$RemoteDeployScript = $RemoteDeployScript.Replace("__REMOTE_DIR__", $RemoteDir) -replace "`r`n", "`n"
-Invoke-Native "ssh remote deploy" {
-    $RemoteDeployScript | ssh @SshArgs $HostAlias "tr -d '\r' | bash -s"
-}
-
-Write-Host "Deploy complete." -ForegroundColor Green
-Write-Host "QuickQuip logs: ssh $HostAlias 'cd $RemoteDir/prod && docker compose --env-file ../.env logs -f quickquip'" -ForegroundColor Yellow
-Write-Host "Web Admin logs: ssh $HostAlias 'cd $RemoteDir/prod && docker compose --env-file ../.env logs -f web-admin'" -ForegroundColor Yellow
-
-Remove-Item -Force $TempArchive -ErrorAction SilentlyContinue
-Remove-Item -Force $TiebaStateArchive -ErrorAction SilentlyContinue

--- a/prod.example/deploy-v4.sh
+++ b/prod.example/deploy-v4.sh
@@ -1,247 +1,94 @@
 #!/bin/bash
-# QuickQuip production deploy script (IPv4 / Linux local driver).
-# Linux equivalent of deploy-v4.ps1: builds the frontend locally, packs the
-# project, uploads it via scp, and runs the remote deploy over ssh.
-#
-# Usage (run from project root):
-#   bash prod/deploy-v4.sh
-#   bash prod/deploy-v4.sh -LocalCheck        # pack + report size, no upload
-#   bash prod/deploy-v4.sh -HostAlias <host> -RemoteDir </opt/QuickQuip>
-#
-# quickquip-prod is a placeholder SSH host alias; change it via -HostAlias.
-
+# Local release driver. DryRun builds locally and previews the upload manifest.
 set -euo pipefail
-
+umask 077
 HostAlias="quickquip-prod"
 RemoteDir="/opt/QuickQuip"
-LocalCheck=0
+Mode=deploy
+Modes=0
+DryRun=0
+SkipHealth=0
+KeepReleases=4
+ReleaseId=""
 while [ $# -gt 0 ]; do
     case "$1" in
-        -LocalCheck|--local-check) LocalCheck=1 ;;
-        -HostAlias|--host-alias) HostAlias="${2:?missing value for -HostAlias}"; shift ;;
-        -RemoteDir|--remote-dir) RemoteDir="${2:?missing value for -RemoteDir}"; shift ;;
-        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+        -DryRun|--dry-run|-LocalCheck|--local-check) DryRun=1 ;;
+        -Status|--status) Mode=status; Modes=$((Modes + 1)) ;;
+        -Rollback|--rollback)
+            Mode=rollback; Modes=$((Modes + 1))
+            if [ -n "${2:-}" ] && [[ "$2" != -* ]]; then ReleaseId="$2"; shift; fi ;;
+        -Migrate|--migrate) Mode=migrate; Modes=$((Modes + 1)) ;;
+        -SkipHealth|--skip-health) SkipHealth=1 ;;
+        -HostAlias|--host-alias) HostAlias="${2:?missing host}"; shift ;;
+        -RemoteDir|--remote-dir) RemoteDir="${2:?missing root}"; shift ;;
+        -KeepReleases|--keep-releases) KeepReleases="${2:?missing retention}"; shift ;;
+        *) printf 'Unknown argument: %s\n' "$1" >&2; exit 2 ;;
     esac
     shift
 done
-
-if [ -t 1 ]; then
-    C=$'\033[0;36m'; G=$'\033[0;32m'; R=$'\033[0;31m'; Y=$'\033[1;33m'; D=$'\033[0;36m'; N=$'\033[0m'
-else
-    C=''; G=''; R=''; Y=''; D=''; N=''
-fi
+die() { printf 'FAILED: %s\n' "$*" >&2; exit 1; }
+[[ "$Modes" -le 1 ]] || die "choose only one action"
+[[ "$DryRun" = 0 || ( "$Mode" = deploy && "$SkipHealth" = 0 ) ]] || die "DryRun supports deployment preview only"
+[[ "$SkipHealth" = 0 || "$Mode" = deploy || "$Mode" = migrate ]] || die "SkipHealth supports deploy/migrate only"
+[[ "$RemoteDir" =~ ^/[a-zA-Z0-9_./-]+$ && "$RemoteDir" != / && "$RemoteDir" != *'/../'* ]] || die "use an absolute root with letters, digits, dot, slash, underscore or hyphen"
+[[ "$HostAlias" =~ ^[a-zA-Z0-9_][a-zA-Z0-9_.@-]*$ ]] || die "invalid SSH alias"
+[[ "$KeepReleases" =~ ^[0-9]+$ && "$KeepReleases" -ge 2 && "$KeepReleases" -le 100 ]] || die "KeepReleases must be 2..100"
+[[ -z "$ReleaseId" || "$ReleaseId" =~ ^[0-9]{8}-[0-9]{6}(-[a-f0-9]{12})?(-baseline)?$ ]] || die "invalid release id"
 
 ScriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ProjectRoot="$(cd "$ScriptDir/.." && pwd)"
-cd "$ProjectRoot"
-
-TmpBase="${TMPDIR:-/tmp}"
-TempArchive="$TmpBase/quickquip-deploy.tar.gz"
-TiebaStateArchive="$TmpBase/quickquip-tieba-state.tar.gz"
-TiebaStateFile="data/tieba/storage_state.json"
-SendkeyEnvFile="prod/sendkey.env"
-FontFile="data/fonts/NotoSansSC-Regular.ttf"
-LocalPrivateWorkspace="d""ev"
-
-ssh_args=(-o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
-
-run_step() {
-    local desc="$1"; shift
-    local rc=0
-    "$@" || rc=$?
-    if [ "$rc" -ne 0 ]; then
-        echo "${R}FAILED: $desc (exit $rc)${N}" >&2
-        exit 1
-    fi
-}
-
-for required_path in ".env" "prod/Dockerfile" "prod/docker-compose.yml" "pyproject.toml" "requirements.txt" "src/quickquip" "src/plugins" "config/llm.toml" "llm_about/_example/vocab.yaml" "llm_about/_example/identities.yaml" "docker/searxng/settings.yml"; do
-    [ -e "$required_path" ] || { echo "${R}Missing required file: $required_path${N}" >&2; exit 1; }
+cd "$ScriptDir/.."
+[ ! -d prod/prod.example ] || die "nested prod/prod.example; move it aside and initialize prod again"
+for file in remote-deploy-v4.sh deploy-state.py; do
+    [ -f "$ScriptDir/$file" ] || die "missing $file"
 done
+Id="$(date -u +%Y%m%d-%H%M%S)-$(od -An -N6 -tx1 /dev/urandom | tr -d ' \n')"
+Incoming="$RemoteDir/.deploy/incoming/$Id"
+ssh_args=(-o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=3)
+rsync_args=(--rsh "ssh ${ssh_args[*]}")
 
-# Nested prod/prod.example means the template was copied into an existing prod/
-# (cp -r does not overwrite); abort so the script never runs with production
-# settings or uploads prod/sendkey.env. See prod.example/README.md.
-if [ -d "prod/prod.example" ]; then
-    echo "${R}prod/prod.example exists: the template was nested into an existing prod/ by 'cp -r prod.example prod'.${N}" >&2
-    echo "${R}This script would run with your production settings and upload prod/sendkey.env. Move the old prod/ aside and re-copy the template.${N}" >&2
-    exit 1
+if [ "$Mode" = deploy ] || [ "$Mode" = migrate ]; then
+    [ -f .env ] || die "root .env missing"
+    [ -f "$ScriptDir/deploy-manifest.txt" ] || die "manifest missing"
+    (cd frontend && pnpm install --frozen-lockfile && pnpm build)
+    while IFS= read -r item; do
+        [[ "$item" =~ ^[a-zA-Z0-9_./-]+$ && "$item" != /* && "$item" != *..* ]] || die "invalid manifest entry"
+        [ -e "$item" ] || die "manifest entry missing: $item"
+    done < "$ScriptDir/deploy-manifest.txt"
+    if [ "$DryRun" = 1 ]; then
+        tar --exclude=__pycache__ --exclude='*.pyc' -cf /dev/null -v -T "$ScriptDir/deploy-manifest.txt"
+        printf 'Preview complete; frontend built locally, no remote connection or upload. Shared files: root .env, ops scripts, and present optional assets.\n'
+        exit 0
+    fi
+    command -v rsync >/dev/null || die "local rsync required"
 fi
 
-echo "${C}Building frontend...${N}"
-run_step "frontend build" bash -c 'cd frontend && pnpm install --frozen-lockfile && pnpm build'
-
-echo "${C}Packing project...${N}"
-run_step "tar archive" tar czf "$TempArchive" \
-    --exclude='.git' \
-    --exclude='.github' \
-    --exclude='__pycache__' \
-    --exclude='.venv' \
-    --exclude='.vscode' \
-    --exclude='.claude' \
-    --exclude='.gemini' \
-    --exclude='AGENTS.md' \
-    --exclude='AGENTS.override.md' \
-    --exclude='CLAUDE.md' \
-    --exclude='./data' \
-    --exclude="$LocalPrivateWorkspace" \
-    --exclude='prod/sendkey.env' \
-    --exclude='prod/sendkey.env.example' \
-    --exclude='prod/README.md' \
-    --exclude='prod/llbot-qq' \
-    --exclude='prod/llbot-data' \
-    --exclude='prod/napcat-data' \
-    --exclude='prod/home_router_ed25519' \
-    --exclude='prod/home_router_ed25519.pub' \
-    --exclude='frontend/node_modules' \
-    --exclude='./tests' \
-    --exclude='test_*.py' \
-    --exclude='./scripts' \
-    --exclude='requirements-dev.txt' \
-    --exclude='.pytest-tmp-*' \
-    --exclude='*.tar' \
-    --exclude='*.tar.gz' \
-    .
-
-if [ -e "$TiebaStateFile" ]; then
-    echo "${C}Packing Tieba storage state...${N}"
-    run_step "Tieba state archive" tar czf "$TiebaStateArchive" "$TiebaStateFile"
-fi
-
-[ -e "$TempArchive" ] || { echo "${R}Archive was not created; aborting.${N}" >&2; exit 1; }
-
-if [ "$LocalCheck" -eq 1 ]; then
-    sizeMB=$(awk -v b="$(wc -c < "$TempArchive")" 'BEGIN{printf "%.2f", b/1048576}')
-    echo "${G}Local check complete. Archive size: ${sizeMB} MB${N}"
-    rm -f "$TempArchive" "$TiebaStateArchive"
-    exit 0
-fi
-
-echo "${C}Uploading to server...${N}"
-run_step "scp archive" scp "${ssh_args[@]}" "$TempArchive" "${HostAlias}:/tmp/quickquip-deploy.tar.gz"
-if [ -e "$TiebaStateArchive" ]; then
-    run_step "scp Tieba state" scp "${ssh_args[@]}" "$TiebaStateArchive" "${HostAlias}:/tmp/quickquip-tieba-state.tar.gz"
-fi
-if [ -e "$SendkeyEnvFile" ]; then
-    echo "${D}Uploading ops notification env...${N}"
-    run_step "scp sendkey env" scp "${ssh_args[@]}" "$SendkeyEnvFile" "${HostAlias}:/tmp/quickquip-sendkey.env"
-fi
-if [ -e "$FontFile" ]; then
-    echo "${D}Uploading wordcloud font...${N}"
-    run_step "ssh create font dir" ssh "${ssh_args[@]}" "$HostAlias" "mkdir -p $RemoteDir/data/fonts"
-    run_step "scp font" scp "${ssh_args[@]}" "$FontFile" "${HostAlias}:${RemoteDir}/data/fonts/NotoSansSC-Regular.ttf"
-fi
-
-echo "${C}Extracting and rebuilding containers...${N}"
-remote_script=$(cat <<'REMOTE'
-set -eu
-REMOTE_DIR="__REMOTE_DIR__"
-NULL_DEVICE="/d""ev/null"
-mkdir -p "$REMOTE_DIR"
-cd "$REMOTE_DIR"
-
-tar xzf /tmp/quickquip-deploy.tar.gz
-rm -f "$REMOTE_DIR/AGENTS.md" "$REMOTE_DIR/AGENTS.override.md" "$REMOTE_DIR/CLAUDE.md" "$REMOTE_DIR"/test_*.py
-rm -f "$REMOTE_DIR/requirements-dev.txt" "$REMOTE_DIR/docs/GROUP_COMMANDS.md"
-rm -rf "$REMOTE_DIR/.gemini" "$REMOTE_DIR/tests" "$REMOTE_DIR/scripts" "$REMOTE_DIR/frontend-v1" "$REMOTE_DIR/frontend-v2"
-
-if [ -f /tmp/quickquip-sendkey.env ]; then
-    mkdir -p "$REMOTE_DIR/prod"
-    install -m 600 /tmp/quickquip-sendkey.env "$REMOTE_DIR/prod/sendkey.env"
-fi
-
-if [ -f /tmp/quickquip-tieba-state.tar.gz ]; then
-    mkdir -p "$REMOTE_DIR/data/tieba"
-    tar xzf /tmp/quickquip-tieba-state.tar.gz -C "$REMOTE_DIR"
-fi
-
-sed -i 's/\r$//' "$REMOTE_DIR/.env" 2>"$NULL_DEVICE" || true
-chmod 600 "$REMOTE_DIR/.env" 2>"$NULL_DEVICE" || true
-
-if [ -f "$REMOTE_DIR/prod/sendkey.env" ]; then
-    sed -i 's/\r$//' "$REMOTE_DIR/prod/sendkey.env" 2>"$NULL_DEVICE" || true
-    chmod 600 "$REMOTE_DIR/prod/sendkey.env" 2>"$NULL_DEVICE" || true
-fi
-
-if [ -d "$REMOTE_DIR/prod/llbot-data" ]; then
-    LLBOT_PYTHON=python3
-    for candidate in "$REMOTE_DIR/prod/llbot-data/default_config.json" "$REMOTE_DIR"/prod/llbot-data/data/config_*.json; do
-        if [ -e "$candidate" ] && [ ! -w "$candidate" ]; then
-            LLBOT_PYTHON="sudo -n python3"
-            break
-        fi
+# All uploads are private, unique and outside live directories.
+ssh "${ssh_args[@]}" "$HostAlias" \
+    "command -v rsync >/dev/null && command -v flock >/dev/null && docker compose version >/dev/null && umask 077 && mkdir -p '$RemoteDir/.deploy/incoming' && chmod 700 '$RemoteDir/.deploy' '$RemoteDir/.deploy/incoming' && mkdir '$Incoming'" \
+    || die "remote prerequisites or exclusive staging directory failed"
+scp "${ssh_args[@]}" "$ScriptDir/remote-deploy-v4.sh" "$ScriptDir/deploy-state.py" "$HostAlias:$Incoming/"
+if [ "$Mode" = deploy ] || [ "$Mode" = migrate ]; then
+    ssh "${ssh_args[@]}" "$HostAlias" "umask 077; mkdir '$Incoming/tree' '$Incoming/shared'"
+    rsync -ar --chmod=D700,F600 --exclude=__pycache__ --exclude='*.pyc' "${rsync_args[@]}" \
+        --files-from="$ScriptDir/deploy-manifest.txt" ./ "$HostAlias:$Incoming/tree/"
+    Shared=(.env prod/check_bot.sh prod/cron_check_bot.sh)
+    for item in prod/sendkey.env data/fonts/NotoSansSC-Regular.ttf data/tieba/storage_state.json; do
+        [ ! -f "$item" ] || Shared+=("$item")
     done
-    $LLBOT_PYTHON - "$REMOTE_DIR" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-remote_dir = Path(sys.argv[1])
-
-def read_env_value(path: Path, key: str) -> str:
-    try:
-        lines = path.read_text(encoding="utf-8-sig").splitlines()
-    except OSError:
-        return ""
-    for line in lines:
-        line = line.strip()
-        if not line or line.startswith("#") or "=" not in line:
-            continue
-        name, value = line.split("=", 1)
-        if name == key:
-            value = value.strip()
-            if (value.startswith('"') and value.endswith('"')) or (
-                value.startswith("'") and value.endswith("'")
-            ):
-                value = value[1:-1]
-            return value
-    return ""
-
-token = read_env_value(remote_dir / ".env", "ONEBOT_ACCESS_TOKEN")
-if not token:
-    raise SystemExit(0)
-
-paths = [remote_dir / "prod/llbot-data/default_config.json"]
-paths.extend(sorted((remote_dir / "prod/llbot-data/data").glob("config_*.json")))
-for path in paths:
-    if not path.exists():
-        continue
-    data = json.loads(path.read_text(encoding="utf-8"))
-    connect = data.setdefault("ob11", {}).setdefault("connect", [])
-    while len(connect) <= 1:
-        connect.append({})
-    connect[1]["url"] = "ws://quickquip:8080/onebot/v11/ws/"
-    connect[1]["token"] = token
-    path.write_text(json.dumps(data, ensure_ascii=False, indent=4) + "\n", encoding="utf-8")
-    print(f"Synced LLBot OneBot reverse WebSocket config: {path}")
-PY
+    rsync -aR --chmod=D700,F600 "${rsync_args[@]}" "${Shared[@]}" "$HostAlias:$Incoming/shared/"
 fi
-
-chmod 750 "$REMOTE_DIR" "$REMOTE_DIR/prod" 2>"$NULL_DEVICE" || true
-if [ -f "$REMOTE_DIR/data/tieba/pool.json" ]; then
-    sudo chown "$(id -u):$(id -g)" "$REMOTE_DIR/data/tieba/pool.json" 2>"$NULL_DEVICE" || true
-fi
-
-rm -f /tmp/quickquip-deploy.tar.gz /tmp/quickquip-tieba-state.tar.gz /tmp/quickquip-sendkey.env
-
-cd "$REMOTE_DIR/prod"
-docker compose --env-file ../.env config --quiet
-docker compose --env-file ../.env build quickquip web-admin
-docker compose --env-file ../.env up -d --remove-orphans llbot quickquip web-admin
-docker compose --env-file ../.env up -d --force-recreate quickquip web-admin
-docker compose --env-file ../.env ps
-docker builder prune --filter 'until=48h' --force
-docker image prune -f
-REMOTE
-)
-remote_script=${remote_script//__REMOTE_DIR__/$RemoteDir}
-if ! printf '%s\n' "$remote_script" | ssh "${ssh_args[@]}" "$HostAlias" "tr -d '\r' | bash -s"; then
-    echo "${R}FAILED: ssh remote deploy${N}" >&2
-    exit 1
-fi
-
-echo "${G}Deploy complete.${N}"
-echo "${Y}QuickQuip logs: ssh $HostAlias 'cd $RemoteDir/prod && docker compose --env-file ../.env logs -f quickquip'${N}"
-echo "${Y}Web Admin logs: ssh $HostAlias 'cd $RemoteDir/prod && docker compose --env-file ../.env logs -f web-admin'${N}"
-
-rm -f "$TempArchive" "$TiebaStateArchive"
+ssh "${ssh_args[@]}" "$HostAlias" \
+    "DETACH=1 SKIP_HEALTH=$SkipHealth bash '$Incoming/remote-deploy-v4.sh' '$RemoteDir' '$Id' '$KeepReleases' '$Mode' '$ReleaseId'" \
+    || die "launch uncertain; inspect $RemoteDir/.deploy/$Id.log and .exit before retrying"
+Log="$RemoteDir/.deploy/$Id.log"
+ExitFile="$RemoteDir/.deploy/$Id.exit"
+attempts=0
+until ssh "${ssh_args[@]}" "$HostAlias" \
+    "while [ ! -f '$ExitFile' ]; do sleep 1; done & watcher=\$!; tail -n +1 -f --pid=\$watcher '$Log'; wait \$watcher"; do
+    attempts=$((attempts + 1))
+    [ "$attempts" -le 20 ] || die "connection lost; remote action may continue: $Log"
+    sleep 5
+done
+code="$(ssh "${ssh_args[@]}" "$HostAlias" "cat '$ExitFile'")" || die "cannot read completion status: $ExitFile"
+[ "$code" = 0 ] || die "remote action failed (exit $code): $Log"
+printf '%s complete. Status: bash prod/deploy-v4.sh -Status -HostAlias %s -RemoteDir %s\n' "$Mode" "$HostAlias" "$RemoteDir"

--- a/prod.example/docker-compose.yml
+++ b/prod.example/docker-compose.yml
@@ -12,8 +12,8 @@ services:
       - -c
       - "(sleep 5 && echo 'nameserver 127.0.0.11' > /etc/resolv.conf && echo 'options ndots:0' >> /etc/resolv.conf) & exec /bin/llonebot-service"
     volumes:
-      - ./llbot-qq:/root/.config/QQ
-      - ./llbot-data:/root/llonebot
+      - ${QUICKQUIP_ROOT:-..}/prod/llbot-qq:/root/.config/QQ
+      - ${QUICKQUIP_ROOT:-..}/prod/llbot-data:/root/llonebot
     environment:
       - TZ=Asia/Shanghai
       - QUICK_LOGIN_QQ=${QQ_ACCOUNT:?请设置 QQ 号}
@@ -24,6 +24,7 @@ services:
 
   quickquip:
     init: true
+    image: quickquip-app:${QUICKQUIP_RELEASE:-latest}
     build:
       context: ..
       dockerfile: prod/Dockerfile
@@ -35,7 +36,7 @@ services:
     depends_on:
       - llbot
     env_file:
-      - ../.env
+      - ${QUICKQUIP_ENV_FILE:-../.env}
     environment:
       TZ: "${TZ:-Asia/Shanghai}"
       DRIVER: "${DRIVER:-~fastapi+~websockets}"
@@ -47,7 +48,7 @@ services:
       PYTHONPATH: "/app/src"
     shm_size: "1gb"
     volumes:
-      - ../data:/app/data
+      - ${QUICKQUIP_ROOT:-..}/data:/app/data
       - ../config:/app/config:ro
       - ../llm_about:/app/llm_about:ro
       - ../bot.py:/app/bot.py:ro
@@ -56,17 +57,11 @@ services:
 
   web-admin:
     init: true
-    build:
-      context: ..
-      dockerfile: prod/Dockerfile
-      args:
-        PIP_INDEX_URL: "${PIP_INDEX_URL:-https://pypi.tuna.tsinghua.edu.cn/simple}"
-        PIP_TRUSTED_HOST: "${PIP_TRUSTED_HOST:-pypi.tuna.tsinghua.edu.cn}"
-        PLAYWRIGHT_BASE_IMAGE: "${PLAYWRIGHT_BASE_IMAGE:-m.daocloud.io/mcr.microsoft.com/playwright/python:v1.58.0-noble}"
+    image: quickquip-app:${QUICKQUIP_RELEASE:-latest}
     container_name: quickquip-web-admin
     command: ["python", "-u", "web_api.py"]
     env_file:
-      - ../.env
+      - ${QUICKQUIP_ENV_FILE:-../.env}
     environment:
       TZ: "${TZ:-Asia/Shanghai}"
       WEB_ADMIN_HOST: "0.0.0.0"
@@ -76,7 +71,7 @@ services:
     ports:
       - "127.0.0.1:5104:5104"
     volumes:
-      - ../data:/app/data
+      - ${QUICKQUIP_ROOT:-..}/data:/app/data
       - ../config:/app/config
       - ../llm_about:/app/llm_about
       - ../frontend/dist:/app/frontend/dist:ro

--- a/prod.example/remote-deploy-v4.sh
+++ b/prod.example/remote-deploy-v4.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+# Server-side release transaction. Drivers upload a private incoming directory.
+set -Eeuo pipefail
+umask 077
+
+Root="${1:?deployment root required}"
+Id="${2:?operation id required}"
+Keep="${3:?retention count required}"
+Action="${4:?action required}"
+Target="${5:-}"
+[[ "$Root" =~ ^/[a-zA-Z0-9_./-]+$ && "$Root" != / && "$Root" != *'/../'* ]] || exit 2
+[[ "$Id" =~ ^[0-9]{8}-[0-9]{6}-[a-f0-9]{12}$ ]] || exit 2
+[[ "$Keep" =~ ^[0-9]+$ && "$Keep" -ge 2 && "$Keep" -le 100 ]] || exit 2
+[[ "$Action" =~ ^(deploy|migrate|rollback|status)$ ]] || exit 2
+[[ -z "$Target" || "$Target" =~ ^[0-9]{8}-[0-9]{6}(-[a-f0-9]{12})?(-baseline)?$ ]] || exit 2
+
+Root="$(realpath -m "$Root")"
+[ "$Root" != / ] || exit 2
+Incoming="$Root/.deploy/incoming/$Id"
+StateTool="$Incoming/deploy-state.py"
+Log="$Root/.deploy/$Id.log"
+ExitFile="$Root/.deploy/$Id.exit"
+if [ "${DETACH:-0}" = 1 ]; then
+    exec 8>"$Incoming/start.lock"
+    flock -n 8 || exit 1
+    [ ! -e "$Incoming/started" ] || exit 0
+    touch "$Incoming/started"
+    : > "$Log"
+    DETACH=0 EXIT_FILE="$ExitFile" setsid nohup bash -c \
+        'bash "$0" "$@"; code=$?; printf "%s\n" "$code" > "$EXIT_FILE"' \
+        "$0" "$@" >>"$Log" 2>&1 </dev/null 8>&- &
+    exit 0
+fi
+
+step() { printf '[deploy] %s\n' "$*"; }
+fail() { step "FAILED: $*" >&2; exit 1; }
+Python=""
+for candidate in python3.13 python3.12 python3.11 python3; do
+    if command -v "$candidate" >/dev/null && "$candidate" -c 'import sys; assert sys.version_info >= (3, 11, 8)' 2>/dev/null; then
+        Python="$candidate"
+        break
+    fi
+done
+[ -n "$Python" ] || fail "Python >= 3.11.8 required on server"
+export QUICKQUIP_ROOT="$Root"
+export QUICKQUIP_ENV_FILE="$Root/.env"
+Release="$Root/releases/$Id"
+Backup="$Incoming/backup"
+Prev=""
+OriginalCurrent=""
+PrevPrevious=""
+Changed=0
+Activated=0
+Succeeded=0
+SharedSudo=0
+
+shared_state() {
+    if [ "$SharedSudo" = 1 ]; then
+        sudo -n "$Python" "$StateTool" "$@"
+    else
+        "$Python" "$StateTool" "$@"
+    fi
+}
+snapshot_shared() {
+    local code=0
+    shared_state snapshot "$Root" "$Incoming" "$Backup" || code=$?
+    if [ "$code" = 3 ]; then
+        rm -rf "$Backup"
+        step "shared files require sudo; retrying snapshot with noninteractive sudo"
+        SharedSudo=1
+        shared_state snapshot "$Root" "$Incoming" "$Backup"
+    else
+        return "$code"
+    fi
+}
+
+release_id() { readlink "$Root/$1" 2>/dev/null | sed 's|^releases/||' || true; }
+set_link() {
+    local name="$1" value="$2" temp="$Root/.${1}-$Id"
+    if [ -z "$value" ]; then rm -f "$Root/$name"; return 0; fi
+    ln -s "releases/$value" "$temp" && mv -Tf "$temp" "$Root/$name"
+}
+compose() {
+    local release="$1"; shift
+    QUICKQUIP_RELEASE="$release" docker compose --env-file "$QUICKQUIP_ENV_FILE" \
+        -f "$Root/releases/$release/prod/docker-compose.yml" "$@"
+}
+verify_release() {
+    local release="$1" image images
+    [ -f "$Root/releases/$release/prod/docker-compose.yml" ] || return 1
+    compose "$release" config --quiet || return 1
+    images="$(compose "$release" config --images)" || return 1
+    [ -n "$images" ] || return 1
+    while IFS= read -r image; do
+        docker image inspect "$image" >/dev/null || return 1
+    done <<< "$images"
+}
+up() {
+    compose "$1" up -d --no-build --pull never --remove-orphans llbot || return 1
+    compose "$1" up -d --no-build --pull never --force-recreate --remove-orphans quickquip web-admin
+}
+health() {
+    local release="$1" deadline=$((SECONDS + ${DEPLOY_HEALTH_TIMEOUT:-150})) bad container service
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        bad=0
+        for service in llbot quickquip web-admin; do
+            container="$(compose "$release" ps -q "$service")" || return 1
+            [ -n "$container" ] && [ "$(docker inspect -f '{{.State.Running}}' "$container")" = true ] || bad=1
+        done
+        if [ "$bad" = 0 ] \
+            && compose "$release" logs --tail 500 quickquip 2>&1 | grep -E 'Bot [0-9]+ connected' >/dev/null \
+            && compose "$release" exec -T web-admin python -c \
+                'import urllib.request; urllib.request.urlopen("http://127.0.0.1:5104/ops/", timeout=5).close()' >/dev/null 2>&1; then
+            step "health PASS: $release"
+            return 0
+        fi
+        sleep 5
+    done
+    step "health FAILED: $release"
+    compose "$release" logs --tail 30 quickquip web-admin || true
+    return 1
+}
+finish() {
+    local code=$? restored=1
+    trap - EXIT INT TERM
+    export QUICKQUIP_ENV_FILE="$Root/.env"
+    if [ "$Succeeded" = 0 ] && [ "$Changed" = 1 ]; then
+        step "restoring shared files and previous release: ${Prev:-none}"
+        shared_state restore "$Root" "$Backup" || restored=0
+        if [ "$Activated" = 1 ]; then
+            set_link current "$Prev" || restored=0
+        else
+            set_link current "$OriginalCurrent" || restored=0
+        fi
+        set_link previous "$PrevPrevious" || restored=0
+        if [ "$Activated" = 1 ]; then
+            if [ -n "$Prev" ]; then
+                if ! verify_release "$Prev" || ! up "$Prev" || ! health "$Prev"; then restored=0; fi
+            else
+                step "no previous release exists; manual recovery required"
+                restored=0
+            fi
+        fi
+        if [ "$restored" = 1 ]; then
+            step "RECOVERY SUCCEEDED; requested action failed"
+        else
+            step "RECOVERY FAILED; containers may be unavailable; preserve $Incoming"
+            exit 2
+        fi
+    fi
+    # Secrets are transient; retain only logs and numeric exit status.
+    if [ "$SharedSudo" = 1 ]; then sudo -n rm -rf "$Backup" || exit 2; fi
+    rm -rf "$Incoming"
+    exit "$code"
+}
+trap finish EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+if [ "$Action" = status ]; then
+    step "current: $(release_id current); previous: $(release_id previous)"
+    Current="$(release_id current)"
+    if [ -n "$Current" ]; then
+        compose "$Current" ps -a
+    elif [ -f "$Root/prod/docker-compose.yml" ]; then
+        docker compose --env-file "$Root/.env" -f "$Root/prod/docker-compose.yml" ps -a
+    fi
+    exit 0
+fi
+exec 9>"$Root/.deploy/lock"
+flock -n 9 || fail "another deployment is active; retry after it finishes"
+mkdir -p "$Root/releases"
+Prev="$(release_id current)"
+OriginalCurrent="$Prev"
+PrevPrevious="$(release_id previous)"
+
+if [ "$Action" = rollback ]; then
+    Target="${Target:-$PrevPrevious}"
+    [[ "$Target" =~ ^[0-9]{8}-[0-9]{6}(-[a-f0-9]{12})?(-baseline)?$ ]] || fail "no valid previous release"
+    [ "$Target" != "$Prev" ] || fail "target is already current"
+    verify_release "$Prev" || fail "current release cannot be used for recovery"
+    verify_release "$Target" || fail "rollback target or image missing"
+    # Empty shared snapshot: manual rollback retains the current environment.
+    mkdir -p "$Incoming/shared"
+    mkdir -m 700 "$Backup"
+    printf '[]\n' > "$Backup/index.json"
+    Changed=1
+    set_link current "$Target"
+    Activated=1
+    up "$Target" || fail "rollback startup failed"
+    health "$Target" || fail "rollback health failed"
+    set_link previous "$Prev"
+    Succeeded=1
+    step "rollback complete: $Target (current credentials and data retained)"
+    exit 0
+fi
+
+if [ -f "$Incoming/release.tar.gz" ]; then
+    "$Python" "$StateTool" extract "$Incoming/release.tar.gz" "$Incoming/tree"
+fi
+"$Python" "$StateTool" validate "$Incoming/tree"
+[ -f "$Incoming/shared/.env" ] || fail "staged environment missing"
+if [ "$Action" = migrate ]; then
+    [ -z "$Prev" ] || fail "already migrated"
+    [ -f "$Root/.env" ] || fail "flat layout .env missing"
+    Baseline="$Id-baseline"
+    "$Python" "$StateTool" baseline "$Root" "$Root/releases/$Baseline"
+    verify_release "$Baseline" || fail "baseline verification failed"
+    # Existing containers retain their original bind mounts until first activation.
+    Prev="$Baseline"
+elif [ -z "$Prev" ] && [ -f "$Root/prod/docker-compose.yml" ]; then
+    fail "flat deployment detected; use -Migrate first"
+fi
+[ -z "$Prev" ] || verify_release "$Prev" || fail "previous release lacks a usable image; repair it before deploying"
+[ ! -e "$Release" ] || fail "release id already exists"
+mkdir -m 700 "$Release"
+LinkDest=()
+[ -z "$Prev" ] || LinkDest=(--link-dest="$Root/releases/$Prev/")
+rsync -ar --chmod=D755,F644 --exclude=__pycache__ --exclude='*.pyc' \
+    "${LinkDest[@]}" "$Incoming/tree/" "$Release/"
+chmod 700 "$Release"
+export QUICKQUIP_ENV_FILE="$Incoming/shared/.env"
+compose "$Id" config --quiet
+# Resolved values stay within the private transaction and never enter the release.
+compose "$Id" config --format json > "$Incoming/candidate-compose.json"
+llbot_image="$(compose "$Id" config --images llbot)"
+if ! docker image inspect "$llbot_image" >/dev/null 2>&1; then
+    pulled=0
+    for attempt in 1 2 3; do
+        if compose "$Id" pull llbot; then pulled=1; break; fi
+        sleep 10
+    done
+    [ "$pulled" = 1 ] || fail "LLBot pull failed before activation"
+fi
+compose "$Id" build quickquip
+snapshot_shared
+Changed=1
+shared_state apply "$Root" "$Incoming" "$Backup"
+export QUICKQUIP_ENV_FILE="$Root/.env"
+set_link current "$Id"
+Activated=1
+up "$Id" || fail "deployment startup failed"
+if [ "${SKIP_HEALTH:-0}" = 1 ]; then
+    step "health explicitly skipped; release is UNVERIFIED"
+else
+    health "$Id" || fail "deployment health failed"
+fi
+set_link previous "$Prev"
+Succeeded=1
+step "release complete: $Id"
+# Only collect completed deployments; never remove current, previous or baselines.
+touch "$Release/.complete"
+count=0
+while IFS= read -r stale; do
+    count=$((count + 1))
+    [ "$count" -gt "$Keep" ] || continue
+    [ "$stale" != "$Id" ] && [ "$stale" != "$Prev" ] || continue
+    rm -rf "$Root/releases/$stale"
+    docker rmi "quickquip-app:$stale" >/dev/null 2>&1 || true
+done < <(find "$Root/releases" -mindepth 2 -maxdepth 2 -name .complete -printf '%h\n' | sort -r | sed 's|.*/||')

--- a/tests/unit/scripts/test_deploy_v4.py
+++ b/tests/unit/scripts/test_deploy_v4.py
@@ -1,0 +1,229 @@
+"""Isolated deployment transactions; no SSH or real Docker daemon access."""
+from __future__ import annotations
+
+import io
+import json
+import os
+from pathlib import Path
+import runpy
+import shutil
+import subprocess
+import sys
+import tarfile
+
+import pytest
+
+
+TEMPLATE = Path(__file__).resolve().parents[3] / "prod.example"
+STATE = runpy.run_path(str(TEMPLATE / "deploy-state.py"))
+OLD = "20260907-010000-aaaaaaaaaaaa"
+NEW = "20260907-020000-bbbbbbbbbbbb"
+
+
+@pytest.fixture
+def deployment(tmp_path):
+    root = tmp_path / "server"
+    root.mkdir()
+    (root / ".env").write_text("ONEBOT_ACCESS_TOKEN=old\n")
+    (root / ".env").chmod(0o600)
+    (root / "prod").mkdir()
+    inbox = root / ".deploy/incoming" / NEW
+    inbox.mkdir(parents=True)
+    for name in ("deploy-state.py", "remote-deploy-v4.sh"):
+        shutil.copyfile(TEMPLATE / name, inbox / name)
+    tree = inbox / "tree"
+    (tree / "prod").mkdir(parents=True)
+    (tree / "prod/docker-compose.yml").write_text("services: {}\n")
+    shared = inbox / "shared"
+    shared.mkdir()
+    (shared / ".env").write_text("ONEBOT_ACCESS_TOKEN=new\n")
+    old = root / "releases" / OLD
+    (old / "prod").mkdir(parents=True)
+    (old / "prod/docker-compose.yml").write_text("services: {}\n")
+    (root / "current").symlink_to(f"releases/{OLD}")
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    docker = bin_dir / "docker"
+    docker.write_text(f"#!{sys.executable}\n" + '''
+import json, os, pathlib, sys
+args = sys.argv[1:]
+root = pathlib.Path(os.environ["TEST_ROOT"])
+with (root / "calls").open("a") as log:
+    log.write(json.dumps(args) + "\\n")
+if args[0] == "compose":
+    release = pathlib.Path(args[args.index("-f") + 1]).parents[1].name
+    if "config" in args:
+        if "--images" in args:
+            print("quickquip-app:" + release)
+        elif "--no-interpolate" in args:
+            print(json.dumps({"services": {
+                name: {"container_name": name, "environment": {"TOKEN": "${TOKEN:-}"}}
+                for name in ("llbot", "quickquip", "web-admin")
+            }}))
+        elif "--format" in args:
+            print(json.dumps({"services": {"quickquip": {"environment": {"ONEBOT_ACCESS_TOKEN": "new"}}}}))
+    elif "build" in args and os.environ.get("FAIL_BUILD") == "1":
+        sys.exit(1)
+    elif "up" in args:
+        if os.environ.get("FAIL_UP") == "all" or (os.environ.get("FAIL_UP") == "new" and release == os.environ["TEST_NEW"]):
+            sys.exit(1)
+    elif "ps" in args:
+        print("test-container")
+    elif "logs" in args:
+        print("Bot 123456 connected")
+elif args[0] == "inspect":
+    print("true")
+''')
+    docker.chmod(0o700)
+    env = dict(os.environ, PATH=f"{bin_dir}:{os.environ['PATH']}", TEST_ROOT=str(root), TEST_NEW=NEW)
+    return root, inbox, env
+
+
+def run_deploy(deployment, action="deploy", target="", **overrides):
+    root, inbox, env = deployment
+    return subprocess.run(
+        ["bash", str(inbox / "remote-deploy-v4.sh"), str(root), NEW, "4", action, target],
+        env=env | overrides, text=True, capture_output=True, timeout=20,
+    )
+
+
+def test_success_commits_environment_and_previous(deployment):
+    root, inbox, _ = deployment
+    result = run_deploy(deployment)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (root / "current").readlink() == Path("releases") / NEW
+    assert (root / "previous").readlink() == Path("releases") / OLD
+    assert (root / ".env").read_text() == "ONEBOT_ACCESS_TOKEN=new\n"
+    assert (root / ".env").stat().st_mode & 0o777 == 0o600
+    assert not inbox.exists()
+
+
+@pytest.mark.parametrize("failure", ["build", "up"])
+def test_failure_restores_original_files_and_links(deployment, failure):
+    root, inbox, _ = deployment
+    result = run_deploy(deployment, **({"FAIL_BUILD": "1"} if failure == "build" else {"FAIL_UP": "new"}))
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert (root / ".env").read_text() == "ONEBOT_ACCESS_TOKEN=old\n"
+    assert (root / "current").readlink() == Path("releases") / OLD
+    assert not (root / "previous").exists()
+    assert not inbox.exists()
+    if failure == "up":
+        assert "RECOVERY SUCCEEDED" in result.stdout
+
+
+def test_failed_recovery_retains_private_backup_and_reports_failure(deployment):
+    root, inbox, _ = deployment
+    result = run_deploy(deployment, FAIL_UP="all")
+    assert result.returncode == 2
+    assert "RECOVERY FAILED" in result.stdout
+    assert (inbox / "backup/.env").read_text() == "ONEBOT_ACCESS_TOKEN=old\n"
+    assert (inbox / "backup").stat().st_mode & 0o777 == 0o700
+    assert (root / "current").readlink() == Path("releases") / OLD
+
+
+def test_lock_rejects_second_action_before_live_mutation(deployment):
+    import fcntl
+
+    root, _, _ = deployment
+    with (root / ".deploy/lock").open("w") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        result = run_deploy(deployment)
+    assert result.returncode == 1
+    assert "another deployment is active" in result.stderr
+    assert (root / ".env").read_text() == "ONEBOT_ACCESS_TOKEN=old\n"
+    assert not (root / "calls").exists()
+
+
+@pytest.mark.parametrize("args", [["-Rollback", "-DryRun"], ["-Status", "-Migrate"], ["-Status", "-SkipHealth"]])
+def test_bash_rejects_invalid_modes_before_side_effects(args):
+    result = subprocess.run(["bash", str(TEMPLATE / "deploy-v4.sh"), *args], capture_output=True, text=True)
+    assert result.returncode != 0
+    assert "FAILED:" in result.stderr
+
+
+def test_shared_transaction_restores_token_and_missing_files(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    incoming = tmp_path / "incoming"
+    (incoming / "shared/prod").mkdir(parents=True)
+    (incoming / "shared/.env").write_text("ONEBOT_ACCESS_TOKEN=new\r\n")
+    (incoming / "shared/prod/sendkey.env").write_text("SENDKEY=synthetic\n")
+    (incoming / "candidate-compose.json").write_text(json.dumps({"services": {"quickquip": {"environment": {"ONEBOT_ACCESS_TOKEN": "new"}}}}))
+    path = root / "prod/llbot-data/default_config.json"
+    path.parent.mkdir(parents=True)
+    original = b'{"ob11":{"connect":[{}, {"token":"old","url":"old-url"}]}}'
+    path.write_bytes(original)
+    backup = incoming / "backup"
+    STATE["snapshot_shared"](root, incoming, backup)
+    STATE["apply_shared"](root, incoming, backup)
+    assert json.loads(path.read_text())["ob11"]["connect"][1]["token"] == "new"
+    assert (root / ".env").read_bytes() == b"ONEBOT_ACCESS_TOKEN=new\n"
+    STATE["restore_shared"](root, backup)
+    assert path.read_bytes() == original
+    assert not (root / ".env").exists()
+    assert not (root / "prod/sendkey.env").exists()
+
+
+def test_archive_rejects_escape_and_links(tmp_path):
+    for index, name in enumerate(("../escape", "link")):
+        archive = tmp_path / f"bundle-{index}.tar.gz"
+        with tarfile.open(archive, "w:gz") as bundle:
+            member = tarfile.TarInfo(name)
+            if name == "link":
+                member.type = tarfile.SYMTYPE
+                member.linkname = "/etc/passwd"
+            bundle.addfile(member, io.BytesIO())
+        with pytest.raises(ValueError):
+            STATE["extract"](archive, tmp_path / f"tree-{index}")
+
+
+def test_migration_build_failure_keeps_flat_files_and_no_current(deployment):
+    root, _, _ = deployment
+    (root / "current").unlink()
+    (root / "prod/docker-compose.yml").write_text("services: {}\n")
+    (root / "src").mkdir()
+    (root / "src/server.txt").write_text("original server code")
+    result = run_deploy(deployment, action="migrate", FAIL_BUILD="1")
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert not (root / "current").is_symlink()
+    assert (root / "src/server.txt").read_text() == "original server code"
+    baseline = root / "releases" / (NEW + "-baseline")
+    assert (baseline / "src/server.txt").read_text() == "original server code"
+    config = json.loads((baseline / "prod/docker-compose.yml").read_text())
+    assert config["services"]["quickquip"]["env_file"] == [str(root / ".env")]
+    assert config["services"]["quickquip"]["environment"]["TOKEN"] == "${TOKEN:-}"
+    calls = [json.loads(line) for line in (root / "calls").read_text().splitlines()]
+    assert not any("up" in call for call in calls)
+    assert (root / ".env").read_text() == "ONEBOT_ACCESS_TOKEN=old\n"
+
+
+def test_sudo_atomic_write_assigns_new_owner_and_preserves_existing(tmp_path, monkeypatch):
+    owners = []
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(os, "chown", lambda path, uid, gid: owners.append((uid, gid)))
+    path = tmp_path / "new/ops/sendkey.env"
+    STATE["atomic_write"](path, b"synthetic", 0o600, (1234, 5678))
+    assert owners == [(1234, 5678)] * 3
+    assert path.parent.stat().st_mode & 0o777 == 0o755
+    assert path.parent.parent.stat().st_mode & 0o777 == 0o755
+    existing = path.stat()
+    STATE["atomic_write"](path, b"updated", 0o600, (1234, 5678))
+    assert owners[-1] == (existing.st_uid, existing.st_gid)
+
+
+def test_sudo_new_shared_file_uses_invoking_user(tmp_path, monkeypatch):
+    root = tmp_path / "root"
+    root.mkdir()
+    incoming = tmp_path / "incoming"
+    (incoming / "shared").mkdir(parents=True)
+    (incoming / "shared/.env").write_text("TOKEN=synthetic\n")
+    (incoming / "candidate-compose.json").write_text('{"services":{"quickquip":{}}}')
+    backup = incoming / "backup"
+    STATE["snapshot_shared"](root, incoming, backup)
+    owners = []
+    monkeypatch.setenv("SUDO_UID", "1234")
+    monkeypatch.setenv("SUDO_GID", "5678")
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(os, "chown", lambda path, uid, gid: owners.append((uid, gid)))
+    STATE["apply_shared"](root, incoming, backup)
+    assert owners == [(1234, 5678)]


### PR DESCRIPTION
部署脚本采用版本目录、私有暂存和统一远端事务：候选配置校验、镜像构建成功后切换版本；启动或健康检查失败时恢复本次修改的共享配置和上一版本，并验证恢复结果。Bash 和 PowerShell 使用同一远端实现。

## 变更

- 正式 `deploy-v4.sh/.ps1` 支持部署、迁移、回滚、状态和本地预览；旧平铺驱动归档为 `deploy-v4-bak`，拒绝向已有版本目录上传。
- 按清单上传应用，独立暂存根环境、维护脚本和可选资产。LLBot 登录目录始终留在服务器；共享文件更新由部署锁串行化，sudo 路径保留已有所有者并为新文件和目录设置实际部署用户。
- 迁移基线保存服务器旧代码并固定实际运行镜像；手动回滚保留当前环境和运行数据。自动恢复失败明确报告并保留私有备份。
- 同步 Compose、巡检入口和管理员文档；应用服务共用带版本标签的镜像，运行数据与应用凭证保持在部署根目录。

## 升级与边界

服务器需要 rsync、flock、Python >= 3.11.8、Docker Compose >= 2.27，以及适用时的非交互 sudo 权限。已有平铺部署首次使用 `-Migrate`；已经迁移的环境继续直接执行 `bash prod/deploy-v4.sh`。首次尚未 QQ 登录可显式使用 `-SkipHealth`，结果标记为未验证。数据库迁移和外部副作用需要独立评估回退要求。

## 验证

- 13 项部署回归用例通过：成功提交、构建/启动失败恢复、恢复失败、并发锁、非法参数、共享状态、归档越界、迁移预激活失败及 sudo 所有者。
- 隔离 Linux 服务器实测：旧平铺部署、迁移、基线回滚、PowerShell 7 部署/预览/状态、构建失败不切换、150 秒健康门禁失败后自动恢复。Compose 2.27 兼容及 root 所有目录下的普通部署用户读取也已验证。
- 验收使用合成配置和无网络进程，无真实凭证或登录态上传。未验证真实 QQ/OneBot 登录、真实应用镜像重建或 Windows PowerShell 5.1 实机行为。
- 独立 Tier 1 审查及本批五透镜 Deep-CR 均无待修问题。Bash/PowerShell 语法、合成环境下的模板 Compose 配置均通过。
- 包含本 PR 的本批汇总代码：1871 项 pytest、Ruff、前端 type-check、12 份 TOML 示例与 ID literals 检查通过。

## Changelog 草稿

部署脚本支持按版本发布、迁移旧部署与健康验证回滚，统一 Bash 和 PowerShell 行为；上传和切换采用私有暂存与部署锁，失败时恢复本次修改的共享配置并明确报告恢复结果。
