### PR TITLE
feat(llm): 交付开关拆分为中间轮/最终轮两域

### DIFF
--- a/config/llm.toml.example
+++ b/config/llm.toml.example
@@ -51,10 +51,13 @@ tool_max_calls_per_round = 16
 # agent_record_max_bytes_per_scope = 67108864
 
 # 逐 Turn 交付（全局默认关闭：安装新版本不改变群内消息量；记录与重放始终工作）
-# 开启后每次模型响应的普通正文先于工具执行分段外发；阈值/上限为 Unicode
-# code point 口径，独立于 OneBot 协议报文长度限制。
-# 各群/私聊会话可用 /llm delivery on|off|reset|status 按会话覆盖此默认。
-# agent_delivery_enabled = false
+# 两域独立：intermediate 管非最终轮正文是否照常先于工具执行外发，final 管最终
+# 正文是否按自然段拆分经 sink 外发（关闭时最终正文沿旧单发路径整条发送）。
+# 阈值/上限为 Unicode code point 口径，独立于 OneBot 协议报文长度限制。
+# 各群/私聊会话可用 /llm delivery interim|final|all <on|off|reset> 按会话覆盖。
+# 旧键 agent_delivery_enabled 仍可读取，未显式配置的新键按旧键值映射。
+# agent_delivery_intermediate_enabled = false
+# agent_delivery_final_enabled = false
 # reply_split_threshold_chars = 800
 # reply_chunk_max_chars = 1200
 # reply_send_interval_ms = 800

--- a/config/llm.toml.example
+++ b/config/llm.toml.example
@@ -54,7 +54,7 @@ tool_max_calls_per_round = 16
 # 两域独立：intermediate 管非最终轮正文是否照常先于工具执行外发，final 管最终
 # 正文是否按自然段拆分经 sink 外发（关闭时最终正文沿旧单发路径整条发送）。
 # 阈值/上限为 Unicode code point 口径，独立于 OneBot 协议报文长度限制。
-# 各群/私聊会话可用 /llm delivery interim|final|all <on|off|reset> 按会话覆盖。
+# 各群/私聊会话可用 /llm delivery intermediate|final|all <on|off|reset> 按会话覆盖。
 # 旧键 agent_delivery_enabled 仍可读取，未显式配置的新键按旧键值映射。
 # agent_delivery_intermediate_enabled = false
 # agent_delivery_final_enabled = false

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -140,7 +140,7 @@ GHCR 分发镜像和 `prod.example/Dockerfile` 均基于 Playwright Python 镜�
 | `agent_record_max_bytes_per_scope` | 每会话 Loop 业务记录字节上限（UTF-8 计量） | `67108864` |
 | `agent_replay_loop_tokens` | 历史 Loop 重放投影预算的推导下限（token 估算，512-4194304）：实际预算按「请求输入预算 − 纪元可见窗上限 − system/工具预留 − 当前 Loop 比例预留」推导（配置了模型容量的 provider 自动放大到窗口量级），超限按固定阶梯确定性精简（先剥原生 thinking，再丢原生副本，再收工具结果）；可在 `[[providers]]` 段按 provider 硬覆盖 | `4096` |
 | `agent_delivery_intermediate_enabled` | 中间轮交付的全局默认：开启后工具调用多轮回复中非最终轮的普通正文照常先于工具执行外发；关闭时非最终正文只记录不发送（`suppressed_by_policy`） | `false` |
-| `agent_delivery_final_enabled` | 最终轮分段的全局默认：开启后最终正文按自然段拆成多条消息经 sink 外发；关闭时最终正文沿旧单发路径整条发送。两域独立，旧键 `agent_delivery_enabled` 未删除，读取时按两域同值映射。各群/私聊会话可用 `/llm delivery interim/final/all …` 或 Web Admin「群设置」按会话覆盖 | `false` |
+| `agent_delivery_final_enabled` | 最终轮分段的全局默认：开启后最终正文按自然段拆成多条消息经 sink 外发；关闭时最终正文沿旧单发路径整条发送。两域独立，旧键 `agent_delivery_enabled` 未删除，读取时按两域同值映射。各群/私聊会话可用 `/llm delivery intermediate/final/all …` 或 Web Admin「群设置」按会话覆盖 | `false` |
 | `reply_split_threshold_chars` | 回复超过该长度（Unicode code point）才进行自然分段 | `800` |
 | `reply_chunk_max_chars` | 单段源文本上限，独立于 OneBot 协议报文长度 | `1200` |
 | `reply_send_interval_ms` | 同会话相邻发送开始时间的最小间隔（0-10000） | `800` |

--- a/docs/admin/configuration.md
+++ b/docs/admin/configuration.md
@@ -139,7 +139,8 @@ GHCR 分发镜像和 `prod.example/Dockerfile` 均基于 Playwright Python 镜�
 | `agent_record_max_loops_per_scope` | 每会话已关闭 Loop 数量上限，先触顶者触发清理最旧完整 Loop | `1000` |
 | `agent_record_max_bytes_per_scope` | 每会话 Loop 业务记录字节上限（UTF-8 计量） | `67108864` |
 | `agent_replay_loop_tokens` | 历史 Loop 重放投影预算的推导下限（token 估算，512-4194304）：实际预算按「请求输入预算 − 纪元可见窗上限 − system/工具预留 − 当前 Loop 比例预留」推导（配置了模型容量的 provider 自动放大到窗口量级），超限按固定阶梯确定性精简（先剥原生 thinking，再丢原生副本，再收工具结果）；可在 `[[providers]]` 段按 provider 硬覆盖 | `4096` |
-| `agent_delivery_enabled` | 逐 Turn 交付的全局默认：开启后每次模型响应的普通正文先于工具执行分段外发；关闭时仅最终正文单发，记录不受影响。各群/私聊会话可用 `/llm delivery on/off/reset/status` 或 Web Admin「群设置」按会话覆盖 | `false` |
+| `agent_delivery_intermediate_enabled` | 中间轮交付的全局默认：开启后工具调用多轮回复中非最终轮的普通正文照常先于工具执行外发；关闭时非最终正文只记录不发送（`suppressed_by_policy`） | `false` |
+| `agent_delivery_final_enabled` | 最终轮分段的全局默认：开启后最终正文按自然段拆成多条消息经 sink 外发；关闭时最终正文沿旧单发路径整条发送。两域独立，旧键 `agent_delivery_enabled` 未删除，读取时按两域同值映射。各群/私聊会话可用 `/llm delivery interim/final/all …` 或 Web Admin「群设置」按会话覆盖 | `false` |
 | `reply_split_threshold_chars` | 回复超过该长度（Unicode code point）才进行自然分段 | `800` |
 | `reply_chunk_max_chars` | 单段源文本上限，独立于 OneBot 协议报文长度 | `1200` |
 | `reply_send_interval_ms` | 同会话相邻发送开始时间的最小间隔（0-10000） | `800` |

--- a/docs/user/group-commands.md
+++ b/docs/user/group-commands.md
@@ -146,7 +146,7 @@ QuickQuip 在群里有两类能力：规则回复（复读、接龙、时区猜�
 | `/llm trigger at on / off` | 开关艾特触发（仅群聊有此命令） |
 | `/llm memory on / off` | 开关记忆注入 |
 | `/llm auto_memory on / off / reset / status` | 自动记忆抽取的开关、跟随全局默认、查看 |
-| `/llm delivery on / off / reset / status` | 分段发送（长回复按自然段拆成多条消息）的开关、跟随全局默认、查看；默认关闭 |
+| `/llm delivery interim / final / all <on / off / reset>` | 分段交付两域的按群开关：`interim` = 中间轮发送（多轮工具回复的过程正文照常发出），`final` = 最终轮分段（最终长回复按自然段拆成多条），`all` = 两域同时操作；`/llm delivery status`（或带域）查看当前值与全局默认，默认两域关闭 |
 | `/llm context_limit <条数>`（`reset` 或 `off` 恢复默认） | 把本群上下文改为固定保留最新 n 条（上限 1024；默认由会话纪元自动管理，窗口随对话增长、冷场后收缩）；重启和 `/llm clear_context` 不影响此设置 |
 | `/llm clear_context` | 清空本群短期上下文，AI“串台”或记错上下文时用 |
 | `/llm delete_msg` | 引用一条消息发送本命令，或 `/llm delete_msg <消息ID>`，从上下文删除该条 |

--- a/docs/user/group-commands.md
+++ b/docs/user/group-commands.md
@@ -146,7 +146,7 @@ QuickQuip 在群里有两类能力：规则回复（复读、接龙、时区猜�
 | `/llm trigger at on / off` | 开关艾特触发（仅群聊有此命令） |
 | `/llm memory on / off` | 开关记忆注入 |
 | `/llm auto_memory on / off / reset / status` | 自动记忆抽取的开关、跟随全局默认、查看 |
-| `/llm delivery interim / final / all <on / off / reset>` | 分段交付两域的按群开关：`interim` = 中间轮发送（多轮工具回复的过程正文照常发出），`final` = 最终轮分段（最终长回复按自然段拆成多条），`all` = 两域同时操作；`/llm delivery status`（或带域）查看当前值与全局默认，默认两域关闭 |
+| `/llm delivery intermediate / final / all <on / off / reset>` | 分段交付两域的按群开关：`intermediate` = 中间轮发送（多轮工具回复的过程正文照常发出），`final` = 最终轮分段（最终长回复按自然段拆成多条），`all` = 两域同时操作；`/llm delivery status`（或带域）查看当前值与全局默认，默认两域关闭 |
 | `/llm context_limit <条数>`（`reset` 或 `off` 恢复默认） | 把本群上下文改为固定保留最新 n 条（上限 1024；默认由会话纪元自动管理，窗口随对话增长、冷场后收缩）；重启和 `/llm clear_context` 不影响此设置 |
 | `/llm clear_context` | 清空本群短期上下文，AI“串台”或记错上下文时用 |
 | `/llm delete_msg` | 引用一条消息发送本命令，或 `/llm delete_msg <消息ID>`，从上下文删除该条 |

--- a/docs/user/private-commands.md
+++ b/docs/user/private-commands.md
@@ -64,7 +64,7 @@ provider 指 AI 的服务来源（如 Gemini、OpenAI），一个 provider 下�
 | `/llm trigger prefix_mode on / off` | 开关前缀触发 |
 | `/llm memory on / off` | 开关记忆注入 |
 | `/llm auto_memory on / off / reset / status` | 自动记忆抽取的开关、重置为全局默认、查看 |
-| `/llm delivery on / off / reset / status` | 分段发送（长回复按自然段拆成多条消息）的开关、重置为全局默认、查看；默认关闭 |
+| `/llm delivery interim / final / all <on / off / reset>` | 分段交付两域的开关：`interim` = 中间轮发送（多轮工具回复的过程正文照常发出），`final` = 最终轮分段（最终长回复按自然段拆成多条），`all` = 两域同时操作；`/llm delivery status`（或带域）查看当前值与全局默认，默认两域关闭 |
 | `/llm context_limit <条数>`（`reset` 或 `off` 恢复默认） | 把本会话改为固定保留最新 n 条（上限 1024；默认由会话纪元自动管理） |
 | `/llm clear_context` | 清空短期上下文，“串台”或记错上下文时用 |
 | `/llm delete_msg` | 引用一条消息发送本命令，或 `/llm delete_msg <消息ID>`，从上下文删除该条 |

--- a/docs/user/private-commands.md
+++ b/docs/user/private-commands.md
@@ -64,7 +64,7 @@ provider 指 AI 的服务来源（如 Gemini、OpenAI），一个 provider 下�
 | `/llm trigger prefix_mode on / off` | 开关前缀触发 |
 | `/llm memory on / off` | 开关记忆注入 |
 | `/llm auto_memory on / off / reset / status` | 自动记忆抽取的开关、重置为全局默认、查看 |
-| `/llm delivery interim / final / all <on / off / reset>` | 分段交付两域的开关：`interim` = 中间轮发送（多轮工具回复的过程正文照常发出），`final` = 最终轮分段（最终长回复按自然段拆成多条），`all` = 两域同时操作；`/llm delivery status`（或带域）查看当前值与全局默认，默认两域关闭 |
+| `/llm delivery intermediate / final / all <on / off / reset>` | 分段交付两域的开关：`intermediate` = 中间轮发送（多轮工具回复的过程正文照常发出），`final` = 最终轮分段（最终长回复按自然段拆成多条），`all` = 两域同时操作；`/llm delivery status`（或带域）查看当前值与全局默认，默认两域关闭 |
 | `/llm context_limit <条数>`（`reset` 或 `off` 恢复默认） | 把本会话改为固定保留最新 n 条（上限 1024；默认由会话纪元自动管理） |
 | `/llm clear_context` | 清空短期上下文，“串台”或记错上下文时用 |
 | `/llm delete_msg` | 引用一条消息发送本命令，或 `/llm delete_msg <消息ID>`，从上下文删除该条 |

--- a/frontend/src/api/groupSettings.ts
+++ b/frontend/src/api/groupSettings.ts
@@ -5,7 +5,8 @@ export type GroupOverrideField =
   | 'enabled'
   | 'memory_enabled'
   | 'auto_memory_enabled'
-  | 'agent_delivery_enabled'
+  | 'agent_delivery_intermediate'
+  | 'agent_delivery_final'
   | 'provider_id'
   | 'model'
   | 'persona_id'
@@ -29,7 +30,8 @@ export interface GroupOverrideDraft {
   enabled: boolean | null
   memory_enabled: boolean | null
   auto_memory_enabled: boolean | null
-  agent_delivery_enabled: boolean | null
+  agent_delivery_intermediate: boolean | null
+  agent_delivery_final: boolean | null
   provider_id: string | null
   model: string | null
   persona_id: string | null
@@ -72,7 +74,8 @@ export interface GroupSettingsDefaults {
   enabled?: boolean
   memory_enabled?: boolean
   auto_memory_enabled?: boolean
-  agent_delivery_enabled?: boolean
+  agent_delivery_intermediate?: boolean
+  agent_delivery_final?: boolean
   provider_id?: string | null
   persona_id?: string | null
   trigger_prefix?: string | null

--- a/frontend/src/api/groupSettings.ts
+++ b/frontend/src/api/groupSettings.ts
@@ -5,8 +5,8 @@ export type GroupOverrideField =
   | 'enabled'
   | 'memory_enabled'
   | 'auto_memory_enabled'
-  | 'agent_delivery_intermediate'
-  | 'agent_delivery_final'
+  | 'agent_delivery_intermediate_enabled'
+  | 'agent_delivery_final_enabled'
   | 'provider_id'
   | 'model'
   | 'persona_id'
@@ -30,8 +30,8 @@ export interface GroupOverrideDraft {
   enabled: boolean | null
   memory_enabled: boolean | null
   auto_memory_enabled: boolean | null
-  agent_delivery_intermediate: boolean | null
-  agent_delivery_final: boolean | null
+  agent_delivery_intermediate_enabled: boolean | null
+  agent_delivery_final_enabled: boolean | null
   provider_id: string | null
   model: string | null
   persona_id: string | null
@@ -74,8 +74,8 @@ export interface GroupSettingsDefaults {
   enabled?: boolean
   memory_enabled?: boolean
   auto_memory_enabled?: boolean
-  agent_delivery_intermediate?: boolean
-  agent_delivery_final?: boolean
+  agent_delivery_intermediate_enabled?: boolean
+  agent_delivery_final_enabled?: boolean
   provider_id?: string | null
   persona_id?: string | null
   trigger_prefix?: string | null

--- a/frontend/src/composables/useGroupOverrideDraft.ts
+++ b/frontend/src/composables/useGroupOverrideDraft.ts
@@ -8,7 +8,7 @@ import type {
 
 /** 可编辑字段表：草稿/原始快照/diff 的键集合唯一来源 */
 const FIELDS: readonly GroupOverrideField[] = [
-  'enabled', 'memory_enabled', 'auto_memory_enabled', 'agent_delivery_intermediate', 'agent_delivery_final', 'provider_id', 'model', 'persona_id',
+  'enabled', 'memory_enabled', 'auto_memory_enabled', 'agent_delivery_intermediate_enabled', 'agent_delivery_final_enabled', 'provider_id', 'model', 'persona_id',
   'trigger_prefix', 'allow_prefix', 'allow_at', 'history_limit',
 ]
 

--- a/frontend/src/composables/useGroupOverrideDraft.ts
+++ b/frontend/src/composables/useGroupOverrideDraft.ts
@@ -8,7 +8,7 @@ import type {
 
 /** 可编辑字段表：草稿/原始快照/diff 的键集合唯一来源 */
 const FIELDS: readonly GroupOverrideField[] = [
-  'enabled', 'memory_enabled', 'auto_memory_enabled', 'agent_delivery_enabled', 'provider_id', 'model', 'persona_id',
+  'enabled', 'memory_enabled', 'auto_memory_enabled', 'agent_delivery_intermediate', 'agent_delivery_final', 'provider_id', 'model', 'persona_id',
   'trigger_prefix', 'allow_prefix', 'allow_at', 'history_limit',
 ]
 

--- a/frontend/src/views/GroupSettingsView.vue
+++ b/frontend/src/views/GroupSettingsView.vue
@@ -120,16 +120,16 @@
               </div>
               <div class="field">
                 <label>中间轮发送<UiInfoTip text="开启后该会话的工具调用多轮回复中，非最终轮的正文照常作为消息发出（如「我先查一下…」这类过程文本）；关闭时中间轮只记录不发送。全局默认在 llm.toml 的 agent_delivery_intermediate_enabled 配置。" /></label>
-                <select v-model="draftTriState.agent_delivery_intermediate">
-                  <option :value="null">跟随默认（{{ defaultHint('agent_delivery_intermediate') }}）</option>
+                <select v-model="draftTriState.agent_delivery_intermediate_enabled">
+                  <option :value="null">跟随默认（{{ defaultHint('agent_delivery_intermediate_enabled') }}）</option>
                   <option :value="true">开</option>
                   <option :value="false">关</option>
                 </select>
               </div>
               <div class="field">
                 <label>最终轮分段<UiInfoTip text="开启后该会话的最终回复按自然段拆成多条消息发出；关闭时最终回复合并为一条。全局默认在 llm.toml 的 agent_delivery_final_enabled 配置。" /></label>
-                <select v-model="draftTriState.agent_delivery_final">
-                  <option :value="null">跟随默认（{{ defaultHint('agent_delivery_final') }}）</option>
+                <select v-model="draftTriState.agent_delivery_final_enabled">
+                  <option :value="null">跟随默认（{{ defaultHint('agent_delivery_final_enabled') }}）</option>
                   <option :value="true">开</option>
                   <option :value="false">关</option>
                 </select>

--- a/frontend/src/views/GroupSettingsView.vue
+++ b/frontend/src/views/GroupSettingsView.vue
@@ -119,9 +119,17 @@
                 </select>
               </div>
               <div class="field">
-                <label>分段发送<UiInfoTip text="开启后该会话的 LLM 回复按自然段拆成多条消息发出；关闭时长回复合并为一条。全局默认在 llm.toml 的 agent_delivery_enabled 配置。" /></label>
-                <select v-model="draftTriState.agent_delivery_enabled">
-                  <option :value="null">跟随默认（{{ defaultHint('agent_delivery_enabled') }}）</option>
+                <label>中间轮发送<UiInfoTip text="开启后该会话的工具调用多轮回复中，非最终轮的正文照常作为消息发出（如「我先查一下…」这类过程文本）；关闭时中间轮只记录不发送。全局默认在 llm.toml 的 agent_delivery_intermediate_enabled 配置。" /></label>
+                <select v-model="draftTriState.agent_delivery_intermediate">
+                  <option :value="null">跟随默认（{{ defaultHint('agent_delivery_intermediate') }}）</option>
+                  <option :value="true">开</option>
+                  <option :value="false">关</option>
+                </select>
+              </div>
+              <div class="field">
+                <label>最终轮分段<UiInfoTip text="开启后该会话的最终回复按自然段拆成多条消息发出；关闭时最终回复合并为一条。全局默认在 llm.toml 的 agent_delivery_final_enabled 配置。" /></label>
+                <select v-model="draftTriState.agent_delivery_final">
+                  <option :value="null">跟随默认（{{ defaultHint('agent_delivery_final') }}）</option>
                   <option :value="true">开</option>
                   <option :value="false">关</option>
                 </select>

--- a/src/quickquip/adapters/nonebot/command_parts/llm.py
+++ b/src/quickquip/adapters/nonebot/command_parts/llm.py
@@ -25,51 +25,53 @@ class DeliveryViews(NamedTuple):
     default_final: str
 
 
+def _delivery_views(svc, chat_id, chat_type: str) -> DeliveryViews:
+    settings = svc.get_chat_settings(chat_id, chat_type=chat_type)
+    return DeliveryViews(
+        "开" if settings.agent_delivery_intermediate_enabled else "关",
+        "开" if settings.agent_delivery_final_enabled else "关",
+        "开" if svc.config.runtime.agent_delivery_intermediate_enabled else "关",
+        "开" if svc.config.runtime.agent_delivery_final_enabled else "关",
+    )
+
+
 async def _handle_delivery_command(
-    llm_cmd, svc, *, chat_id, chat_type, scope_label, tokens
+    llm_cmd, svc, *, chat_id, chat_type, scope_label, sub_tokens
 ) -> None:
-    """`/llm delivery` 三域子命令。
+    """`/llm delivery` 三域子命令（``sub_tokens`` 已剥去 delivery 动词）。
 
     域 token 与配置/存储同用 intermediate/final/all 一个词根；未匹配的
     输入原样返回，由调用方继续后续分支（最终落用法提示）。
     """
-    rest = [token.lower() for token in tokens[1:]]
+    rest = [token.lower() for token in sub_tokens]
     try:
         domain = DeliveryDomain(rest[0]) if rest else None
     except ValueError:
         domain = None
     action = rest[1] if len(rest) >= 2 else ""
-
-    def _views() -> DeliveryViews:
-        settings = svc.get_chat_settings(chat_id, chat_type=chat_type)
-        return DeliveryViews(
-            "开" if settings.agent_delivery_intermediate_enabled else "关",
-            "开" if settings.agent_delivery_final_enabled else "关",
-            "开" if svc.config.runtime.agent_delivery_intermediate_enabled else "关",
-            "开" if svc.config.runtime.agent_delivery_final_enabled else "关",
-        )
+    # 单次取值快照，后续文案全部复用（避免重复读库）
+    views = _delivery_views(svc, chat_id, chat_type)
 
     def _domain_default(scope_domain: DeliveryDomain) -> str:
-        views = _views()
         if scope_domain is DeliveryDomain.INTERMEDIATE:
             return views.default_intermediate
         if scope_domain is DeliveryDomain.FINAL:
             return views.default_final
         return f"中间轮 {views.default_intermediate} / 最终轮 {views.default_final}"
 
-    if domain is not None and action == "on":
-        svc.set_chat_agent_delivery_enabled(chat_id, True, chat_type=chat_type, domain=domain)
-        await llm_cmd.finish(f"{scope_label}{_DELIVERY_DOMAIN_LABELS[domain]}已开启")
-    if domain is not None and action == "off":
-        svc.set_chat_agent_delivery_enabled(chat_id, False, chat_type=chat_type, domain=domain)
-        await llm_cmd.finish(f"{scope_label}{_DELIVERY_DOMAIN_LABELS[domain]}已关闭")
-    if domain is not None and action == "reset":
-        svc.set_chat_agent_delivery_enabled(chat_id, None, chat_type=chat_type, domain=domain)
-        await llm_cmd.finish(
-            f"{scope_label}{_DELIVERY_DOMAIN_LABELS[domain]}已跟随全局默认（当前：{_domain_default(domain)}）"
-        )
+    # 动作互斥分发：一次命令只走一个动作，分支内自证，不依赖 finish 的
+    # 终止副作用。
+    if domain is not None and action in {"on", "off", "reset"}:
+        value = {"on": True, "off": False, "reset": None}[action]
+        svc.set_chat_agent_delivery_enabled(chat_id, value, chat_type=chat_type, domain=domain)
+        if action == "reset":
+            await llm_cmd.finish(
+                f"{scope_label}{_DELIVERY_DOMAIN_LABELS[domain]}已跟随全局默认"
+                f"（当前：{_domain_default(domain)}）"
+            )
+        suffix = "已开启" if value else "已关闭"
+        await llm_cmd.finish(f"{scope_label}{_DELIVERY_DOMAIN_LABELS[domain]}{suffix}")
     if not rest or rest == ["status"] or (domain is not None and action == "status"):
-        views = _views()
         # 概览与单域显式互斥，不依赖 finish 的终止副作用兜底控制流。
         if domain is None or domain is DeliveryDomain.ALL:
             await llm_cmd.finish(
@@ -298,7 +300,7 @@ def register_llm_commands(on_command, Message, MessageSegment) -> None:
             await _handle_delivery_command(
                 llm_cmd, svc,
                 chat_id=chat_id, chat_type=chat_type,
-                scope_label=scope_label, tokens=tokens,
+                scope_label=scope_label, sub_tokens=tokens[1:],
             )
 
         if tokens[:1] == ["context_limit"] and len(tokens) >= 2:

--- a/src/quickquip/adapters/nonebot/command_parts/llm.py
+++ b/src/quickquip/adapters/nonebot/command_parts/llm.py
@@ -213,24 +213,52 @@ def register_llm_commands(on_command, Message, MessageSegment) -> None:
                     f"{scope_label}自动记忆抽取：{current}（全局默认 {default}）"
                 )
 
-        if tokens[:1] == ["delivery"] and len(tokens) >= 2:
-            sub = tokens[1].lower()
-            if sub == "on":
-                svc.set_chat_agent_delivery_enabled(chat_id, True, chat_type=chat_type)
-                await llm_cmd.finish(f"{scope_label}分段发送已开启")
-            if sub == "off":
-                svc.set_chat_agent_delivery_enabled(chat_id, False, chat_type=chat_type)
-                await llm_cmd.finish(f"{scope_label}分段发送已关闭")
-            if sub == "reset":
-                svc.set_chat_agent_delivery_enabled(chat_id, None, chat_type=chat_type)
-                default = "开" if svc.config.runtime.agent_delivery_enabled else "关"
-                await llm_cmd.finish(f"{scope_label}分段发送已跟随全局默认（当前：{default}）")
-            if sub == "status":
+        if tokens[:1] == ["delivery"]:
+            rest = [token.lower() for token in tokens[1:]]
+            domain_labels = {"interim": "中间轮发送", "final": "最终轮分段", "all": "分段交付"}
+            domain = rest[0] if rest and rest[0] in domain_labels else ""
+            action = rest[1] if len(rest) >= 2 else ""
+            # 命令域 token（interim）到 service 写入域（intermediate）的映射
+            service_domain = {"interim": "intermediate", "final": "final", "all": "all"}.get(domain, "")
+
+            def _delivery_views():
                 settings = svc.get_chat_settings(chat_id, chat_type=chat_type)
-                default = "开" if svc.config.runtime.agent_delivery_enabled else "关"
-                current = "开" if settings.agent_delivery_enabled else "关"
+                return (
+                    "开" if settings.agent_delivery_intermediate_enabled else "关",
+                    "开" if settings.agent_delivery_final_enabled else "关",
+                    "开" if svc.config.runtime.agent_delivery_intermediate_enabled else "关",
+                    "开" if svc.config.runtime.agent_delivery_final_enabled else "关",
+                )
+
+            def _domain_default(domain: str) -> str:
+                _, _, default_intermediate, default_final = _delivery_views()
+                if domain == "interim":
+                    return default_intermediate
+                if domain == "final":
+                    return default_final
+                return f"中间轮 {default_intermediate} / 最终轮 {default_final}"
+
+            if domain and action == "on":
+                svc.set_chat_agent_delivery_enabled(chat_id, True, chat_type=chat_type, domain=service_domain)
+                await llm_cmd.finish(f"{scope_label}{domain_labels[domain]}已开启")
+            if domain and action == "off":
+                svc.set_chat_agent_delivery_enabled(chat_id, False, chat_type=chat_type, domain=service_domain)
+                await llm_cmd.finish(f"{scope_label}{domain_labels[domain]}已关闭")
+            if domain and action == "reset":
+                svc.set_chat_agent_delivery_enabled(chat_id, None, chat_type=chat_type, domain=service_domain)
                 await llm_cmd.finish(
-                    f"{scope_label}分段发送：{current}（全局默认 {default}）"
+                    f"{scope_label}{domain_labels[domain]}已跟随全局默认（当前：{_domain_default(domain)}）"
+                )
+            if not rest or rest == ["status"] or (domain and action == "status"):
+                current_intermediate, current_final, default_intermediate, default_final = _delivery_views()
+                if domain in ("", "all"):
+                    await llm_cmd.finish(
+                        f"{scope_label}分段交付：中间轮 {current_intermediate}（默认 {default_intermediate}）"
+                        f" / 最终轮 {current_final}（默认 {default_final}）"
+                    )
+                current = current_intermediate if domain == "interim" else current_final
+                await llm_cmd.finish(
+                    f"{scope_label}{domain_labels[domain]}：{current}（全局默认 {_domain_default(domain)}）"
                 )
 
         if tokens[:1] == ["context_limit"] and len(tokens) >= 2:
@@ -254,7 +282,7 @@ def register_llm_commands(on_command, Message, MessageSegment) -> None:
         await llm_cmd.finish(
             "LLM 命令用法：/llm status|current|on|off|providers|probe|models [provider]|use <provider> [model]|"
             "personas|persona use <id>|trigger prefix <value>|trigger prefix_mode on|off|trigger at on|off|"
-            "memory status|memory on|memory off|auto_memory on|off|reset|status|delivery on|off|reset|status|"
+            "memory status|memory on|memory off|auto_memory on|off|reset|status|delivery interim|final|all <on|off|reset>|delivery status|"
             "context_limit <n>|context_limit reset|clear_context|reload|mcp status"
         )
 

--- a/src/quickquip/adapters/nonebot/command_parts/llm.py
+++ b/src/quickquip/adapters/nonebot/command_parts/llm.py
@@ -1,9 +1,90 @@
 from __future__ import annotations
 
+from typing import NamedTuple
+
 from quickquip.adapters.nonebot.command_parts.common import _allow_scope_management, _chat_id, _chat_label, _chat_type, _parse_preset, _parse_resume, _strip_command_name
 from quickquip.app.message_pipeline import _ensure_llm_bindings, get_llm_service, rate_limiter
 from quickquip.llm.epoch import DEFAULT_EPOCH_MAX_ROWS
+from quickquip.llm.settings import DeliveryDomain
 from quickquip.search.web_search import SearXNGSearchClient, WebSearchError, format_search_response
+
+
+_DELIVERY_DOMAIN_LABELS = {
+    DeliveryDomain.INTERMEDIATE: "中间轮发送",
+    DeliveryDomain.FINAL: "最终轮分段",
+    DeliveryDomain.ALL: "分段交付",
+}
+
+
+class DeliveryViews(NamedTuple):
+    """status 文案的四个取值：当前值两域 + 全局默认两域。"""
+
+    current_intermediate: str
+    current_final: str
+    default_intermediate: str
+    default_final: str
+
+
+async def _handle_delivery_command(
+    llm_cmd, svc, *, chat_id, chat_type, scope_label, tokens
+) -> None:
+    """`/llm delivery` 三域子命令。
+
+    域 token 与配置/存储同用 intermediate/final/all 一个词根；未匹配的
+    输入原样返回，由调用方继续后续分支（最终落用法提示）。
+    """
+    rest = [token.lower() for token in tokens[1:]]
+    try:
+        domain = DeliveryDomain(rest[0]) if rest else None
+    except ValueError:
+        domain = None
+    action = rest[1] if len(rest) >= 2 else ""
+
+    def _views() -> DeliveryViews:
+        settings = svc.get_chat_settings(chat_id, chat_type=chat_type)
+        return DeliveryViews(
+            "开" if settings.agent_delivery_intermediate_enabled else "关",
+            "开" if settings.agent_delivery_final_enabled else "关",
+            "开" if svc.config.runtime.agent_delivery_intermediate_enabled else "关",
+            "开" if svc.config.runtime.agent_delivery_final_enabled else "关",
+        )
+
+    def _domain_default(scope_domain: DeliveryDomain) -> str:
+        views = _views()
+        if scope_domain is DeliveryDomain.INTERMEDIATE:
+            return views.default_intermediate
+        if scope_domain is DeliveryDomain.FINAL:
+            return views.default_final
+        return f"中间轮 {views.default_intermediate} / 最终轮 {views.default_final}"
+
+    if domain is not None and action == "on":
+        svc.set_chat_agent_delivery_enabled(chat_id, True, chat_type=chat_type, domain=domain)
+        await llm_cmd.finish(f"{scope_label}{_DELIVERY_DOMAIN_LABELS[domain]}已开启")
+    if domain is not None and action == "off":
+        svc.set_chat_agent_delivery_enabled(chat_id, False, chat_type=chat_type, domain=domain)
+        await llm_cmd.finish(f"{scope_label}{_DELIVERY_DOMAIN_LABELS[domain]}已关闭")
+    if domain is not None and action == "reset":
+        svc.set_chat_agent_delivery_enabled(chat_id, None, chat_type=chat_type, domain=domain)
+        await llm_cmd.finish(
+            f"{scope_label}{_DELIVERY_DOMAIN_LABELS[domain]}已跟随全局默认（当前：{_domain_default(domain)}）"
+        )
+    if not rest or rest == ["status"] or (domain is not None and action == "status"):
+        views = _views()
+        # 概览与单域显式互斥，不依赖 finish 的终止副作用兜底控制流。
+        if domain is None or domain is DeliveryDomain.ALL:
+            await llm_cmd.finish(
+                f"{scope_label}分段交付：中间轮 {views.current_intermediate}（默认 {views.default_intermediate}）"
+                f" / 最终轮 {views.current_final}（默认 {views.default_final}）"
+            )
+        else:
+            current = (
+                views.current_intermediate
+                if domain is DeliveryDomain.INTERMEDIATE
+                else views.current_final
+            )
+            await llm_cmd.finish(
+                f"{scope_label}{_DELIVERY_DOMAIN_LABELS[domain]}：{current}（全局默认 {_domain_default(domain)}）"
+            )
 
 
 def register_llm_commands(on_command, Message, MessageSegment) -> None:
@@ -214,52 +295,11 @@ def register_llm_commands(on_command, Message, MessageSegment) -> None:
                 )
 
         if tokens[:1] == ["delivery"]:
-            rest = [token.lower() for token in tokens[1:]]
-            domain_labels = {"interim": "中间轮发送", "final": "最终轮分段", "all": "分段交付"}
-            domain = rest[0] if rest and rest[0] in domain_labels else ""
-            action = rest[1] if len(rest) >= 2 else ""
-            # 命令域 token（interim）到 service 写入域（intermediate）的映射
-            service_domain = {"interim": "intermediate", "final": "final", "all": "all"}.get(domain, "")
-
-            def _delivery_views():
-                settings = svc.get_chat_settings(chat_id, chat_type=chat_type)
-                return (
-                    "开" if settings.agent_delivery_intermediate_enabled else "关",
-                    "开" if settings.agent_delivery_final_enabled else "关",
-                    "开" if svc.config.runtime.agent_delivery_intermediate_enabled else "关",
-                    "开" if svc.config.runtime.agent_delivery_final_enabled else "关",
-                )
-
-            def _domain_default(domain: str) -> str:
-                _, _, default_intermediate, default_final = _delivery_views()
-                if domain == "interim":
-                    return default_intermediate
-                if domain == "final":
-                    return default_final
-                return f"中间轮 {default_intermediate} / 最终轮 {default_final}"
-
-            if domain and action == "on":
-                svc.set_chat_agent_delivery_enabled(chat_id, True, chat_type=chat_type, domain=service_domain)
-                await llm_cmd.finish(f"{scope_label}{domain_labels[domain]}已开启")
-            if domain and action == "off":
-                svc.set_chat_agent_delivery_enabled(chat_id, False, chat_type=chat_type, domain=service_domain)
-                await llm_cmd.finish(f"{scope_label}{domain_labels[domain]}已关闭")
-            if domain and action == "reset":
-                svc.set_chat_agent_delivery_enabled(chat_id, None, chat_type=chat_type, domain=service_domain)
-                await llm_cmd.finish(
-                    f"{scope_label}{domain_labels[domain]}已跟随全局默认（当前：{_domain_default(domain)}）"
-                )
-            if not rest or rest == ["status"] or (domain and action == "status"):
-                current_intermediate, current_final, default_intermediate, default_final = _delivery_views()
-                if domain in ("", "all"):
-                    await llm_cmd.finish(
-                        f"{scope_label}分段交付：中间轮 {current_intermediate}（默认 {default_intermediate}）"
-                        f" / 最终轮 {current_final}（默认 {default_final}）"
-                    )
-                current = current_intermediate if domain == "interim" else current_final
-                await llm_cmd.finish(
-                    f"{scope_label}{domain_labels[domain]}：{current}（全局默认 {_domain_default(domain)}）"
-                )
+            await _handle_delivery_command(
+                llm_cmd, svc,
+                chat_id=chat_id, chat_type=chat_type,
+                scope_label=scope_label, tokens=tokens,
+            )
 
         if tokens[:1] == ["context_limit"] and len(tokens) >= 2:
             value = tokens[1].lower()
@@ -282,7 +322,7 @@ def register_llm_commands(on_command, Message, MessageSegment) -> None:
         await llm_cmd.finish(
             "LLM 命令用法：/llm status|current|on|off|providers|probe|models [provider]|use <provider> [model]|"
             "personas|persona use <id>|trigger prefix <value>|trigger prefix_mode on|off|trigger at on|off|"
-            "memory status|memory on|memory off|auto_memory on|off|reset|status|delivery interim|final|all <on|off|reset>|delivery status|"
+            "memory status|memory on|memory off|auto_memory on|off|reset|status|delivery intermediate|final|all <on|off|reset>|delivery status|"
             "context_limit <n>|context_limit reset|clear_context|reload|mcp status"
         )
 

--- a/src/quickquip/app/web/routes/group_settings.py
+++ b/src/quickquip/app/web/routes/group_settings.py
@@ -39,7 +39,8 @@ class GroupSettingsBody(BaseModel):
     enabled: bool | None = None
     memory_enabled: bool | None = None
     auto_memory_enabled: bool | None = None
-    agent_delivery_enabled: bool | None = None
+    agent_delivery_intermediate: bool | None = None
+    agent_delivery_final: bool | None = None
     provider_id: str | None = Field(default=None, max_length=64)
     model: str | None = Field(default=None, max_length=128)
     persona_id: str | None = Field(default=None, max_length=64)
@@ -77,7 +78,8 @@ def get_options():
         "enabled": cfg.runtime.enabled,
         "memory_enabled": cfg.runtime.memory_enabled,
         "auto_memory_enabled": cfg.runtime.auto_memory_enabled,
-        "agent_delivery_enabled": cfg.runtime.agent_delivery_enabled,
+        "agent_delivery_intermediate": cfg.runtime.agent_delivery_intermediate_enabled,
+        "agent_delivery_final": cfg.runtime.agent_delivery_final_enabled,
         "provider_id": cfg.runtime.default_provider,
         "persona_id": cfg.runtime.default_persona,
         "trigger_prefix": cfg.triggers.default_prefix,
@@ -101,7 +103,8 @@ def _format_group_entry(group_id: str, row) -> dict:
         "enabled": None,
         "memory_enabled": None,
         "auto_memory_enabled": None,
-        "agent_delivery_enabled": None,
+        "agent_delivery_intermediate": None,
+        "agent_delivery_final": None,
         "provider_id": None,
         "model": None,
         "persona_id": None,
@@ -116,7 +119,8 @@ def _format_group_entry(group_id: str, row) -> dict:
             "enabled": None if row["enabled"] is None else bool(row["enabled"]),
             "memory_enabled": None if row["memory_enabled"] is None else bool(row["memory_enabled"]),
             "auto_memory_enabled": None if row["auto_memory_enabled"] is None else bool(row["auto_memory_enabled"]),
-            "agent_delivery_enabled": None if row["agent_delivery_enabled"] is None else bool(row["agent_delivery_enabled"]),
+            "agent_delivery_intermediate": None if row["agent_delivery_intermediate"] is None else bool(row["agent_delivery_intermediate"]),
+            "agent_delivery_final": None if row["agent_delivery_final"] is None else bool(row["agent_delivery_final"]),
             "provider_id": row["provider_id"],
             "model": row["model"],
             "persona_id": row["persona_id"],
@@ -143,7 +147,7 @@ def list_group_settings():
         with store._connect() as conn:
             rows = conn.execute(
                 """
-                SELECT group_id, enabled, memory_enabled, auto_memory_enabled, agent_delivery_enabled, provider_id, model, persona_id,
+                SELECT group_id, enabled, memory_enabled, auto_memory_enabled, agent_delivery_intermediate, agent_delivery_final, provider_id, model, persona_id,
                        trigger_prefix, allow_prefix, allow_at, history_limit, updated_at
                 FROM group_settings
                 ORDER BY updated_at DESC

--- a/src/quickquip/app/web/routes/group_settings.py
+++ b/src/quickquip/app/web/routes/group_settings.py
@@ -39,8 +39,8 @@ class GroupSettingsBody(BaseModel):
     enabled: bool | None = None
     memory_enabled: bool | None = None
     auto_memory_enabled: bool | None = None
-    agent_delivery_intermediate: bool | None = None
-    agent_delivery_final: bool | None = None
+    agent_delivery_intermediate_enabled: bool | None = None
+    agent_delivery_final_enabled: bool | None = None
     provider_id: str | None = Field(default=None, max_length=64)
     model: str | None = Field(default=None, max_length=128)
     persona_id: str | None = Field(default=None, max_length=64)
@@ -78,8 +78,8 @@ def get_options():
         "enabled": cfg.runtime.enabled,
         "memory_enabled": cfg.runtime.memory_enabled,
         "auto_memory_enabled": cfg.runtime.auto_memory_enabled,
-        "agent_delivery_intermediate": cfg.runtime.agent_delivery_intermediate_enabled,
-        "agent_delivery_final": cfg.runtime.agent_delivery_final_enabled,
+        "agent_delivery_intermediate_enabled": cfg.runtime.agent_delivery_intermediate_enabled,
+        "agent_delivery_final_enabled": cfg.runtime.agent_delivery_final_enabled,
         "provider_id": cfg.runtime.default_provider,
         "persona_id": cfg.runtime.default_persona,
         "trigger_prefix": cfg.triggers.default_prefix,
@@ -103,8 +103,8 @@ def _format_group_entry(group_id: str, row) -> dict:
         "enabled": None,
         "memory_enabled": None,
         "auto_memory_enabled": None,
-        "agent_delivery_intermediate": None,
-        "agent_delivery_final": None,
+        "agent_delivery_intermediate_enabled": None,
+        "agent_delivery_final_enabled": None,
         "provider_id": None,
         "model": None,
         "persona_id": None,
@@ -119,8 +119,8 @@ def _format_group_entry(group_id: str, row) -> dict:
             "enabled": None if row["enabled"] is None else bool(row["enabled"]),
             "memory_enabled": None if row["memory_enabled"] is None else bool(row["memory_enabled"]),
             "auto_memory_enabled": None if row["auto_memory_enabled"] is None else bool(row["auto_memory_enabled"]),
-            "agent_delivery_intermediate": None if row["agent_delivery_intermediate"] is None else bool(row["agent_delivery_intermediate"]),
-            "agent_delivery_final": None if row["agent_delivery_final"] is None else bool(row["agent_delivery_final"]),
+            "agent_delivery_intermediate_enabled": None if row["agent_delivery_intermediate_enabled"] is None else bool(row["agent_delivery_intermediate_enabled"]),
+            "agent_delivery_final_enabled": None if row["agent_delivery_final_enabled"] is None else bool(row["agent_delivery_final_enabled"]),
             "provider_id": row["provider_id"],
             "model": row["model"],
             "persona_id": row["persona_id"],
@@ -147,7 +147,7 @@ def list_group_settings():
         with store._connect() as conn:
             rows = conn.execute(
                 """
-                SELECT group_id, enabled, memory_enabled, auto_memory_enabled, agent_delivery_intermediate, agent_delivery_final, provider_id, model, persona_id,
+                SELECT group_id, enabled, memory_enabled, auto_memory_enabled, agent_delivery_intermediate_enabled, agent_delivery_final_enabled, provider_id, model, persona_id,
                        trigger_prefix, allow_prefix, allow_at, history_limit, updated_at
                 FROM group_settings
                 ORDER BY updated_at DESC

--- a/src/quickquip/llm/config.py
+++ b/src/quickquip/llm/config.py
@@ -852,11 +852,18 @@ def load_llm_config(path: str | Path) -> LLMConfig:
             source_path=config_path,
         )
     legacy_agent_delivery = runtime_raw.get("agent_delivery_enabled")
-    if legacy_agent_delivery is not None:
+    legacy_fallback_active = legacy_agent_delivery is not None and (
+        "agent_delivery_intermediate_enabled" not in runtime_raw
+        or "agent_delivery_final_enabled" not in runtime_raw
+    )
+    if legacy_fallback_active:
         logger.warning(
-            "[runtime] agent_delivery_enabled 已由 agent_delivery_intermediate_enabled / "
-            "agent_delivery_final_enabled 取代，未显式配置的新键按旧键值映射"
+            "[runtime] agent_delivery_enabled 已废弃：存在未显式配置的交付域，"
+            "该域正按旧键值映射，请迁移到 agent_delivery_intermediate_enabled / "
+            "agent_delivery_final_enabled"
         )
+    elif legacy_agent_delivery is not None:
+        logger.debug("[runtime] agent_delivery_enabled 已被两枚新键取代，忽略旧键")
     config = LLMConfig(
         runtime=RuntimeConfig(
             enabled=as_bool(runtime_raw.get("enabled", False), default=False),

--- a/src/quickquip/llm/config.py
+++ b/src/quickquip/llm/config.py
@@ -94,8 +94,10 @@ class RuntimeConfig:
     agent_record_max_loops_per_scope: int = 1000
     agent_record_max_bytes_per_scope: int = 67_108_864
     # 逐 Turn 交付上线开关（§6.3）：默认关闭——安装新版本不立刻增加群内
-    # 消息数；记录与投影始终工作。
-    agent_delivery_enabled: bool = False
+    # 消息数；记录与投影始终工作。两域独立：中间轮正文是否发送、最终
+    # 正文是否走 sink 自然分段（关闭时沿旧单发路径）。
+    agent_delivery_intermediate_enabled: bool = False
+    agent_delivery_final_enabled: bool = False
     # 历史重放投影预算（§8.2）：推导下限（512..4MiB）。实际预算由
     # request_budget.derive_replay_budget 从请求输入预算（仲裁者）推导；
     # provider 覆盖键为硬值，capacity unknown 时本值即实际值。
@@ -849,6 +851,12 @@ def load_llm_config(path: str | Path) -> LLMConfig:
             load_error="reply_split_threshold_chars 不能超过 reply_chunk_max_chars",
             source_path=config_path,
         )
+    legacy_agent_delivery = runtime_raw.get("agent_delivery_enabled")
+    if legacy_agent_delivery is not None:
+        logger.warning(
+            "[runtime] agent_delivery_enabled 已由 agent_delivery_intermediate_enabled / "
+            "agent_delivery_final_enabled 取代，未显式配置的新键按旧键值映射"
+        )
     config = LLMConfig(
         runtime=RuntimeConfig(
             enabled=as_bool(runtime_raw.get("enabled", False), default=False),
@@ -887,8 +895,13 @@ def load_llm_config(path: str | Path) -> LLMConfig:
             agent_record_max_bytes_per_scope=max(
                 1024, int(runtime_raw.get("agent_record_max_bytes_per_scope", 67_108_864))
             ),
-            agent_delivery_enabled=as_bool(
-                runtime_raw.get("agent_delivery_enabled"), default=False
+            agent_delivery_intermediate_enabled=as_bool(
+                runtime_raw.get("agent_delivery_intermediate_enabled"),
+                default=as_bool(legacy_agent_delivery, default=False),
+            ),
+            agent_delivery_final_enabled=as_bool(
+                runtime_raw.get("agent_delivery_final_enabled"),
+                default=as_bool(legacy_agent_delivery, default=False),
             ),
             agent_replay_loop_tokens=min(
                 AGENT_REPLAY_LOOP_TOKENS_CEILING,

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -755,8 +755,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             store=self.store,
             handle=handle,
             config=RecorderConfig(
-                intermediate_delivery_enabled=agent_delivery_intermediate,
-                final_delivery_enabled=agent_delivery_final,
+                agent_delivery_intermediate_enabled=agent_delivery_intermediate,
+                agent_delivery_final_enabled=agent_delivery_final,
                 reply_split_threshold_chars=runtime.reply_split_threshold_chars,
                 reply_chunk_max_chars=runtime.reply_chunk_max_chars,
                 reply_max_chunks_per_loop=runtime.reply_max_chunks_per_loop,
@@ -1582,13 +1582,11 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         except DeliveryAborted as exc:
             if recorder is not None:
                 recorder.close(LoopStatus.INTERRUPTED, str(exc) or "delivery_aborted")
-            # 逐 Turn 模式下静默：已交付的分段就是用户看到的全部。无记录路径
-            # 同样可能在这里终止（逐轮预算门禁不依赖 recorder），但它没有任何
-            # sink 交付，必须给出可见的中止提示而不是空串。
-            aborted_silently = recorder is not None and (
-                settings.agent_delivery_intermediate_enabled
-                or settings.agent_delivery_final_enabled
-            )
+            # 静默的依据是「用户已看到至少一条成功交付的分段」——零交付时
+            # （如中间轮抑制 + 最终轮未及交付即中止）必须给出可见中止提示，
+            # 否则用户既无正文也无通知。无记录路径没有任何 sink 交付，
+            # 同样必须可见。
+            aborted_silently = recorder is not None and recorder.summary().sent > 0
             return {
                 "reply": "" if aborted_silently else "本次回复未确认送达，已停止后续生成。",
                 "rate_limit_key": LLM_RULE_NAME,

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -696,7 +696,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         image_descriptions: list[ImageDescription] | None,
         delivery_sink=None,
         trigger_kind: TriggerKind | None = None,
-        agent_delivery_enabled: bool,
+        agent_delivery_intermediate: bool,
+        agent_delivery_final: bool,
     ):
         """创建 Loop 与 user 触发行（§5.3.1），返回 TurnRecorder。
 
@@ -754,7 +755,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             store=self.store,
             handle=handle,
             config=RecorderConfig(
-                agent_delivery_enabled=agent_delivery_enabled,
+                intermediate_delivery_enabled=agent_delivery_intermediate,
+                final_delivery_enabled=agent_delivery_final,
                 reply_split_threshold_chars=runtime.reply_split_threshold_chars,
                 reply_chunk_max_chars=runtime.reply_chunk_max_chars,
                 reply_max_chunks_per_loop=runtime.reply_max_chunks_per_loop,
@@ -1544,7 +1546,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 image_descriptions=[d for d in image_descriptions if not d.context_label.startswith(RECENT_IMAGE_CONTEXT_PREFIX)] or None,
                 delivery_sink=delivery_sink,
                 trigger_kind=trigger_kind,
-                agent_delivery_enabled=settings.agent_delivery_enabled,
+                agent_delivery_intermediate=settings.agent_delivery_intermediate_enabled,
+                agent_delivery_final=settings.agent_delivery_final_enabled,
             )
             with (
                 usage_scope("chat", group_id=scope_key, persona_id=settings.persona_id or None),
@@ -1582,7 +1585,10 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             # 逐 Turn 模式下静默：已交付的分段就是用户看到的全部。无记录路径
             # 同样可能在这里终止（逐轮预算门禁不依赖 recorder），但它没有任何
             # sink 交付，必须给出可见的中止提示而不是空串。
-            aborted_silently = recorder is not None and settings.agent_delivery_enabled
+            aborted_silently = recorder is not None and (
+                settings.agent_delivery_intermediate_enabled
+                or settings.agent_delivery_final_enabled
+            )
             return {
                 "reply": "" if aborted_silently else "本次回复未确认送达，已停止后续生成。",
                 "rate_limit_key": LLM_RULE_NAME,
@@ -1676,10 +1682,12 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             if recorder.final_turn_record is not None:
                 result_payload = dict(result_payload)
                 result_payload["agent_turn_row_id"] = recorder.final_turn_record.message_row_id
-        if recorder is not None and settings.agent_delivery_enabled:
-            # 逐 Turn 模式：正文已由 sink 交付，reply 不再二次发送（§5.1）。
-            # 无记录路径（同 scope 并发触发 / store 不可用）没有任何 sink 交付，
-            # reply 仍是唯一出口，置空会把整条回复静默吞掉。
+        if recorder is not None and settings.agent_delivery_final_enabled:
+            # 最终轮分段模式：最终正文已由 sink 交付，reply 不再二次发送
+            # （§5.1）。中间轮单开（最终轮关）时最终正文仍走旧单发路径，
+            # reply 必须保留；无记录路径（同 scope 并发触发 / store 不可用）
+            # 没有任何 sink 交付，reply 仍是唯一出口，置空会把整条回复静默
+            # 吞掉。
             result_payload = dict(result_payload)
             result_payload["reply"] = ""
         return result_payload

--- a/src/quickquip/llm/service.py
+++ b/src/quickquip/llm/service.py
@@ -696,8 +696,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
         image_descriptions: list[ImageDescription] | None,
         delivery_sink=None,
         trigger_kind: TriggerKind | None = None,
-        agent_delivery_intermediate: bool,
-        agent_delivery_final: bool,
+        agent_delivery_intermediate_enabled: bool,
+        agent_delivery_final_enabled: bool,
     ):
         """创建 Loop 与 user 触发行（§5.3.1），返回 TurnRecorder。
 
@@ -755,8 +755,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
             store=self.store,
             handle=handle,
             config=RecorderConfig(
-                agent_delivery_intermediate_enabled=agent_delivery_intermediate,
-                agent_delivery_final_enabled=agent_delivery_final,
+                agent_delivery_intermediate_enabled=agent_delivery_intermediate_enabled,
+                agent_delivery_final_enabled=agent_delivery_final_enabled,
                 reply_split_threshold_chars=runtime.reply_split_threshold_chars,
                 reply_chunk_max_chars=runtime.reply_chunk_max_chars,
                 reply_max_chunks_per_loop=runtime.reply_max_chunks_per_loop,
@@ -1546,8 +1546,8 @@ class LLMService(ScopeMixin, ToolMixin, McpLifecycleMixin, DrawSvgToolMixin, Sch
                 image_descriptions=[d for d in image_descriptions if not d.context_label.startswith(RECENT_IMAGE_CONTEXT_PREFIX)] or None,
                 delivery_sink=delivery_sink,
                 trigger_kind=trigger_kind,
-                agent_delivery_intermediate=settings.agent_delivery_intermediate_enabled,
-                agent_delivery_final=settings.agent_delivery_final_enabled,
+                agent_delivery_intermediate_enabled=settings.agent_delivery_intermediate_enabled,
+                agent_delivery_final_enabled=settings.agent_delivery_final_enabled,
             )
             with (
                 usage_scope("chat", group_id=scope_key, persona_id=settings.persona_id or None),

--- a/src/quickquip/llm/service_parts/agent_runtime.py
+++ b/src/quickquip/llm/service_parts/agent_runtime.py
@@ -69,8 +69,9 @@ class DeliveryAborted(RuntimeError):
 
 @dataclass(slots=True)
 class RecorderConfig:
-    intermediate_delivery_enabled: bool = False
-    final_delivery_enabled: bool = False
+    # 与配置键/设置解析/Web 字段同词根，跨层比对与全局搜索同一命名。
+    agent_delivery_intermediate_enabled: bool = False
+    agent_delivery_final_enabled: bool = False
     reply_split_threshold_chars: int = 800
     reply_chunk_max_chars: int = 1200
     reply_max_chunks_per_loop: int = 64
@@ -105,7 +106,10 @@ class TurnRecorder:
         self._config = config
         self._sink = (
             sink
-            if (config.intermediate_delivery_enabled or config.final_delivery_enabled)
+            if (
+                config.agent_delivery_intermediate_enabled
+                or config.agent_delivery_final_enabled
+            )
             else None
         )
         self._sensitive_scan = sensitive_scan
@@ -113,6 +117,11 @@ class TurnRecorder:
         self._delivery_stats = {"sent": 0, "failed": 0, "unknown": 0, "skipped": 0, "suppressed": 0}
         self._final_turn_record: TurnRecord | None = None
         self._terminal_reason: str | None = None
+        # 待发状态显式声明：on_turn 写入、deliver_turn 消费后清空。
+        self._pending_record: TurnRecord | None = None
+        self._pending_text: str = ""
+        self._pending_plan: dict[str, DeliveryPlanItem] = {}
+        self._pending_suppressed_ids: set[str] = set()
 
     @property
     def handle(self) -> LoopHandle:
@@ -145,26 +154,26 @@ class TurnRecorder:
 
     def _plan_deliveries(
         self, turn_id: str, text: str, *, is_final: bool
-    ) -> list[DeliveryPlanItem]:
+    ) -> tuple[list[DeliveryPlanItem], set[str]]:
+        """规划交付项并单独返回抑制项 ID——抑制判定的唯一归属者。"""
         policy = self._config
         items: list[DeliveryPlanItem] = []
         if not text:
-            return items
+            return items, set()
         if is_final:
-            if not policy.final_delivery_enabled:
+            if not policy.agent_delivery_final_enabled:
                 # 最终轮关闭：最终正文沿现有单次交付，交付记录由 receipt
                 # 回填阶段写入。
-                return items
-        elif not policy.intermediate_delivery_enabled:
+                return items, set()
+        elif not policy.agent_delivery_intermediate_enabled:
             # 中间轮关闭：非最终正文只记 suppressed（§6.3）。
-            items.append(
-                DeliveryPlanItem(
-                    delivery_id=new_agent_id("dlv"), kind=DeliveryKind.TEXT_CHUNK,
-                    turn_id=turn_id, chunk_index=0, source_start=0, source_end=len(text),
-                )
+            item = DeliveryPlanItem(
+                delivery_id=new_agent_id("dlv"), kind=DeliveryKind.TEXT_CHUNK,
+                turn_id=turn_id, chunk_index=0, source_start=0, source_end=len(text),
             )
+            items.append(item)
             self._delivery_stats["suppressed"] += 1
-            return items
+            return items, {item.delivery_id}
         if self._sink is None:
             raise RuntimeError("交付开关开启但缺少 DeliverySink（编程错误）")
         try:
@@ -181,7 +190,7 @@ class TurnRecorder:
             raise DeliveryAborted("split_limit") from None
         if limit_reason == "delivery_limit":
             self._terminal_reason = "delivery_limit"
-            return []
+            return [], set()
         for chunk in chunks:
             items.append(
                 DeliveryPlanItem(
@@ -193,7 +202,7 @@ class TurnRecorder:
                     source_end=chunk.end,
                 )
             )
-        return items
+        return items, set()
 
     def on_turn(
         self,
@@ -253,7 +262,7 @@ class TurnRecorder:
                 )
             else:
                 native_state = candidate
-        plan = self._plan_deliveries(turn_id, text, is_final=is_final)
+        plan, suppressed_ids = self._plan_deliveries(turn_id, text, is_final=is_final)
         record = self._store.commit_turn(
             self._handle,
             TurnResponseRecord(
@@ -272,27 +281,24 @@ class TurnRecorder:
         )
         if is_final or not has_more_rounds:
             self._final_turn_record = record
-        # 中间轮关闭的非最终 suppressed 交付落 planned 即收敛为 suppressed；
-        # 同批 ID 记入待发排除清单，deliver_turn 不得经 sink 发出抑制正文。
-        if not self._config.intermediate_delivery_enabled and not is_final:
-            for delivery_id in record.delivery_ids:
-                self._store.suppress_delivery(self._handle, delivery_id)
-            self._pending_suppressed_ids = set(record.delivery_ids)
-        else:
-            self._pending_suppressed_ids = set()
+        # 抑制项落 planned 即收敛为 suppressed；抑制清单由 _plan_deliveries
+        # 单一产出，deliver_turn 不得经 sink 发出抑制正文。
+        for delivery_id in suppressed_ids:
+            self._store.suppress_delivery(self._handle, delivery_id)
         if self._terminal_reason == "delivery_limit":
             raise DeliveryAborted("delivery_limit")
         self._pending_record = record
         self._pending_text = text
         self._pending_plan = {item.delivery_id: item for item in plan}
+        self._pending_suppressed_ids = set(suppressed_ids)
         return execution_ids
 
     async def deliver_turn(self) -> None:
         """提交后的文字 Chunk 交付（§5.3.6）：先于所属工具执行。"""
-        record = getattr(self, "_pending_record", None)
-        text = getattr(self, "_pending_text", "")
-        plan = getattr(self, "_pending_plan", {})
-        suppressed_ids = getattr(self, "_pending_suppressed_ids", set())
+        record = self._pending_record
+        text = self._pending_text
+        plan = self._pending_plan
+        suppressed_ids = self._pending_suppressed_ids
         self._pending_record = None
         self._pending_text = ""
         self._pending_plan = {}

--- a/src/quickquip/llm/service_parts/agent_runtime.py
+++ b/src/quickquip/llm/service_parts/agent_runtime.py
@@ -5,9 +5,9 @@
 原顺序执行工具 batch → 关闭。D3：首个 failed/unknown 交付即终止后续
 发送、工具启动与生成。
 
-上线开关（§6.3）：``agent_delivery_enabled=false`` 时仍记录全部 Turn 与
-工具，非最终正文标记 ``suppressed_by_policy``，最终正文由适配层按现有
-单次交付方式发送。
+上线开关（§6.3，两域独立）：中间轮开关关闭时非最终正文标记
+``suppressed_by_policy``；最终轮开关关闭时最终正文由适配层按现有单次
+交付方式发送。任一域开启即激活 sink 逐 Turn 交付。
 """
 from __future__ import annotations
 
@@ -69,7 +69,8 @@ class DeliveryAborted(RuntimeError):
 
 @dataclass(slots=True)
 class RecorderConfig:
-    agent_delivery_enabled: bool = False
+    intermediate_delivery_enabled: bool = False
+    final_delivery_enabled: bool = False
     reply_split_threshold_chars: int = 800
     reply_chunk_max_chars: int = 1200
     reply_max_chunks_per_loop: int = 64
@@ -102,7 +103,11 @@ class TurnRecorder:
         self._store = store
         self._handle = handle
         self._config = config
-        self._sink = sink if config.agent_delivery_enabled else None
+        self._sink = (
+            sink
+            if (config.intermediate_delivery_enabled or config.final_delivery_enabled)
+            else None
+        )
         self._sensitive_scan = sensitive_scan
         self._delivery_count = 0
         self._delivery_stats = {"sent": 0, "failed": 0, "unknown": 0, "skipped": 0, "suppressed": 0}
@@ -145,8 +150,13 @@ class TurnRecorder:
         items: list[DeliveryPlanItem] = []
         if not text:
             return items
-        if not policy.agent_delivery_enabled and not is_final:
-            # 关闭开关：非最终正文只记 suppressed（§6.3）。
+        if is_final:
+            if not policy.final_delivery_enabled:
+                # 最终轮关闭：最终正文沿现有单次交付，交付记录由 receipt
+                # 回填阶段写入。
+                return items
+        elif not policy.intermediate_delivery_enabled:
+            # 中间轮关闭：非最终正文只记 suppressed（§6.3）。
             items.append(
                 DeliveryPlanItem(
                     delivery_id=new_agent_id("dlv"), kind=DeliveryKind.TEXT_CHUNK,
@@ -155,11 +165,8 @@ class TurnRecorder:
             )
             self._delivery_stats["suppressed"] += 1
             return items
-        if not policy.agent_delivery_enabled:
-            # 最终正文沿现有单次交付，交付记录由 receipt 回填阶段写入。
-            return items
         if self._sink is None:
-            raise RuntimeError("agent_delivery_enabled=true 但缺少 DeliverySink（编程错误）")
+            raise RuntimeError("交付开关开启但缺少 DeliverySink（编程错误）")
         try:
             chunks, limit_reason = plan_text_chunks(
                 text,
@@ -265,10 +272,14 @@ class TurnRecorder:
         )
         if is_final or not has_more_rounds:
             self._final_turn_record = record
-        # 关闭开关的非最终 suppressed 交付落 planned 即收敛为 suppressed。
-        if not self._config.agent_delivery_enabled and not is_final:
+        # 中间轮关闭的非最终 suppressed 交付落 planned 即收敛为 suppressed；
+        # 同批 ID 记入待发排除清单，deliver_turn 不得经 sink 发出抑制正文。
+        if not self._config.intermediate_delivery_enabled and not is_final:
             for delivery_id in record.delivery_ids:
                 self._store.suppress_delivery(self._handle, delivery_id)
+            self._pending_suppressed_ids = set(record.delivery_ids)
+        else:
+            self._pending_suppressed_ids = set()
         if self._terminal_reason == "delivery_limit":
             raise DeliveryAborted("delivery_limit")
         self._pending_record = record
@@ -281,14 +292,21 @@ class TurnRecorder:
         record = getattr(self, "_pending_record", None)
         text = getattr(self, "_pending_text", "")
         plan = getattr(self, "_pending_plan", {})
+        suppressed_ids = getattr(self, "_pending_suppressed_ids", set())
         self._pending_record = None
         self._pending_text = ""
         self._pending_plan = {}
-        if record is None or not self._config.agent_delivery_enabled or self._sink is None:
+        self._pending_suppressed_ids = set()
+        # sink 为 None 即两域全关（构造时判定）；最终轮关闭的 Turn 计划为空，
+        # 循环体自然跳过。
+        if record is None or self._sink is None:
             return
         for delivery_id in record.delivery_ids:
             if self._terminal_reason is not None:
                 break
+            if delivery_id in suppressed_ids:
+                # 中间轮关闭的 suppressed 项不进入 sink：防止把抑制正文发出。
+                continue
             item = plan.get(delivery_id)
             chunk_text = text[item.source_start : item.source_end] if item else text
             # 范围恒等要求段落分隔换行归前段（§6.1），段尾空白只属于显示层：

--- a/src/quickquip/llm/service_parts/state.py
+++ b/src/quickquip/llm/service_parts/state.py
@@ -134,21 +134,21 @@ class StateMixin:
         chat_id: int | str,
         enabled: bool | None,
         chat_type: str = "group",
-        domain: DeliveryDomain = DeliveryDomain.ALL,
+        domain: DeliveryDomain | str = DeliveryDomain.ALL,
     ) -> None:
-        """按域写交付开关覆盖；域入参在此归一为枚举，非法值抛 ValueError。"""
+        """按域写交付开关覆盖；域入参接受枚举或其字符串值，非法值抛 ValueError。"""
         domain = DeliveryDomain(domain)
         value = None if enabled is None else int(enabled)
         match domain:
             case DeliveryDomain.INTERMEDIATE:
-                self._update_chat_settings(chat_id, chat_type, agent_delivery_intermediate=value)
+                self._update_chat_settings(chat_id, chat_type, agent_delivery_intermediate_enabled=value)
             case DeliveryDomain.FINAL:
-                self._update_chat_settings(chat_id, chat_type, agent_delivery_final=value)
+                self._update_chat_settings(chat_id, chat_type, agent_delivery_final_enabled=value)
             case DeliveryDomain.ALL:
                 self._update_chat_settings(
                     chat_id, chat_type,
-                    agent_delivery_intermediate=value,
-                    agent_delivery_final=value,
+                    agent_delivery_intermediate_enabled=value,
+                    agent_delivery_final_enabled=value,
                 )
 
     def set_chat_history_limit(self, chat_id: int | str, limit: int, chat_type: str = "group") -> None:

--- a/src/quickquip/llm/service_parts/state.py
+++ b/src/quickquip/llm/service_parts/state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from quickquip.llm.config import ProviderConfig
 from quickquip.llm.epoch import EpochKey
 from quickquip.llm.service_parts.constants import MAX_MEMORY_RETRIEVAL_ITEMS, MAX_STORED_MEMORY_ITEMS
+from quickquip.llm.settings import DeliveryDomain
 from quickquip.llm.store_parts.agent_records import HistoryMutation
 
 
@@ -133,22 +134,21 @@ class StateMixin:
         chat_id: int | str,
         enabled: bool | None,
         chat_type: str = "group",
-        domain: str = "all",
+        domain: DeliveryDomain = DeliveryDomain.ALL,
     ) -> None:
-        """按域写交付开关覆盖：intermediate / final / all（all 同时写两域）。"""
+        """按域写交付开关覆盖；非法域由 DeliveryDomain 枚举在解析期拒绝。"""
         value = None if enabled is None else int(enabled)
-        if domain == "intermediate":
-            self._update_chat_settings(chat_id, chat_type, agent_delivery_intermediate=value)
-        elif domain == "final":
-            self._update_chat_settings(chat_id, chat_type, agent_delivery_final=value)
-        elif domain == "all":
-            self._update_chat_settings(
-                chat_id, chat_type,
-                agent_delivery_intermediate=value,
-                agent_delivery_final=value,
-            )
-        else:
-            raise ValueError(f"未知交付开关域：{domain!r}")
+        match domain:
+            case DeliveryDomain.INTERMEDIATE:
+                self._update_chat_settings(chat_id, chat_type, agent_delivery_intermediate=value)
+            case DeliveryDomain.FINAL:
+                self._update_chat_settings(chat_id, chat_type, agent_delivery_final=value)
+            case DeliveryDomain.ALL:
+                self._update_chat_settings(
+                    chat_id, chat_type,
+                    agent_delivery_intermediate=value,
+                    agent_delivery_final=value,
+                )
 
     def set_chat_history_limit(self, chat_id: int | str, limit: int, chat_type: str = "group") -> None:
         self._update_chat_settings(chat_id, chat_type, history_limit=limit)

--- a/src/quickquip/llm/service_parts/state.py
+++ b/src/quickquip/llm/service_parts/state.py
@@ -129,10 +129,24 @@ class StateMixin:
         self._update_chat_settings(chat_id, chat_type, auto_memory_enabled=value)
 
     def set_chat_agent_delivery_enabled(
-        self, chat_id: int | str, enabled: bool | None, chat_type: str = "group"
+        self,
+        chat_id: int | str,
+        enabled: bool | None,
+        chat_type: str = "group",
+        domain: str = "all",
     ) -> None:
+        """按域写交付开关覆盖：intermediate / final / all（all 同时写两域）。"""
         value = None if enabled is None else int(enabled)
-        self._update_chat_settings(chat_id, chat_type, agent_delivery_enabled=value)
+        if domain == "intermediate":
+            self._update_chat_settings(chat_id, chat_type, agent_delivery_intermediate=value)
+        elif domain == "final":
+            self._update_chat_settings(chat_id, chat_type, agent_delivery_final=value)
+        else:
+            self._update_chat_settings(
+                chat_id, chat_type,
+                agent_delivery_intermediate=value,
+                agent_delivery_final=value,
+            )
 
     def set_chat_history_limit(self, chat_id: int | str, limit: int, chat_type: str = "group") -> None:
         self._update_chat_settings(chat_id, chat_type, history_limit=limit)

--- a/src/quickquip/llm/service_parts/state.py
+++ b/src/quickquip/llm/service_parts/state.py
@@ -141,12 +141,14 @@ class StateMixin:
             self._update_chat_settings(chat_id, chat_type, agent_delivery_intermediate=value)
         elif domain == "final":
             self._update_chat_settings(chat_id, chat_type, agent_delivery_final=value)
-        else:
+        elif domain == "all":
             self._update_chat_settings(
                 chat_id, chat_type,
                 agent_delivery_intermediate=value,
                 agent_delivery_final=value,
             )
+        else:
+            raise ValueError(f"未知交付开关域：{domain!r}")
 
     def set_chat_history_limit(self, chat_id: int | str, limit: int, chat_type: str = "group") -> None:
         self._update_chat_settings(chat_id, chat_type, history_limit=limit)

--- a/src/quickquip/llm/service_parts/state.py
+++ b/src/quickquip/llm/service_parts/state.py
@@ -136,7 +136,8 @@ class StateMixin:
         chat_type: str = "group",
         domain: DeliveryDomain = DeliveryDomain.ALL,
     ) -> None:
-        """按域写交付开关覆盖；非法域由 DeliveryDomain 枚举在解析期拒绝。"""
+        """按域写交付开关覆盖；域入参在此归一为枚举，非法值抛 ValueError。"""
+        domain = DeliveryDomain(domain)
         value = None if enabled is None else int(enabled)
         match domain:
             case DeliveryDomain.INTERMEDIATE:

--- a/src/quickquip/llm/settings.py
+++ b/src/quickquip/llm/settings.py
@@ -47,13 +47,13 @@ def resolve_group_settings(store, config, group_id: int | str) -> ResolvedGroupS
             else config.runtime.auto_memory_enabled
         ),
         agent_delivery_intermediate_enabled=(
-            overrides.agent_delivery_intermediate
-            if overrides.agent_delivery_intermediate is not None
+            overrides.agent_delivery_intermediate_enabled
+            if overrides.agent_delivery_intermediate_enabled is not None
             else config.runtime.agent_delivery_intermediate_enabled
         ),
         agent_delivery_final_enabled=(
-            overrides.agent_delivery_final
-            if overrides.agent_delivery_final is not None
+            overrides.agent_delivery_final_enabled
+            if overrides.agent_delivery_final_enabled is not None
             else config.runtime.agent_delivery_final_enabled
         ),
         provider_id=provider_id,

--- a/src/quickquip/llm/settings.py
+++ b/src/quickquip/llm/settings.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+import enum
 from dataclasses import dataclass
+
+
+class DeliveryDomain(enum.StrEnum):
+    """交付开关的写入域：中间轮正文 / 最终轮分段 / 两域同写。"""
+
+    INTERMEDIATE = "intermediate"
+    FINAL = "final"
+    ALL = "all"
 
 
 @dataclass(slots=True)

--- a/src/quickquip/llm/settings.py
+++ b/src/quickquip/llm/settings.py
@@ -15,7 +15,8 @@ class ResolvedGroupSettings:
     allow_prefix: bool
     allow_at: bool
     history_limit: int | None = None
-    agent_delivery_enabled: bool = False
+    agent_delivery_intermediate_enabled: bool = False
+    agent_delivery_final_enabled: bool = False
 
 
 def resolve_group_settings(store, config, group_id: int | str) -> ResolvedGroupSettings:
@@ -36,10 +37,15 @@ def resolve_group_settings(store, config, group_id: int | str) -> ResolvedGroupS
             if overrides.auto_memory_enabled is not None
             else config.runtime.auto_memory_enabled
         ),
-        agent_delivery_enabled=(
-            overrides.agent_delivery_enabled
-            if overrides.agent_delivery_enabled is not None
-            else config.runtime.agent_delivery_enabled
+        agent_delivery_intermediate_enabled=(
+            overrides.agent_delivery_intermediate
+            if overrides.agent_delivery_intermediate is not None
+            else config.runtime.agent_delivery_intermediate_enabled
+        ),
+        agent_delivery_final_enabled=(
+            overrides.agent_delivery_final
+            if overrides.agent_delivery_final is not None
+            else config.runtime.agent_delivery_final_enabled
         ),
         provider_id=provider_id,
         model=model,

--- a/src/quickquip/llm/store_parts/_base.py
+++ b/src/quickquip/llm/store_parts/_base.py
@@ -58,7 +58,8 @@ class GroupSettingsOverride:
     enabled: bool | None = None
     memory_enabled: bool | None = None
     auto_memory_enabled: bool | None = None
-    agent_delivery_enabled: bool | None = None
+    agent_delivery_intermediate: bool | None = None
+    agent_delivery_final: bool | None = None
     provider_id: str | None = None
     model: str | None = None
     persona_id: str | None = None
@@ -117,6 +118,8 @@ class _StoreBase:
                     memory_enabled INTEGER,
                     auto_memory_enabled INTEGER,
                     agent_delivery_enabled INTEGER,
+                    agent_delivery_intermediate INTEGER,
+                    agent_delivery_final INTEGER,
                     provider_id TEXT,
                     model TEXT,
                     persona_id TEXT,
@@ -186,6 +189,25 @@ class _StoreBase:
                 conn.execute("ALTER TABLE group_settings ADD COLUMN auto_memory_enabled INTEGER")
             if "agent_delivery_enabled" not in existing_columns:
                 conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_enabled INTEGER")
+            # 交付开关拆分（中间轮/最终轮）：加列时一次性把旧单开关值回填进
+            # 两列。回填只与加列绑定执行——若挂在启动路径无条件重跑，会与
+            # 后续 reset（列置 NULL 跟随默认）的语义冲突，重启后覆盖用户选择。
+            added_delivery_split_columns = False
+            if "agent_delivery_intermediate" not in existing_columns:
+                conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_intermediate INTEGER")
+                added_delivery_split_columns = True
+            if "agent_delivery_final" not in existing_columns:
+                conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_final INTEGER")
+                added_delivery_split_columns = True
+            if added_delivery_split_columns:
+                conn.execute(
+                    """
+                    UPDATE group_settings
+                    SET agent_delivery_intermediate = agent_delivery_enabled,
+                        agent_delivery_final = agent_delivery_enabled
+                    WHERE agent_delivery_enabled IS NOT NULL
+                    """
+                )
             conversation_columns = {
                 row["name"]
                 for row in conn.execute("PRAGMA table_info(conversation_messages)").fetchall()

--- a/src/quickquip/llm/store_parts/_base.py
+++ b/src/quickquip/llm/store_parts/_base.py
@@ -69,6 +69,23 @@ class GroupSettingsOverride:
     history_limit: int | None = None
 
 
+def _backfill_delivery_split_columns(conn: sqlite3.Connection, existing_columns: set[str]) -> None:
+    """交付开关拆分（中间轮/最终轮）的加列 + 一次性回填。
+
+    回填只与各自加列绑定执行——若挂在启动路径无条件重跑，会与后续 reset
+    （列置 NULL 跟随默认）的语义冲突，重启后覆盖用户选择；按列独立门控，
+    半迁移状态下不跨列覆写另一列的已有取值。
+    """
+    for column in ("agent_delivery_intermediate", "agent_delivery_final"):
+        if column in existing_columns:
+            continue
+        conn.execute(f"ALTER TABLE group_settings ADD COLUMN {column} INTEGER")
+        conn.execute(
+            f"UPDATE group_settings SET {column} = agent_delivery_enabled "
+            "WHERE agent_delivery_enabled IS NOT NULL"
+        )
+
+
 class _StoreBase:
     """LLMStore 的基础设施层：连接管理、schema 初始化、不可用守卫。
 
@@ -189,28 +206,7 @@ class _StoreBase:
                 conn.execute("ALTER TABLE group_settings ADD COLUMN auto_memory_enabled INTEGER")
             if "agent_delivery_enabled" not in existing_columns:
                 conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_enabled INTEGER")
-            # 交付开关拆分（中间轮/最终轮）：加列时一次性把旧单开关值回填进
-            # 两列。回填只与各自加列绑定执行——若挂在启动路径无条件重跑，会与
-            # 后续 reset（列置 NULL 跟随默认）的语义冲突，重启后覆盖用户选择；
-            # 按列独立门控，避免半迁移状态下跨列覆写另一列的已有取值。
-            if "agent_delivery_intermediate" not in existing_columns:
-                conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_intermediate INTEGER")
-                conn.execute(
-                    """
-                    UPDATE group_settings
-                    SET agent_delivery_intermediate = agent_delivery_enabled
-                    WHERE agent_delivery_enabled IS NOT NULL
-                    """
-                )
-            if "agent_delivery_final" not in existing_columns:
-                conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_final INTEGER")
-                conn.execute(
-                    """
-                    UPDATE group_settings
-                    SET agent_delivery_final = agent_delivery_enabled
-                    WHERE agent_delivery_enabled IS NOT NULL
-                    """
-                )
+            _backfill_delivery_split_columns(conn, existing_columns)
             conversation_columns = {
                 row["name"]
                 for row in conn.execute("PRAGMA table_info(conversation_messages)").fetchall()

--- a/src/quickquip/llm/store_parts/_base.py
+++ b/src/quickquip/llm/store_parts/_base.py
@@ -58,8 +58,8 @@ class GroupSettingsOverride:
     enabled: bool | None = None
     memory_enabled: bool | None = None
     auto_memory_enabled: bool | None = None
-    agent_delivery_intermediate: bool | None = None
-    agent_delivery_final: bool | None = None
+    agent_delivery_intermediate_enabled: bool | None = None
+    agent_delivery_final_enabled: bool | None = None
     provider_id: str | None = None
     model: str | None = None
     persona_id: str | None = None
@@ -76,7 +76,7 @@ def _backfill_delivery_split_columns(conn: sqlite3.Connection, existing_columns:
     （列置 NULL 跟随默认）的语义冲突，重启后覆盖用户选择；按列独立门控，
     半迁移状态下不跨列覆写另一列的已有取值。
     """
-    for column in ("agent_delivery_intermediate", "agent_delivery_final"):
+    for column in ("agent_delivery_intermediate_enabled", "agent_delivery_final_enabled"):
         if column in existing_columns:
             continue
         conn.execute(f"ALTER TABLE group_settings ADD COLUMN {column} INTEGER")
@@ -135,8 +135,8 @@ class _StoreBase:
                     memory_enabled INTEGER,
                     auto_memory_enabled INTEGER,
                     agent_delivery_enabled INTEGER,
-                    agent_delivery_intermediate INTEGER,
-                    agent_delivery_final INTEGER,
+                    agent_delivery_intermediate_enabled INTEGER,
+                    agent_delivery_final_enabled INTEGER,
                     provider_id TEXT,
                     model TEXT,
                     persona_id TEXT,

--- a/src/quickquip/llm/store_parts/_base.py
+++ b/src/quickquip/llm/store_parts/_base.py
@@ -190,21 +190,24 @@ class _StoreBase:
             if "agent_delivery_enabled" not in existing_columns:
                 conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_enabled INTEGER")
             # 交付开关拆分（中间轮/最终轮）：加列时一次性把旧单开关值回填进
-            # 两列。回填只与加列绑定执行——若挂在启动路径无条件重跑，会与
-            # 后续 reset（列置 NULL 跟随默认）的语义冲突，重启后覆盖用户选择。
-            added_delivery_split_columns = False
+            # 两列。回填只与各自加列绑定执行——若挂在启动路径无条件重跑，会与
+            # 后续 reset（列置 NULL 跟随默认）的语义冲突，重启后覆盖用户选择；
+            # 按列独立门控，避免半迁移状态下跨列覆写另一列的已有取值。
             if "agent_delivery_intermediate" not in existing_columns:
                 conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_intermediate INTEGER")
-                added_delivery_split_columns = True
-            if "agent_delivery_final" not in existing_columns:
-                conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_final INTEGER")
-                added_delivery_split_columns = True
-            if added_delivery_split_columns:
                 conn.execute(
                     """
                     UPDATE group_settings
-                    SET agent_delivery_intermediate = agent_delivery_enabled,
-                        agent_delivery_final = agent_delivery_enabled
+                    SET agent_delivery_intermediate = agent_delivery_enabled
+                    WHERE agent_delivery_enabled IS NOT NULL
+                    """
+                )
+            if "agent_delivery_final" not in existing_columns:
+                conn.execute("ALTER TABLE group_settings ADD COLUMN agent_delivery_final INTEGER")
+                conn.execute(
+                    """
+                    UPDATE group_settings
+                    SET agent_delivery_final = agent_delivery_enabled
                     WHERE agent_delivery_enabled IS NOT NULL
                     """
                 )

--- a/src/quickquip/llm/store_parts/group_settings.py
+++ b/src/quickquip/llm/store_parts/group_settings.py
@@ -14,7 +14,7 @@ class GroupSettingsMixin:
         with self._connect() as conn:
             row = conn.execute(
                 """
-                SELECT enabled, memory_enabled, auto_memory_enabled, agent_delivery_enabled, provider_id, model, persona_id, trigger_prefix, allow_prefix, allow_at, history_limit
+                SELECT enabled, memory_enabled, auto_memory_enabled, agent_delivery_intermediate, agent_delivery_final, provider_id, model, persona_id, trigger_prefix, allow_prefix, allow_at, history_limit
                 FROM group_settings
                 WHERE group_id = ?
                 """,
@@ -26,7 +26,8 @@ class GroupSettingsMixin:
             enabled=None if row["enabled"] is None else bool(row["enabled"]),
             memory_enabled=None if row["memory_enabled"] is None else bool(row["memory_enabled"]),
             auto_memory_enabled=None if row["auto_memory_enabled"] is None else bool(row["auto_memory_enabled"]),
-            agent_delivery_enabled=None if row["agent_delivery_enabled"] is None else bool(row["agent_delivery_enabled"]),
+            agent_delivery_intermediate=None if row["agent_delivery_intermediate"] is None else bool(row["agent_delivery_intermediate"]),
+            agent_delivery_final=None if row["agent_delivery_final"] is None else bool(row["agent_delivery_final"]),
             provider_id=row["provider_id"],
             model=row["model"],
             persona_id=row["persona_id"],
@@ -44,7 +45,8 @@ class GroupSettingsMixin:
             "enabled",
             "memory_enabled",
             "auto_memory_enabled",
-            "agent_delivery_enabled",
+            "agent_delivery_intermediate",
+            "agent_delivery_final",
             "provider_id",
             "model",
             "persona_id",

--- a/src/quickquip/llm/store_parts/group_settings.py
+++ b/src/quickquip/llm/store_parts/group_settings.py
@@ -14,7 +14,7 @@ class GroupSettingsMixin:
         with self._connect() as conn:
             row = conn.execute(
                 """
-                SELECT enabled, memory_enabled, auto_memory_enabled, agent_delivery_intermediate, agent_delivery_final, provider_id, model, persona_id, trigger_prefix, allow_prefix, allow_at, history_limit
+                SELECT enabled, memory_enabled, auto_memory_enabled, agent_delivery_intermediate_enabled, agent_delivery_final_enabled, provider_id, model, persona_id, trigger_prefix, allow_prefix, allow_at, history_limit
                 FROM group_settings
                 WHERE group_id = ?
                 """,
@@ -26,8 +26,8 @@ class GroupSettingsMixin:
             enabled=None if row["enabled"] is None else bool(row["enabled"]),
             memory_enabled=None if row["memory_enabled"] is None else bool(row["memory_enabled"]),
             auto_memory_enabled=None if row["auto_memory_enabled"] is None else bool(row["auto_memory_enabled"]),
-            agent_delivery_intermediate=None if row["agent_delivery_intermediate"] is None else bool(row["agent_delivery_intermediate"]),
-            agent_delivery_final=None if row["agent_delivery_final"] is None else bool(row["agent_delivery_final"]),
+            agent_delivery_intermediate_enabled=None if row["agent_delivery_intermediate_enabled"] is None else bool(row["agent_delivery_intermediate_enabled"]),
+            agent_delivery_final_enabled=None if row["agent_delivery_final_enabled"] is None else bool(row["agent_delivery_final_enabled"]),
             provider_id=row["provider_id"],
             model=row["model"],
             persona_id=row["persona_id"],
@@ -45,8 +45,8 @@ class GroupSettingsMixin:
             "enabled",
             "memory_enabled",
             "auto_memory_enabled",
-            "agent_delivery_intermediate",
-            "agent_delivery_final",
+            "agent_delivery_intermediate_enabled",
+            "agent_delivery_final_enabled",
             "provider_id",
             "model",
             "persona_id",

--- a/tests/integration/test_agent_delivery_optin.py
+++ b/tests/integration/test_agent_delivery_optin.py
@@ -91,22 +91,32 @@ async def test_delivery_matrix_all_four_combos(tmp_path: Path, patch_provider_bu
 async def test_delivery_override_false_beats_global_on_and_reset_follows(
     tmp_path: Path, patch_provider_builder
 ):
-    """单域覆盖关优先于全局开；reset 单域只影响该域，另一域覆盖保留。"""
+    """单域覆盖关优先于全局开；reset 单域只清该域，另一域覆盖保留。"""
     service = await _service(tmp_path)
     service.config.runtime.agent_delivery_intermediate_enabled = True
     service.config.runtime.agent_delivery_final_enabled = True
 
+    # 两域写异值覆盖：中间轮显式关、最终轮显式开 → 组合 C
     service.set_chat_agent_delivery_enabled(1001, False, chat_type="group", domain="intermediate")
+    service.set_chat_agent_delivery_enabled(1001, True, chat_type="group", domain="final")
     result, sink = await _run(service, patch_provider_builder, group_id=1001)
-    # 全局双开 + 中间轮覆盖关 = 组合 C
     assert len(sink.deliveries) == 3
     assert result["reply"] == ""
 
+    # reset 只清中间轮：该域回 NULL 跟随全局，最终轮覆盖保留
     service.set_chat_agent_delivery_enabled(1001, None, chat_type="group", domain="intermediate")
     override = service.store.get_group_settings("1001")
     assert override.agent_delivery_intermediate is None
-    assert override.agent_delivery_final is None
+    assert override.agent_delivery_final is True
+    # 同群 resolve：中间轮已跟随全局开（五 Turn 剧本按请求内 assistant 行数计
+    # 轮次，同 scope 复跑必耗尽剧本，reset 生效路径以 resolve 断言钉住）
+    resolved = service.get_chat_settings(1001, chat_type="group")
+    assert resolved.agent_delivery_intermediate_enabled is True
+    assert resolved.agent_delivery_final_enabled is True
+
+    # 行为验证：新群走同样覆盖编排（中间轮关→reset），最终 = 组合 D
+    service.set_chat_agent_delivery_enabled(1003, False, chat_type="group", domain="intermediate")
+    service.set_chat_agent_delivery_enabled(1003, None, chat_type="group", domain="intermediate")
     result2, sink2 = await _run(service, patch_provider_builder, group_id=1003)
-    # 覆盖清空后跟随全局双开 = 组合 D
     assert len(sink2.deliveries) == 7
     assert result2["reply"] == ""

--- a/tests/integration/test_agent_delivery_optin.py
+++ b/tests/integration/test_agent_delivery_optin.py
@@ -65,6 +65,8 @@ async def test_delivery_matrix_all_four_combos(tmp_path: Path, patch_provider_bu
     result_b, sink_b = await _run(service, patch_provider_builder, group_id=1002)
     assert _sink_texts(sink_b) == [text.rstrip() for text in FIVE_TURN_TEXTS[:4]]
     assert result_b["reply"] == FIVE_TURN_TEXTS[4]
+    # 最终轮走旧单发路径：精确回填钩子齐全（adapter record_final_receipt 消费）
+    assert result_b["agent_turn_row_id"] is not None
 
     # C：仅最终轮开 → 中间轮 suppressed 不外发（回归防线），最终三段经 sink
     service.set_chat_agent_delivery_enabled(1003, True, chat_type="group", domain="final")

--- a/tests/integration/test_agent_delivery_optin.py
+++ b/tests/integration/test_agent_delivery_optin.py
@@ -120,3 +120,12 @@ async def test_delivery_override_false_beats_global_on_and_reset_follows(
     result2, sink2 = await _run(service, patch_provider_builder, group_id=1003)
     assert len(sink2.deliveries) == 7
     assert result2["reply"] == ""
+
+
+async def test_delivery_invalid_domain_rejected(tmp_path: Path, patch_provider_builder):
+    """非法域值显式 ValueError，不静默跳过写入。"""
+    import pytest
+
+    service = await _service(tmp_path)
+    with pytest.raises(ValueError):
+        service.set_chat_agent_delivery_enabled(1001, True, chat_type="group", domain="interim")

--- a/tests/integration/test_agent_delivery_optin.py
+++ b/tests/integration/test_agent_delivery_optin.py
@@ -106,8 +106,8 @@ async def test_delivery_override_false_beats_global_on_and_reset_follows(
     # reset 只清中间轮：该域回 NULL 跟随全局，最终轮覆盖保留
     service.set_chat_agent_delivery_enabled(1001, None, chat_type="group", domain="intermediate")
     override = service.store.get_group_settings("1001")
-    assert override.agent_delivery_intermediate is None
-    assert override.agent_delivery_final is True
+    assert override.agent_delivery_intermediate_enabled is None
+    assert override.agent_delivery_final_enabled is True
     # 同群 resolve：中间轮已跟随全局开（五 Turn 剧本按请求内 assistant 行数计
     # 轮次，同 scope 复跑必耗尽剧本，reset 生效路径以 resolve 断言钉住）
     resolved = service.get_chat_settings(1001, chat_type="group")

--- a/tests/integration/test_agent_delivery_optin.py
+++ b/tests/integration/test_agent_delivery_optin.py
@@ -1,9 +1,9 @@
-"""按会话 opt-in 的分段交付：三态覆盖优先于全局默认，两个方向都验证。
+"""按会话 opt-in 的分段交付：两域独立覆盖优先于全局默认。
 
-覆盖开/关优先于全局；未覆盖（reset/NULL）跟随全局默认。与
-test_agent_loop_baseline.py 的差别：那边钉全局开关的行为，这边钉
-per-scope 覆盖的解析与生效。每次运行用独立 scope：五 Turn 剧本客户端
-按请求内 assistant 行数计轮次，同 scope 复跑会耗尽剧本。
+行为矩阵（中间轮 × 最终轮）四组合全部钉死；与 test_agent_loop_baseline.py
+的差别：那边钉全局开关的行为，这边钉 per-scope 覆盖的解析与生效。每次
+运行用独立 scope：五 Turn 剧本客户端按请求内 assistant 行数计轮次，
+同 scope 复跑会耗尽剧本。
 """
 from __future__ import annotations
 
@@ -44,39 +44,67 @@ async def _run(service: LLMService, patch_provider_builder, group_id: int) -> tu
     return result, sink
 
 
-async def test_delivery_default_off_and_group_override_enables(
-    tmp_path: Path, patch_provider_builder
-):
-    """全局默认关：无覆盖走单发；覆盖开的群分段交付。"""
+def _sink_texts(sink: CollectingSink) -> list[str]:
+    return [str(payload.get("text", "")) for _, payload in sink.deliveries]
+
+
+async def test_delivery_matrix_all_four_combos(tmp_path: Path, patch_provider_builder):
+    """两域独立：A 双关 / B 中间开 / C 最终开 / D 双开，行为各自符合定义。"""
     service = await _service(tmp_path)
 
-    result, sink = await _run(service, patch_provider_builder, group_id=1001)
-    assert sink.deliveries == []
-    assert result["reply"] == FIVE_TURN_TEXTS[4]
-    # recorder 仍工作：精确回填键齐全（关闭模式沿现有单发交付）。
-    assert result["agent_turn_row_id"] is not None
-    assert result["scope_key"] == "1001"
+    # A：全局默认双关，无覆盖 → 中间轮 suppressed，最终正文单发
+    result_a, sink_a = await _run(service, patch_provider_builder, group_id=1001)
+    assert sink_a.deliveries == []
+    assert result_a["reply"] == FIVE_TURN_TEXTS[4]
+    # recorder 仍工作：精确回填键齐全（最终单发路径）。
+    assert result_a["agent_turn_row_id"] is not None
+    assert result_a["scope_key"] == "1001"
 
-    service.set_chat_agent_delivery_enabled(1002, True, chat_type="group")
-    result2, sink2 = await _run(service, patch_provider_builder, group_id=1002)
-    assert len(sink2.deliveries) == 7
-    assert result2["reply"] == ""
+    # B：仅中间轮开 → 四个中间 Turn 各一段经 sink，最终正文仍整条单发
+    service.set_chat_agent_delivery_enabled(1002, True, chat_type="group", domain="intermediate")
+    result_b, sink_b = await _run(service, patch_provider_builder, group_id=1002)
+    assert _sink_texts(sink_b) == [text.rstrip() for text in FIVE_TURN_TEXTS[:4]]
+    assert result_b["reply"] == FIVE_TURN_TEXTS[4]
+
+    # C：仅最终轮开 → 中间轮 suppressed 不外发（回归防线），最终三段经 sink
+    service.set_chat_agent_delivery_enabled(1003, True, chat_type="group", domain="final")
+    result_c, sink_c = await _run(service, patch_provider_builder, group_id=1003)
+    assert len(sink_c.deliveries) == 3
+    assert all(
+        text not in _sink_texts(sink_c)
+        for text in (FIVE_TURN_TEXTS[0], FIVE_TURN_TEXTS[1], FIVE_TURN_TEXTS[2], FIVE_TURN_TEXTS[3])
+    ), "中间轮关闭时 suppressed 正文不得进入 sink"
+    assert "".join(_sink_texts(sink_c)) == "".join(
+        FIVE_TURN_TEXTS[4].split("\n\n")
+    ), "最终三段拼回应等于源正文（按空行分界）"
+    assert result_c["reply"] == ""
+
+    # D：双开 → 4 + 3 = 7 段全量交付，reply 置空
+    service.set_chat_agent_delivery_enabled(1004, True, chat_type="group", domain="all")
+    result_d, sink_d = await _run(service, patch_provider_builder, group_id=1004)
+    assert len(sink_d.deliveries) == 7
+    assert result_d["reply"] == ""
 
 
 async def test_delivery_override_false_beats_global_on_and_reset_follows(
     tmp_path: Path, patch_provider_builder
 ):
-    """群覆盖关优先于全局开；清空覆盖后跟随全局。"""
+    """单域覆盖关优先于全局开；reset 单域只影响该域，另一域覆盖保留。"""
     service = await _service(tmp_path)
-    service.config.runtime.agent_delivery_enabled = True
+    service.config.runtime.agent_delivery_intermediate_enabled = True
+    service.config.runtime.agent_delivery_final_enabled = True
 
-    service.set_chat_agent_delivery_enabled(1001, False, chat_type="group")
+    service.set_chat_agent_delivery_enabled(1001, False, chat_type="group", domain="intermediate")
     result, sink = await _run(service, patch_provider_builder, group_id=1001)
-    assert sink.deliveries == []
-    assert result["reply"] == FIVE_TURN_TEXTS[4]
+    # 全局双开 + 中间轮覆盖关 = 组合 C
+    assert len(sink.deliveries) == 3
+    assert result["reply"] == ""
 
-    service.set_chat_agent_delivery_enabled(1001, None, chat_type="group")
-    assert service.store.get_group_settings("1001").agent_delivery_enabled is None
+    service.set_chat_agent_delivery_enabled(1001, None, chat_type="group", domain="intermediate")
+    override = service.store.get_group_settings("1001")
+    assert override.agent_delivery_intermediate is None
+    assert override.agent_delivery_final is None
     result2, sink2 = await _run(service, patch_provider_builder, group_id=1003)
+    # 覆盖清空后跟随全局双开 = 组合 D
     assert len(sink2.deliveries) == 7
     assert result2["reply"] == ""

--- a/tests/integration/test_agent_loop_baseline.py
+++ b/tests/integration/test_agent_loop_baseline.py
@@ -131,7 +131,10 @@ async def test_all_turns_mode_seven_chunks_delivered_before_tools(
     scenario_service, patch_scenario_provider, monkeypatch
 ):
     monkeypatch.setattr(
-        scenario_service.config.runtime, "agent_delivery_enabled", True
+        scenario_service.config.runtime, "agent_delivery_intermediate_enabled", True
+    )
+    monkeypatch.setattr(
+        scenario_service.config.runtime, "agent_delivery_final_enabled", True
     )
     monkeypatch.setattr(
         scenario_service.config.runtime,
@@ -179,7 +182,10 @@ async def test_delivered_chunks_strip_trailing_blank_lines(
     from quickquip.llm.provider import LLMRequest, LLMResponse
 
     monkeypatch.setattr(
-        scenario_service.config.runtime, "agent_delivery_enabled", True
+        scenario_service.config.runtime, "agent_delivery_intermediate_enabled", True
+    )
+    monkeypatch.setattr(
+        scenario_service.config.runtime, "agent_delivery_final_enabled", True
     )
     monkeypatch.setattr(
         scenario_service.config.runtime, "reply_split_threshold_chars", 30

--- a/tests/integration/test_agent_loop_delivery_failure.py
+++ b/tests/integration/test_agent_loop_delivery_failure.py
@@ -62,7 +62,8 @@ async def test_first_chunk_failure_stops_tools_and_generation(
     # 首段失败后：只有一次发送尝试，无第二次模型请求，无工具执行记录。
     assert len(sink.attempts) == 1
     assert len(client.requests) == 1
-    assert result["reply"] == ""
+    # 零送达：中止必须可见（静默依据是「已有成功交付」）
+    assert result["reply"] == "本次回复未确认送达，已停止后续生成。"
     with service.store._connect() as conn:
         tool_status = [row["status"] for row in conn.execute("SELECT status FROM agent_tool_executions")]
         loop_row = conn.execute(
@@ -281,8 +282,8 @@ async def test_no_record_fallback_surfaces_abort_when_delivery_enabled(
     assert result["reply"] == "本次回复未确认送达，已停止后续生成。"
 
 
-async def test_intermediate_only_failure_aborts_silently(tmp_path: Path, patch_provider_builder):
-    """组合 B（仅中间轮开）：首段中间轮失败 → D3 终止且静默（已发即全部）。"""
+async def test_intermediate_only_first_failure_surfaces_notice(tmp_path: Path, patch_provider_builder):
+    """组合 B（仅中间轮开）：首个中间轮段失败 → 零送达，D3 终止并给出可见提示。"""
     from tests.fixtures.agent_loop import FiveTurnScenarioClient
 
     service = await _service(tmp_path)
@@ -304,8 +305,8 @@ async def test_intermediate_only_failure_aborts_silently(tmp_path: Path, patch_p
 
     assert len(sink.attempts) == 1  # 仅首个中间轮段尝试后终止
     assert len(client.requests) == 1
-    # sink 模式激活（中间轮开）：静默，不再补发错误提示
-    assert result["reply"] == ""
+    # 零送达（首段即失败）：中止提示必须可见
+    assert result["reply"] == "本次回复未确认送达，已停止后续生成。"
     with service.store._connect() as conn:
         loop_row = conn.execute("SELECT status, terminal_reason FROM agent_loops").fetchone()
     assert loop_row["status"] == "interrupted"
@@ -337,10 +338,72 @@ async def test_final_only_failure_after_suppressed_intermediate(tmp_path: Path, 
     assert len(sink.attempts) == 1
     assert sink.attempts[0][1] == FIVE_TURN_TEXTS[4][:20]
     assert len(client.requests) == 5
-    assert result["reply"] == ""  # 最终轮开：sink 模式静默
+    # 零送达（suppressed 不外发 + 最终首段失败）：中止提示必须可见
+    assert result["reply"] == "本次回复未确认送达，已停止后续生成。"
     with service.store._connect() as conn:
         statuses = [
             row["status"]
             for row in conn.execute("SELECT status FROM agent_deliveries ORDER BY delivery_index")
         ]
     assert statuses == ["suppressed"] * 4 + ["failed", "skipped", "skipped"]
+
+
+async def test_zero_delivery_abort_surfaces_notice(tmp_path: Path, patch_provider_builder):
+    """组合 C + 交付条数预算耗尽：零送达时中止必须可见，不得静默吞掉。"""
+    from tests.fixtures.agent_loop import CollectingSink, FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    service.config.runtime.agent_delivery_intermediate_enabled = False
+    service.config.runtime.agent_delivery_final_enabled = True
+    for attr, value in [
+        ("reply_split_threshold_chars", AGENT_LOOP_TEST_SPLIT["threshold"]),
+        ("reply_chunk_max_chars", AGENT_LOOP_TEST_SPLIT["chunk_max"]),
+        ("reply_max_chunks_per_loop", 1),
+    ]:
+        setattr(service.config.runtime, attr, value)
+    sink = CollectingSink()
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+
+    result = await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+
+    # 中间轮全抑制、最终轮未及交付即中止：零送达 → 给出可见中止提示
+    assert sink.deliveries == []
+    assert result["reply"] == "本次回复未确认送达，已停止后续生成。"
+    with service.store._connect() as conn:
+        loop_row = conn.execute("SELECT status, terminal_reason FROM agent_loops").fetchone()
+    assert loop_row["status"] == "interrupted"
+    assert loop_row["terminal_reason"] == "delivery_limit"
+
+
+async def test_partial_delivery_abort_stays_silent(tmp_path: Path, patch_provider_builder):
+    """组合 D + 预算在第二 Turn 耗尽：已有一段成功送达，中止保持静默。"""
+    from tests.fixtures.agent_loop import CollectingSink, FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    service.config.runtime.agent_delivery_intermediate_enabled = True
+    service.config.runtime.agent_delivery_final_enabled = True
+    for attr, value in [
+        ("reply_split_threshold_chars", AGENT_LOOP_TEST_SPLIT["threshold"]),
+        ("reply_chunk_max_chars", AGENT_LOOP_TEST_SPLIT["chunk_max"]),
+        ("reply_max_chunks_per_loop", 1),
+    ]:
+        setattr(service.config.runtime, attr, value)
+    sink = CollectingSink()
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+
+    result = await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+
+    # Turn 0 一段已送达用户，Turn 1 预算耗尽中止：已交付分段即用户所见全部
+    assert len(sink.deliveries) == 1
+    assert result["reply"] == ""
+    with service.store._connect() as conn:
+        loop_row = conn.execute("SELECT status, terminal_reason FROM agent_loops").fetchone()
+    assert loop_row["terminal_reason"] == "delivery_limit"

--- a/tests/integration/test_agent_loop_delivery_failure.py
+++ b/tests/integration/test_agent_loop_delivery_failure.py
@@ -44,7 +44,8 @@ async def test_first_chunk_failure_stops_tools_and_generation(
 
     service = await _service(tmp_path)
     for attr, value in [
-        ("agent_delivery_enabled", True),
+        ("agent_delivery_intermediate_enabled", True),
+        ("agent_delivery_final_enabled", True),
         ("reply_split_threshold_chars", AGENT_LOOP_TEST_SPLIT["threshold"]),
         ("reply_chunk_max_chars", AGENT_LOOP_TEST_SPLIT["chunk_max"]),
     ]:
@@ -83,7 +84,8 @@ async def test_unknown_receipt_never_resent(tmp_path: Path, patch_provider_build
     from tests.fixtures.agent_loop import FiveTurnScenarioClient
 
     service = await _service(tmp_path)
-    service.config.runtime.agent_delivery_enabled = True
+    service.config.runtime.agent_delivery_intermediate_enabled = True
+    service.config.runtime.agent_delivery_final_enabled = True
     sink = ScriptedSink([DeliveryReceipt(status=DeliveryStatus.UNKNOWN, error_code="timeout")])
     service.bind_delivery_sink(sink)
     client = FiveTurnScenarioClient(protocol="openai")
@@ -113,7 +115,8 @@ async def test_middle_chunk_failure_keeps_earlier_facts(tmp_path: Path, patch_pr
 
     service = await _service(tmp_path)
     for attr, value in [
-        ("agent_delivery_enabled", True),
+        ("agent_delivery_intermediate_enabled", True),
+        ("agent_delivery_final_enabled", True),
         ("reply_split_threshold_chars", AGENT_LOOP_TEST_SPLIT["threshold"]),
         ("reply_chunk_max_chars", AGENT_LOOP_TEST_SPLIT["chunk_max"]),
     ]:
@@ -166,7 +169,8 @@ async def test_no_record_fallback_keeps_reply_when_delivery_enabled(
     from tests.fixtures.agent_loop import CollectingSink, FiveTurnScenarioClient
 
     service = await _service(tmp_path)
-    service.config.runtime.agent_delivery_enabled = True
+    service.config.runtime.agent_delivery_intermediate_enabled = True
+    service.config.runtime.agent_delivery_final_enabled = True
     sink = CollectingSink()
     service.bind_delivery_sink(sink)
     client = FiveTurnScenarioClient(protocol="openai")
@@ -207,7 +211,8 @@ async def test_no_record_fallback_receipt_backfills_assistant_row(
     from tests.fixtures.agent_loop import CollectingSink, FiveTurnScenarioClient
 
     service = await _service(tmp_path)
-    service.config.runtime.agent_delivery_enabled = True
+    service.config.runtime.agent_delivery_intermediate_enabled = True
+    service.config.runtime.agent_delivery_final_enabled = True
     service.bind_delivery_sink(CollectingSink())
     client = FiveTurnScenarioClient(protocol="openai")
     patch_provider_builder(lambda provider: client)
@@ -245,7 +250,8 @@ async def test_no_record_fallback_surfaces_abort_when_delivery_enabled(
     from tests.fixtures.agent_loop import CollectingSink, FiveTurnScenarioClient
 
     service = await _service(tmp_path)
-    service.config.runtime.agent_delivery_enabled = True
+    service.config.runtime.agent_delivery_intermediate_enabled = True
+    service.config.runtime.agent_delivery_final_enabled = True
     sink = CollectingSink()
     service.bind_delivery_sink(sink)
     client = FiveTurnScenarioClient(protocol="openai")

--- a/tests/integration/test_agent_loop_delivery_failure.py
+++ b/tests/integration/test_agent_loop_delivery_failure.py
@@ -279,3 +279,68 @@ async def test_no_record_fallback_surfaces_abort_when_delivery_enabled(
     assert len(client.requests) == 1  # 第二轮被门禁拦下
     assert sink.deliveries == []
     assert result["reply"] == "本次回复未确认送达，已停止后续生成。"
+
+
+async def test_intermediate_only_failure_aborts_silently(tmp_path: Path, patch_provider_builder):
+    """组合 B（仅中间轮开）：首段中间轮失败 → D3 终止且静默（已发即全部）。"""
+    from tests.fixtures.agent_loop import FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    service.config.runtime.agent_delivery_intermediate_enabled = True
+    service.config.runtime.agent_delivery_final_enabled = False
+    for attr, value in [
+        ("reply_split_threshold_chars", AGENT_LOOP_TEST_SPLIT["threshold"]),
+        ("reply_chunk_max_chars", AGENT_LOOP_TEST_SPLIT["chunk_max"]),
+    ]:
+        setattr(service.config.runtime, attr, value)
+    sink = ScriptedSink([DeliveryReceipt(status=DeliveryStatus.FAILED, error_code="NetworkError")])
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+
+    result = await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+
+    assert len(sink.attempts) == 1  # 仅首个中间轮段尝试后终止
+    assert len(client.requests) == 1
+    # sink 模式激活（中间轮开）：静默，不再补发错误提示
+    assert result["reply"] == ""
+    with service.store._connect() as conn:
+        loop_row = conn.execute("SELECT status, terminal_reason FROM agent_loops").fetchone()
+    assert loop_row["status"] == "interrupted"
+    assert loop_row["terminal_reason"] == "delivery_failed"
+
+
+async def test_final_only_failure_after_suppressed_intermediate(tmp_path: Path, patch_provider_builder):
+    """组合 C（仅最终轮开）：中间轮 suppressed 不外发；最终首段失败 → 终止。"""
+    from tests.fixtures.agent_loop import FiveTurnScenarioClient
+
+    service = await _service(tmp_path)
+    service.config.runtime.agent_delivery_intermediate_enabled = False
+    service.config.runtime.agent_delivery_final_enabled = True
+    for attr, value in [
+        ("reply_split_threshold_chars", AGENT_LOOP_TEST_SPLIT["threshold"]),
+        ("reply_chunk_max_chars", AGENT_LOOP_TEST_SPLIT["chunk_max"]),
+    ]:
+        setattr(service.config.runtime, attr, value)
+    sink = ScriptedSink([DeliveryReceipt(status=DeliveryStatus.FAILED, error_code="NetworkError")])
+    service.bind_delivery_sink(sink)
+    client = FiveTurnScenarioClient(protocol="openai")
+    patch_provider_builder(lambda provider: client)
+
+    result = await service.generate_reply(
+        group_id=1001, user_id="2002", sender_name="镜子", prompt="K甲赛况如何？",
+    )
+
+    # 四个中间轮 suppressed 不进 sink：唯一一次尝试是最终轮首段
+    assert len(sink.attempts) == 1
+    assert sink.attempts[0][1] == FIVE_TURN_TEXTS[4][:20]
+    assert len(client.requests) == 5
+    assert result["reply"] == ""  # 最终轮开：sink 模式静默
+    with service.store._connect() as conn:
+        statuses = [
+            row["status"]
+            for row in conn.execute("SELECT status FROM agent_deliveries ORDER BY delivery_index")
+        ]
+    assert statuses == ["suppressed"] * 4 + ["failed", "skipped", "skipped"]

--- a/tests/integration/test_agent_loop_request_lifecycle.py
+++ b/tests/integration/test_agent_loop_request_lifecycle.py
@@ -36,7 +36,8 @@ async def test_cancellation_closes_loop_preserves_facts_and_allows_next_request(
     if private:
         llm_service.start_private_session(2002)
     runtime = llm_service.config.runtime
-    monkeypatch.setattr(runtime, "agent_delivery_enabled", delivery_enabled)
+    monkeypatch.setattr(runtime, "agent_delivery_intermediate_enabled", delivery_enabled)
+    monkeypatch.setattr(runtime, "agent_delivery_final_enabled", delivery_enabled)
     monkeypatch.setattr(runtime, "reply_split_threshold_chars", 120)
     monkeypatch.setattr(runtime, "reply_chunk_max_chars", 240)
     text = "A" * 120 + "\n\n" + "B" * 120 + "\n\n" + "C" * 120

--- a/tests/unit/adapters/test_llm_delivery_commands.py
+++ b/tests/unit/adapters/test_llm_delivery_commands.py
@@ -1,7 +1,7 @@
 """`/llm delivery` 三域子命令的解析与写入路由（两域独立开关）。
 
-覆盖 interim/final/all 三域的 on/off/reset/status 与无域概览；
-不合法输入不得触发任何写入。
+域 token 与配置/存储同词根（intermediate/final/all，DeliveryDomain 枚举）；
+覆盖 on/off/reset/status 与无域概览；不合法输入不得触发任何写入。
 """
 from __future__ import annotations
 
@@ -10,6 +10,7 @@ import types
 import pytest
 
 from quickquip.adapters.nonebot.command_parts import llm as llm_part
+from quickquip.llm.settings import DeliveryDomain
 
 
 class _FinishSentinel(Exception):
@@ -65,93 +66,89 @@ class _FakeService:
     def __init__(self) -> None:
         self.config = types.SimpleNamespace(runtime=_FakeRuntime())
         self.settings = _FakeSettings(False, False)
-        self.calls: list[tuple[object, str, str]] = []
+        self.calls: list[tuple[object, str, DeliveryDomain]] = []
 
     def get_chat_settings(self, chat_id, chat_type: str = "group"):
         return self.settings
 
     def set_chat_agent_delivery_enabled(
-        self, chat_id, enabled, chat_type: str = "group", domain: str = "all"
+        self, chat_id, enabled, chat_type: str = "group", domain: DeliveryDomain = DeliveryDomain.ALL
     ) -> None:
         self.calls.append((enabled, chat_type, domain))
 
 
-def _setup(monkeypatch: pytest.MonkeyPatch) -> tuple[_FakeLlmCmd, _FakeService]:
-    service = _FakeService()
+_SEG = type("Seg", (), {
+    "text": staticmethod(lambda v: v),
+    "image": staticmethod(lambda v: v),
+    "record": staticmethod(lambda v: v),
+})
+
+
+def _register(service) -> _FakeLlmCmd:
     cmd = _FakeLlmCmd()
-    others: list[str] = []
+    llm_part.register_llm_commands(lambda name, **kw: (cmd if name == "llm" else _FakeLlmCmd()), list, _SEG)
+    return cmd
 
-    def on_command(name, **kwargs):
-        if name == "llm":
-            return cmd
-        others.append(name)
-        return _FakeLlmCmd()
 
+def _patch_service(monkeypatch: pytest.MonkeyPatch, service: _FakeService) -> None:
     monkeypatch.setattr(llm_part, "_ensure_llm_bindings", lambda: None)
     monkeypatch.setattr(llm_part, "get_llm_service", lambda: service)
-    llm_part.register_llm_commands(on_command, list, type("Seg", (), {
-        "text": staticmethod(lambda v: v),
-        "image": staticmethod(lambda v: v),
-        "record": staticmethod(lambda v: v),
-    }))
-    assert others == ["search"]
-    return cmd, service
 
 
 async def _dispatch(monkeypatch, text: str) -> tuple[list[str], _FakeService]:
-    cmd, service = _setup(monkeypatch)
+    service = _FakeService()
+    _patch_service(monkeypatch, service)
+    cmd = _register(service)
     with pytest.raises(_FinishSentinel):
         await cmd.handler(_FakeEvent(text))
     return cmd.finished, service
 
 
 async def test_delivery_domain_actions_route_to_service(monkeypatch):
-    """on/off/reset 按域写入：interim/final 单域，all 双域。"""
-    _, service = await _dispatch(monkeypatch, "/llm delivery interim on")
-    assert service.calls == [(True, "private", "intermediate")]
+    """on/off/reset 按域写入：intermediate/final 单域，all 双域。"""
+    _, service = await _dispatch(monkeypatch, "/llm delivery intermediate on")
+    assert service.calls == [(True, "private", DeliveryDomain.INTERMEDIATE)]
 
     _, service = await _dispatch(monkeypatch, "/llm delivery final off")
-    assert service.calls == [(False, "private", "final")]
+    assert service.calls == [(False, "private", DeliveryDomain.FINAL)]
 
     _, service = await _dispatch(monkeypatch, "/llm delivery all reset")
-    assert service.calls == [(None, "private", "all")]
+    assert service.calls == [(None, "private", DeliveryDomain.ALL)]
 
 
 async def test_delivery_status_outputs(monkeypatch):
-    """带域 status 单行；无域 status 两域概览。"""
+    """带域 status 单行；无域 status 两域概览；all status 等同概览。"""
     service = _FakeService()
     service.settings = _FakeSettings(True, False)
-    monkeypatch.setattr(llm_part, "_ensure_llm_bindings", lambda: None)
-    monkeypatch.setattr(llm_part, "get_llm_service", lambda: service)
+    _patch_service(monkeypatch, service)
 
-    def _register() -> _FakeLlmCmd:
-        cmd = _FakeLlmCmd()
-        llm_part.register_llm_commands(
-            lambda name, **kw: (cmd if name == "llm" else _FakeLlmCmd()), list,
-            type("Seg", (), {"text": staticmethod(lambda v: v)}),
-        )
-        return cmd
-
-    cmd = _register()
+    cmd = _register(service)
     with pytest.raises(_FinishSentinel):
         await cmd.handler(_FakeEvent("/llm delivery final status"))
     assert cmd.finished == ["当前私聊最终轮分段：关（全局默认 关）"]
 
-    cmd2 = _register()
+    cmd2 = _register(service)
     with pytest.raises(_FinishSentinel):
         await cmd2.handler(_FakeEvent("/llm delivery"))
     assert cmd2.finished == [
         "当前私聊分段交付：中间轮 开（默认 关） / 最终轮 关（默认 关）"
     ]
 
+    cmd3 = _register(service)
+    with pytest.raises(_FinishSentinel):
+        await cmd3.handler(_FakeEvent("/llm delivery all status"))
+    assert cmd3.finished == cmd2.finished
+
 
 async def test_delivery_unknown_domain_is_noop(monkeypatch):
     """不认识的域/动作只落用法提示，不触发任何写入。"""
-    cmd, service = _setup(monkeypatch)
+    service = _FakeService()
+    _patch_service(monkeypatch, service)
+    cmd = _register(service)
     with pytest.raises(_FinishSentinel):
         await cmd.handler(_FakeEvent("/llm delivery xyz on"))
     with pytest.raises(_FinishSentinel):
-        await cmd.handler(_FakeEvent("/llm delivery interim maybe"))
+        await cmd.handler(_FakeEvent("/llm delivery intermediate maybe"))
     assert service.calls == []
     assert len(cmd.finished) == 2
     assert all("用法" in msg for msg in cmd.finished)

--- a/tests/unit/adapters/test_llm_delivery_commands.py
+++ b/tests/unit/adapters/test_llm_delivery_commands.py
@@ -1,0 +1,157 @@
+"""`/llm delivery` 三域子命令的解析与写入路由（两域独立开关）。
+
+覆盖 interim/final/all 三域的 on/off/reset/status 与无域概览；
+不合法输入不得触发任何写入。
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from quickquip.adapters.nonebot.command_parts import llm as llm_part
+
+
+class _FinishSentinel(Exception):
+    """模拟 nonebot finish() 终止 handler。"""
+
+
+class _FakeLlmCmd:
+    def __init__(self) -> None:
+        self.finished: list[str] = []
+        self.handler = None
+
+    def handle(self):
+        def deco(fn):
+            self.handler = fn
+            return fn
+
+        return deco
+
+    async def finish(self, msg: str = "") -> None:
+        self.finished.append(str(msg))
+        raise _FinishSentinel()
+
+    async def send(self, msg) -> None:
+        return None
+
+
+class _FakeEvent:
+    """私聊事件：绕过管理员判定，聚焦 delivery 子命令分支。"""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+        self.message_type = "private"
+        self.user_id = 2002
+        self.group_id = None
+
+    def get_message(self) -> str:
+        return self._text
+
+
+class _FakeRuntime:
+    def __init__(self) -> None:
+        self.agent_delivery_intermediate_enabled = False
+        self.agent_delivery_final_enabled = False
+
+
+class _FakeSettings:
+    def __init__(self, intermediate: bool, final: bool) -> None:
+        self.agent_delivery_intermediate_enabled = intermediate
+        self.agent_delivery_final_enabled = final
+
+
+class _FakeService:
+    def __init__(self) -> None:
+        self.config = types.SimpleNamespace(runtime=_FakeRuntime())
+        self.settings = _FakeSettings(False, False)
+        self.calls: list[tuple[object, str, str]] = []
+
+    def get_chat_settings(self, chat_id, chat_type: str = "group"):
+        return self.settings
+
+    def set_chat_agent_delivery_enabled(
+        self, chat_id, enabled, chat_type: str = "group", domain: str = "all"
+    ) -> None:
+        self.calls.append((enabled, chat_type, domain))
+
+
+def _setup(monkeypatch: pytest.MonkeyPatch) -> tuple[_FakeLlmCmd, _FakeService]:
+    service = _FakeService()
+    cmd = _FakeLlmCmd()
+    others: list[str] = []
+
+    def on_command(name, **kwargs):
+        if name == "llm":
+            return cmd
+        others.append(name)
+        return _FakeLlmCmd()
+
+    monkeypatch.setattr(llm_part, "_ensure_llm_bindings", lambda: None)
+    monkeypatch.setattr(llm_part, "get_llm_service", lambda: service)
+    llm_part.register_llm_commands(on_command, list, type("Seg", (), {
+        "text": staticmethod(lambda v: v),
+        "image": staticmethod(lambda v: v),
+        "record": staticmethod(lambda v: v),
+    }))
+    assert others == ["search"]
+    return cmd, service
+
+
+async def _dispatch(monkeypatch, text: str) -> tuple[list[str], _FakeService]:
+    cmd, service = _setup(monkeypatch)
+    with pytest.raises(_FinishSentinel):
+        await cmd.handler(_FakeEvent(text))
+    return cmd.finished, service
+
+
+async def test_delivery_domain_actions_route_to_service(monkeypatch):
+    """on/off/reset 按域写入：interim/final 单域，all 双域。"""
+    _, service = await _dispatch(monkeypatch, "/llm delivery interim on")
+    assert service.calls == [(True, "private", "intermediate")]
+
+    _, service = await _dispatch(monkeypatch, "/llm delivery final off")
+    assert service.calls == [(False, "private", "final")]
+
+    _, service = await _dispatch(monkeypatch, "/llm delivery all reset")
+    assert service.calls == [(None, "private", "all")]
+
+
+async def test_delivery_status_outputs(monkeypatch):
+    """带域 status 单行；无域 status 两域概览。"""
+    service = _FakeService()
+    service.settings = _FakeSettings(True, False)
+    monkeypatch.setattr(llm_part, "_ensure_llm_bindings", lambda: None)
+    monkeypatch.setattr(llm_part, "get_llm_service", lambda: service)
+
+    def _register() -> _FakeLlmCmd:
+        cmd = _FakeLlmCmd()
+        llm_part.register_llm_commands(
+            lambda name, **kw: (cmd if name == "llm" else _FakeLlmCmd()), list,
+            type("Seg", (), {"text": staticmethod(lambda v: v)}),
+        )
+        return cmd
+
+    cmd = _register()
+    with pytest.raises(_FinishSentinel):
+        await cmd.handler(_FakeEvent("/llm delivery final status"))
+    assert cmd.finished == ["当前私聊最终轮分段：关（全局默认 关）"]
+
+    cmd2 = _register()
+    with pytest.raises(_FinishSentinel):
+        await cmd2.handler(_FakeEvent("/llm delivery"))
+    assert cmd2.finished == [
+        "当前私聊分段交付：中间轮 开（默认 关） / 最终轮 关（默认 关）"
+    ]
+
+
+async def test_delivery_unknown_domain_is_noop(monkeypatch):
+    """不认识的域/动作只落用法提示，不触发任何写入。"""
+    cmd, service = _setup(monkeypatch)
+    with pytest.raises(_FinishSentinel):
+        await cmd.handler(_FakeEvent("/llm delivery xyz on"))
+    with pytest.raises(_FinishSentinel):
+        await cmd.handler(_FakeEvent("/llm delivery interim maybe"))
+    assert service.calls == []
+    assert len(cmd.finished) == 2
+    assert all("用法" in msg for msg in cmd.finished)

--- a/tests/unit/llm/test_config_validate.py
+++ b/tests/unit/llm/test_config_validate.py
@@ -621,3 +621,49 @@ def test_recent_context_floor_zero_is_valid(tmp_path):
     )
 
     assert loaded.runtime.recent_context_floor_seconds == 0
+
+
+def test_delivery_legacy_key_maps_to_both_domains(tmp_path: Path):
+    """旧单键按两域同值映射：true → 双开，缺省 → 双关。"""
+    loaded = _load(
+        tmp_path,
+        """
+        [runtime]
+        enabled = true
+        agent_delivery_enabled = true
+        """
+        + _good_provider()
+        + _PERSONA,
+    )
+    assert loaded.runtime.agent_delivery_intermediate_enabled is True
+    assert loaded.runtime.agent_delivery_final_enabled is True
+
+    loaded_off = _load(
+        tmp_path,
+        """
+        [runtime]
+        enabled = true
+        agent_delivery_enabled = false
+        """
+        + _good_provider()
+        + _PERSONA,
+    )
+    assert loaded_off.runtime.agent_delivery_intermediate_enabled is False
+    assert loaded_off.runtime.agent_delivery_final_enabled is False
+
+
+def test_delivery_new_keys_beat_legacy_mapping(tmp_path: Path):
+    """新键显式配置优先于旧键映射；两域可各自独立取值。"""
+    loaded = _load(
+        tmp_path,
+        """
+        [runtime]
+        enabled = true
+        agent_delivery_enabled = true
+        agent_delivery_final_enabled = false
+        """
+        + _good_provider()
+        + _PERSONA,
+    )
+    assert loaded.runtime.agent_delivery_intermediate_enabled is True
+    assert loaded.runtime.agent_delivery_final_enabled is False

--- a/tests/unit/llm/test_store.py
+++ b/tests/unit/llm/test_store.py
@@ -304,13 +304,66 @@ def test_group_settings_bool_conversion(store: LLMStore) -> None:
 
 
 def test_group_settings_agent_delivery_roundtrip(store: LLMStore) -> None:
-    store.update_group_settings(3003, agent_delivery_enabled=True)
-    assert store.get_group_settings(3003).agent_delivery_enabled is True
-    store.update_group_settings(3003, agent_delivery_enabled=False)
-    assert store.get_group_settings(3003).agent_delivery_enabled is False
-    # 显式 None 清空覆盖（回到跟随全局默认）
-    store.update_group_settings(3003, agent_delivery_enabled=None)
-    assert store.get_group_settings(3003).agent_delivery_enabled is None
+    store.update_group_settings(3003, agent_delivery_intermediate=True)
+    override = store.get_group_settings(3003)
+    assert override.agent_delivery_intermediate is True
+    assert override.agent_delivery_final is None
+    store.update_group_settings(3003, agent_delivery_final=False)
+    override = store.get_group_settings(3003)
+    assert override.agent_delivery_intermediate is True
+    assert override.agent_delivery_final is False
+    # 显式 None 清空单域覆盖（另一域不受影响，回到跟随全局默认）
+    store.update_group_settings(3003, agent_delivery_intermediate=None)
+    override = store.get_group_settings(3003)
+    assert override.agent_delivery_intermediate is None
+    assert override.agent_delivery_final is False
+
+
+def test_group_settings_agent_delivery_split_migration(tmp_path: Path) -> None:
+    """旧单开关库升级：加列 + 一次性回填两域，重启不重复回填。"""
+    import sqlite3
+
+    db_path = tmp_path / "legacy.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE group_settings (
+            group_id TEXT PRIMARY KEY,
+            enabled INTEGER,
+            memory_enabled INTEGER,
+            auto_memory_enabled INTEGER,
+            agent_delivery_enabled INTEGER,
+            provider_id TEXT,
+            model TEXT,
+            persona_id TEXT,
+            trigger_prefix TEXT,
+            allow_prefix INTEGER,
+            allow_at INTEGER,
+            updated_at TEXT NOT NULL
+        );
+        INSERT INTO group_settings (group_id, agent_delivery_enabled, updated_at)
+        VALUES ('9001', 1, '2026-09-11T00:00:00+00:00'),
+               ('9002', 0, '2026-09-11T00:00:00+00:00'),
+               ('9003', NULL, '2026-09-11T00:00:00+00:00');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    store = LLMStore(db_path)
+    # 旧值 1/0 → 两域按同值回填（显式开关意图保留）；旧 NULL → 不回填
+    assert store.get_group_settings("9001").agent_delivery_intermediate is True
+    assert store.get_group_settings("9001").agent_delivery_final is True
+    assert store.get_group_settings("9002").agent_delivery_intermediate is False
+    assert store.get_group_settings("9002").agent_delivery_final is False
+    assert store.get_group_settings("9003").agent_delivery_intermediate is None
+    assert store.get_group_settings("9003").agent_delivery_final is None
+
+    # 迁移后 reset 一域为 NULL：旧列值仍在，重启不得把它再搬回来
+    store.update_group_settings("9001", agent_delivery_intermediate=None)
+    store_again = LLMStore(db_path)
+    assert store_again.get_group_settings("9001").agent_delivery_intermediate is None
+    assert store_again.get_group_settings("9001").agent_delivery_final is True
 
 
 # ── _unavailable 守卫路径 ─────────────────────────────────────────────────────

--- a/tests/unit/llm/test_store.py
+++ b/tests/unit/llm/test_store.py
@@ -304,19 +304,19 @@ def test_group_settings_bool_conversion(store: LLMStore) -> None:
 
 
 def test_group_settings_agent_delivery_roundtrip(store: LLMStore) -> None:
-    store.update_group_settings(3003, agent_delivery_intermediate=True)
+    store.update_group_settings(3003, agent_delivery_intermediate_enabled=True)
     override = store.get_group_settings(3003)
-    assert override.agent_delivery_intermediate is True
-    assert override.agent_delivery_final is None
-    store.update_group_settings(3003, agent_delivery_final=False)
+    assert override.agent_delivery_intermediate_enabled is True
+    assert override.agent_delivery_final_enabled is None
+    store.update_group_settings(3003, agent_delivery_final_enabled=False)
     override = store.get_group_settings(3003)
-    assert override.agent_delivery_intermediate is True
-    assert override.agent_delivery_final is False
+    assert override.agent_delivery_intermediate_enabled is True
+    assert override.agent_delivery_final_enabled is False
     # 显式 None 清空单域覆盖（另一域不受影响，回到跟随全局默认）
-    store.update_group_settings(3003, agent_delivery_intermediate=None)
+    store.update_group_settings(3003, agent_delivery_intermediate_enabled=None)
     override = store.get_group_settings(3003)
-    assert override.agent_delivery_intermediate is None
-    assert override.agent_delivery_final is False
+    assert override.agent_delivery_intermediate_enabled is None
+    assert override.agent_delivery_final_enabled is False
 
 
 def test_group_settings_agent_delivery_split_migration(tmp_path: Path) -> None:
@@ -352,18 +352,18 @@ def test_group_settings_agent_delivery_split_migration(tmp_path: Path) -> None:
 
     store = LLMStore(db_path)
     # 旧值 1/0 → 两域按同值回填（显式开关意图保留）；旧 NULL → 不回填
-    assert store.get_group_settings("9001").agent_delivery_intermediate is True
-    assert store.get_group_settings("9001").agent_delivery_final is True
-    assert store.get_group_settings("9002").agent_delivery_intermediate is False
-    assert store.get_group_settings("9002").agent_delivery_final is False
-    assert store.get_group_settings("9003").agent_delivery_intermediate is None
-    assert store.get_group_settings("9003").agent_delivery_final is None
+    assert store.get_group_settings("9001").agent_delivery_intermediate_enabled is True
+    assert store.get_group_settings("9001").agent_delivery_final_enabled is True
+    assert store.get_group_settings("9002").agent_delivery_intermediate_enabled is False
+    assert store.get_group_settings("9002").agent_delivery_final_enabled is False
+    assert store.get_group_settings("9003").agent_delivery_intermediate_enabled is None
+    assert store.get_group_settings("9003").agent_delivery_final_enabled is None
 
     # 迁移后 reset 一域为 NULL：旧列值仍在，重启不得把它再搬回来
-    store.update_group_settings("9001", agent_delivery_intermediate=None)
+    store.update_group_settings("9001", agent_delivery_intermediate_enabled=None)
     store_again = LLMStore(db_path)
-    assert store_again.get_group_settings("9001").agent_delivery_intermediate is None
-    assert store_again.get_group_settings("9001").agent_delivery_final is True
+    assert store_again.get_group_settings("9001").agent_delivery_intermediate_enabled is None
+    assert store_again.get_group_settings("9001").agent_delivery_final_enabled is True
 
 
 # ── _unavailable 守卫路径 ─────────────────────────────────────────────────────
@@ -419,7 +419,7 @@ def test_group_settings_agent_delivery_half_migration(tmp_path: Path) -> None:
             memory_enabled INTEGER,
             auto_memory_enabled INTEGER,
             agent_delivery_enabled INTEGER,
-            agent_delivery_intermediate INTEGER,
+            agent_delivery_intermediate_enabled INTEGER,
             provider_id TEXT,
             model TEXT,
             persona_id TEXT,
@@ -428,7 +428,7 @@ def test_group_settings_agent_delivery_half_migration(tmp_path: Path) -> None:
             allow_at INTEGER,
             updated_at TEXT NOT NULL
         );
-        INSERT INTO group_settings (group_id, agent_delivery_enabled, agent_delivery_intermediate, updated_at)
+        INSERT INTO group_settings (group_id, agent_delivery_enabled, agent_delivery_intermediate_enabled, updated_at)
         VALUES ('9101', 1, 0, '2026-09-11T00:00:00+00:00');
         """
     )
@@ -438,5 +438,5 @@ def test_group_settings_agent_delivery_half_migration(tmp_path: Path) -> None:
     store = LLMStore(db_path)
     override = store.get_group_settings("9101")
     # intermediate 列既有值（0，含刻意 reset 语义）不被 final 的加列回填覆写
-    assert override.agent_delivery_intermediate is False
-    assert override.agent_delivery_final is True
+    assert override.agent_delivery_intermediate_enabled is False
+    assert override.agent_delivery_final_enabled is True

--- a/tests/unit/llm/test_store.py
+++ b/tests/unit/llm/test_store.py
@@ -403,3 +403,40 @@ def test_unavailable_group_settings_raises(unavailable_store: LLMStore) -> None:
         unavailable_store.get_group_settings(1)
     with pytest.raises(RuntimeError, match="数据库不可用"):
         unavailable_store.update_group_settings(1, enabled=True)
+
+
+def test_group_settings_agent_delivery_half_migration(tmp_path: Path) -> None:
+    """半迁移库（仅缺 final 列）：final 加列回填，intermediate 已有值不被覆写。"""
+    import sqlite3
+
+    db_path = tmp_path / "half.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE group_settings (
+            group_id TEXT PRIMARY KEY,
+            enabled INTEGER,
+            memory_enabled INTEGER,
+            auto_memory_enabled INTEGER,
+            agent_delivery_enabled INTEGER,
+            agent_delivery_intermediate INTEGER,
+            provider_id TEXT,
+            model TEXT,
+            persona_id TEXT,
+            trigger_prefix TEXT,
+            allow_prefix INTEGER,
+            allow_at INTEGER,
+            updated_at TEXT NOT NULL
+        );
+        INSERT INTO group_settings (group_id, agent_delivery_enabled, agent_delivery_intermediate, updated_at)
+        VALUES ('9101', 1, 0, '2026-09-11T00:00:00+00:00');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    store = LLMStore(db_path)
+    override = store.get_group_settings("9101")
+    # intermediate 列既有值（0，含刻意 reset 语义）不被 final 的加列回填覆写
+    assert override.agent_delivery_intermediate is False
+    assert override.agent_delivery_final is True

--- a/tests/unit/web/test_group_settings_delivery_routes.py
+++ b/tests/unit/web/test_group_settings_delivery_routes.py
@@ -1,6 +1,8 @@
 """group-settings 路由的交付两域字段：写入路由、默认投影与列表形状。"""
 from __future__ import annotations
 
+import sqlite3
+
 import pytest
 
 fastapi = pytest.importorskip("fastapi")
@@ -13,7 +15,7 @@ def _patch_audit_noop(monkeypatch):
 
 
 def test_options_defaults_carry_both_delivery_domains(monkeypatch, tmp_path):
-    """options 投影携带两域全局默认（读 llm.toml 失败时空对象兜底不回归）。"""
+    """options 投影携带两域全局默认。"""
     import types
 
     fake_runtime = types.SimpleNamespace(
@@ -32,13 +34,28 @@ def test_options_defaults_carry_both_delivery_domains(monkeypatch, tmp_path):
     monkeypatch.setattr(routes, "_LLM_TOML", tmp_path / "llm.toml")
 
     payload = routes.get_options()
-    assert payload["defaults"]["agent_delivery_intermediate"] is True
-    assert payload["defaults"]["agent_delivery_final"] is False
+    assert payload["defaults"]["agent_delivery_intermediate_enabled"] is True
+    assert payload["defaults"]["agent_delivery_final_enabled"] is False
     assert "agent_delivery_enabled" not in payload["defaults"]
 
 
+def test_options_defaults_empty_when_llm_toml_load_fails(monkeypatch, tmp_path):
+    """读 llm.toml 抛异常时兜底空 defaults + 非空 load_error（不向上抛）。"""
+    def _boom(path):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(routes, "load_llm_config", _boom)
+    monkeypatch.setattr(routes, "_LLM_TOML", tmp_path / "llm.toml")
+
+    payload = routes.get_options()
+    assert payload["providers"] == []
+    assert payload["personas"] == []
+    assert payload["defaults"] == {}
+    assert "boom" in payload["load_error"]
+
+
 def test_put_body_fields_route_to_store(monkeypatch, tmp_path):
-    """PUT body 的两域字段进入 store 写入；旧键名被 Pydantic 拒绝。"""
+    """PUT body 的两域字段进入 store 写入；旧键名被 Pydantic 静默忽略。"""
     calls: list[tuple[str, dict]] = []
 
     class FakeStore:
@@ -50,11 +67,53 @@ def test_put_body_fields_route_to_store(monkeypatch, tmp_path):
     _patch_audit_noop(monkeypatch)
 
     body = routes.GroupSettingsBody(
-        agent_delivery_intermediate=True, agent_delivery_final=False
+        agent_delivery_intermediate_enabled=True, agent_delivery_final_enabled=False
     )
     assert routes.put_group_settings("10001", body, object()) == {"ok": True}
-    assert calls == [("10001", {"agent_delivery_intermediate": True, "agent_delivery_final": False})]
+    assert calls == [("10001", {"agent_delivery_intermediate_enabled": True, "agent_delivery_final_enabled": False})]
 
-    # 旧键名被 Pydantic 静默忽略（旧前端 bundle 对新后端不炸、不误写）
+    # 旧键名被 Pydantic 静默忽略（不落库、不报错）：旧前端 bundle 只带旧键
+    # 提交 → payload 为空 → 400；与其他字段一起提交 → 其余字段落库、开关不动。
     legacy_body = routes.GroupSettingsBody(agent_delivery_enabled=True)
     assert legacy_body.model_dump(exclude_unset=True) == {}
+
+
+def test_list_group_settings_projects_both_delivery_domains(monkeypatch, tmp_path):
+    """列表 SELECT/投影包含两域新列：预置行的取值原样出现在条目里。"""
+    db_path = tmp_path / "llm.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE group_settings (
+            group_id TEXT PRIMARY KEY,
+            enabled INTEGER,
+            memory_enabled INTEGER,
+            auto_memory_enabled INTEGER,
+            agent_delivery_enabled INTEGER,
+            agent_delivery_intermediate_enabled INTEGER,
+            agent_delivery_final_enabled INTEGER,
+            provider_id TEXT,
+            model TEXT,
+            persona_id TEXT,
+            trigger_prefix TEXT,
+            allow_prefix INTEGER,
+            allow_at INTEGER,
+            history_limit INTEGER,
+            updated_at TEXT NOT NULL
+        );
+        INSERT INTO group_settings (group_id, agent_delivery_intermediate_enabled, agent_delivery_final_enabled, updated_at)
+        VALUES ('10001', 1, 0, '2026-09-11T00:00:00+00:00');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    import quickquip.app.message_pipeline as message_pipeline
+    monkeypatch.setattr(routes, "_DB", db_path)
+    monkeypatch.setattr(message_pipeline, "stats_tracker",
+                        type("T", (), {"to_dict": staticmethod(lambda: {})})())
+
+    payload = routes.list_group_settings()
+    entry = next(g for g in payload["groups"] if g["group_id"] == "10001")
+    assert entry["agent_delivery_intermediate_enabled"] is True
+    assert entry["agent_delivery_final_enabled"] is False

--- a/tests/unit/web/test_group_settings_delivery_routes.py
+++ b/tests/unit/web/test_group_settings_delivery_routes.py
@@ -1,0 +1,60 @@
+"""group-settings 路由的交付两域字段：写入路由、默认投影与列表形状。"""
+from __future__ import annotations
+
+import pytest
+
+fastapi = pytest.importorskip("fastapi")
+
+from quickquip.app.web.routes import group_settings as routes  # noqa: E402
+
+
+def _patch_audit_noop(monkeypatch):
+    monkeypatch.setattr(routes.audit_logger, "log", lambda *a, **k: None)
+
+
+def test_options_defaults_carry_both_delivery_domains(monkeypatch, tmp_path):
+    """options 投影携带两域全局默认（读 llm.toml 失败时空对象兜底不回归）。"""
+    import types
+
+    fake_runtime = types.SimpleNamespace(
+        enabled=True, memory_enabled=True, auto_memory_enabled=False,
+        agent_delivery_intermediate_enabled=True, agent_delivery_final_enabled=False,
+        default_provider="p1", default_persona=None, history_limit=10,
+    )
+    fake_cfg = types.SimpleNamespace(
+        runtime=fake_runtime,
+        providers={},
+        personas={},
+        triggers=types.SimpleNamespace(default_prefix="/", allow_prefix=True, allow_at=True),
+        load_error=None,
+    )
+    monkeypatch.setattr(routes, "load_llm_config", lambda path: fake_cfg)
+    monkeypatch.setattr(routes, "_LLM_TOML", tmp_path / "llm.toml")
+
+    payload = routes.get_options()
+    assert payload["defaults"]["agent_delivery_intermediate"] is True
+    assert payload["defaults"]["agent_delivery_final"] is False
+    assert "agent_delivery_enabled" not in payload["defaults"]
+
+
+def test_put_body_fields_route_to_store(monkeypatch, tmp_path):
+    """PUT body 的两域字段进入 store 写入；旧键名被 Pydantic 拒绝。"""
+    calls: list[tuple[str, dict]] = []
+
+    class FakeStore:
+        def update_group_settings(self, group_id, **fields):
+            calls.append((group_id, fields))
+
+    monkeypatch.setattr(routes, "_store", lambda: FakeStore())
+    monkeypatch.setattr(routes, "_DB", tmp_path / "llm.db")
+    _patch_audit_noop(monkeypatch)
+
+    body = routes.GroupSettingsBody(
+        agent_delivery_intermediate=True, agent_delivery_final=False
+    )
+    assert routes.put_group_settings("10001", body, object()) == {"ok": True}
+    assert calls == [("10001", {"agent_delivery_intermediate": True, "agent_delivery_final": False})]
+
+    # 旧键名被 Pydantic 静默忽略（旧前端 bundle 对新后端不炸、不误写）
+    legacy_body = routes.GroupSettingsBody(agent_delivery_enabled=True)
+    assert legacy_body.model_dump(exclude_unset=True) == {}


### PR DESCRIPTION
## 背景

现行 \`agent_delivery_enabled\` 单开关同时控制「非最终轮正文是否发送」与「最终正文是否走 sink 自然分段」，2×2 行为矩阵只剩对角线两格可达，群友需要的「中间轮照常说话 + 最终正文整条单发」无法表达。本 PR 按热修复节奏拆为两域独立开关，恢复矩阵全覆盖。实施计划见内部稿（dev/plans/2026-09-11-agent-delivery-switch-split.md）。

同分支后续将追加第二步：MCP resource 正文有界交付（另出简计划）。

## 变更摘要

- **配置**：\`[runtime]\` 新增 \`agent_delivery_intermediate_enabled\` / \`agent_delivery_final_enabled\`（默认均关）。旧键 \`agent_delivery_enabled\` 保留读取：未显式配置的新键按旧键值映射，命中记 warning；新键显式配置优先。
- **存储**：\`group_settings\` 增 \`agent_delivery_intermediate\` / \`agent_delivery_final\` 两列；加列时一次性回填旧值（0/1 均按原值回填以保留显式开关意图，NULL 不动）。旧列退役只读，不 DROP。**与计划稿的偏离**：回填 SQL 去掉了 NULL 守卫、改为仅在加列事务内执行——计划稿的守卫式 SQL 若挂启动路径无条件重跑，会把 reset 后的 NULL 再次覆盖回旧值；加列门控从根上消除该缺陷。
- **Recorder**：\`_plan_deliveries\` 按域分支（中间轮关 → suppressed；最终轮关 → 旧单发路径 receipt 回填）；中间轮关闭的 suppressed 项维护进待发排除清单，\`deliver_turn\` 显式跳过（组合 C 防泄漏关键点）；D3 终止与 \`delivery_limit\` 预算口径维持。
- **service**：\`reply\` 置空仅跟最终轮开关走；\`aborted_silently\` 条件为任一域开启。
- **命令**：\`/llm delivery interim|final|all <on|off|reset>\`，\`/llm delivery status\`（无域）输出两域概览；usage 文案同步。
- **Web Admin**：群设置两枚三态覆盖开关（中间轮发送 / 最终轮分段），前后端字段与默认投影同步。

## 测试

- 全量 1993 passed（本地）
- 新增/改造：四组合行为矩阵端到端（含组合 B 恢复验证、组合 C suppressed 不外发三重断言）；旧库迁移 + 回填幂等 + reset 后重启不回填；配置旧键映射与新键优先；命令三域解析与非法输入零写入；Web 路由字段投影与旧键静默忽略；组合 B/C 的 D3 终止与组合 B 回填钩子。
- 深审 SubAgent 报告：无 BLOCKER/MAJOR；两条 MINOR（组合 B/C D3 测试、回填钩子断言）已随 36bd0bc 补齐。

## CHANGELOG 草稿

> **变更**
> - 分段交付开关拆分为两枚独立开关：「中间轮发送」（多轮工具回复中非最终轮的过程正文照常发出）与「最终轮分段」（最终长回复按自然段拆成多条）。\`/llm delivery\` 改为 \`/llm delivery interim|final|all <on|off|reset>\`，\`/llm delivery status\` 查看两域状态；Web Admin 群设置同步提供两枚开关。原 \`agent_delivery_enabled\` 配置键仍可读取（按两域同值映射），存量按群开关值自动迁移，无需人工重设。