### PR TITLE
fix(scripts): 回灌脚本输出按 UTF-8 重配，修复 Windows 控制台编码崩溃

### DIFF
--- a/scripts/backfill_chat_archive.py
+++ b/scripts/backfill_chat_archive.py
@@ -58,6 +58,11 @@ def _iter_jsonl(root: Path):
 
 
 def main() -> int:
+    # Windows 控制台默认代码页（如 cp1252）无法编码中文输出：统一重配为
+    # UTF-8 并以替换符兜底，避免 UnicodeEncodeError 中断回灌。
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(encoding="utf-8", errors="replace")
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dry-run", action="store_true", help="只统计，不写入")
     args = parser.parse_args()


### PR DESCRIPTION
Grade: Hot-Fix（v1.15.3 发行阻断）

## 问题

tag v1.15.3 触发的 release.yml 中「Build Windows Lazy Package」失败：冒烟步骤执行 `scripts/backfill_chat_archive.py --dry-run` 时，中文输出在 Windows cp1252 控制台代码页下抛 `UnicodeEncodeError`（'charmap' codec can't encode），Create Release 被跳过，GitHub Release 未生成。中文输出来自 #234 的回灌失败报告增强；v1.15.2 同脚本无此输出故未触发。

## 修复

脚本入口将 stdout/stderr 重配为 UTF-8（errors="replace" 兜底），任何控制台代码页不再崩溃。本地以 `PYTHONIOENCODING=cp1252` 复现崩溃并验证修复后退出码 0；ruff 通过。

## 后续（同一指令内执行）

合并后将删除并重建 tag v1.15.3（尚未发布任何 GitHub Release，Docker 镜像 tag 由重跑覆盖），release.yml 重跑全量发行物。